### PR TITLE
feat: post-pipeline artifact cleanup with decision-based finalization

### DIFF
--- a/commands/signum.md
+++ b/commands/signum.md
@@ -3153,7 +3153,7 @@ After displaying results, finalize the current run to prevent stale artifacts fr
 **Decision-based behavior:**
 
 - **AUTO_OK** → auto-finalize (archive + purge working set). Zero-friction success path.
-- **HUMAN_REVIEW** → ask the user: "Pipeline complete (HUMAN_REVIEW). Artifacts in .signum/. Options: (1) archive — save to .signum/contracts/archive/ and clean working set, (2) keep — leave all artifacts for review, (3) delete — remove working set entirely." Default if no answer: keep.
+- **HUMAN_REVIEW** → ask the user: "Pipeline complete (HUMAN_REVIEW). Artifacts in .signum/. Options: (1) archive — save to .signum/archive/ and clean working set, (2) keep — leave all artifacts for review, (3) delete — remove working set entirely." Default if no answer: keep.
 - **AUTO_BLOCK** → ask the user: "Pipeline blocked (AUTO_BLOCK). Options: (1) keep — leave artifacts for debugging (default), (2) delete — remove working set." Default if no answer: keep.
 
 **Finalize flow (archive + purge):**
@@ -3184,7 +3184,7 @@ finalize_run() {
 
   # Step 4: Atomic move to final archive location
   if [ -n "$CONTRACT_ID" ]; then
-    ARCHIVE_FINAL=".signum/contracts/archive/$CONTRACT_ID"
+    ARCHIVE_FINAL=".signum/archive/${CONTRACT_ID}"
     mkdir -p "$ARCHIVE_FINAL"
     cp "$ARCHIVE_TMP/"* "$ARCHIVE_FINAL/" 2>/dev/null
   fi
@@ -3210,7 +3210,7 @@ finalize_run() {
        .signum/audit_iteration_log.json .signum/repair_brief.json .signum/flaky_tests.json
   rm -rf .signum/reviews/ .signum/iterations/ .signum/receipts/ .signum/runs/ .signum/snapshots/
 
-  echo "Run finalized: archived to .signum/contracts/archive/$CONTRACT_ID/, working set cleaned"
+  echo "Run finalized: archived to .signum/archive/$CONTRACT_ID/, working set cleaned"
 }
 
 if [ "$DECISION" = "AUTO_OK" ]; then
@@ -3218,10 +3218,69 @@ if [ "$DECISION" = "AUTO_OK" ]; then
 fi
 ```
 
-If `DECISION` is `AUTO_OK`, finalize runs automatically. For `HUMAN_REVIEW` or `AUTO_BLOCK`, wait for the user's choice (prompted above), then:
-- If user chooses "archive": call `finalize_run` (same flow as above).
-- If user chooses "delete": run only the purge step (Step 6) without archiving.
-- If user chooses "keep" or does not respond: do nothing.
+If `DECISION` is `AUTO_OK`, finalize runs automatically. For `HUMAN_REVIEW` or `AUTO_BLOCK`, wait for the user's choice (prompted above), then run one of the following bash blocks (each is self-contained — variables must be re-resolved since each Bash tool call gets a fresh shell):
+
+**If user chooses "archive":**
+
+```bash
+CONTRACT_ID=$(jq -r '.contractId // empty' .signum/contract.json)
+ARCHIVE_TMP=$(mktemp -d .signum/archive-tmp.XXXXXX)
+cp .signum/contract.json "$ARCHIVE_TMP/" 2>/dev/null
+cp .signum/proofpack.json "$ARCHIVE_TMP/" 2>/dev/null
+cp .signum/approval.json "$ARCHIVE_TMP/" 2>/dev/null
+cp .signum/audit_summary.json "$ARCHIVE_TMP/" 2>/dev/null
+cp .signum/receipts/execute.json "$ARCHIVE_TMP/" 2>/dev/null || true
+if [ ! -f "$ARCHIVE_TMP/contract.json" ] || [ ! -f "$ARCHIVE_TMP/proofpack.json" ]; then
+  echo "ERROR: archive incomplete — keeping working set intact"
+  rm -rf "$ARCHIVE_TMP"; exit 1
+fi
+if [ -n "$CONTRACT_ID" ]; then
+  mkdir -p ".signum/archive/${CONTRACT_ID}"
+  cp "$ARCHIVE_TMP/"* ".signum/archive/${CONTRACT_ID}/" 2>/dev/null
+fi
+rm -rf "$ARCHIVE_TMP"
+if [ -f .signum/contracts/index.json ] && [ -n "$CONTRACT_ID" ]; then
+  jq '.activeContractId = null' .signum/contracts/index.json > .signum/contracts/index.json.tmp \
+    && mv .signum/contracts/index.json.tmp .signum/contracts/index.json
+fi
+rm -f .signum/contract.json .signum/contract-engineer.json .signum/contract-policy.json \
+     .signum/execute_log.json .signum/combined.patch .signum/iteration_delta.patch \
+     .signum/baseline.json .signum/mechanic_report.json .signum/holdout_report.json \
+     .signum/audit_summary.json .signum/proofpack.json .signum/approval.json \
+     .signum/policy_violations.json .signum/policy_scan.json \
+     .signum/spec_quality.json .signum/spec_validation.json \
+     .signum/repo_contract_baseline.json .signum/repo_contract_violations.json \
+     .signum/contract-hash.txt .signum/execution_context.json \
+     .signum/review_prompt_codex.txt .signum/review_prompt_gemini.txt \
+     .signum/clover_report.json .signum/intent_check.json \
+     .signum/audit_iteration_log.json .signum/repair_brief.json .signum/flaky_tests.json
+rm -rf .signum/reviews/ .signum/iterations/ .signum/receipts/ .signum/runs/ .signum/snapshots/
+echo "Run finalized: archived to .signum/archive/$CONTRACT_ID/, working set cleaned"
+```
+
+**If user chooses "delete":**
+
+```bash
+if [ -f .signum/contracts/index.json ]; then
+  jq '.activeContractId = null' .signum/contracts/index.json > .signum/contracts/index.json.tmp \
+    && mv .signum/contracts/index.json.tmp .signum/contracts/index.json 2>/dev/null || true
+fi
+rm -f .signum/contract.json .signum/contract-engineer.json .signum/contract-policy.json \
+     .signum/execute_log.json .signum/combined.patch .signum/iteration_delta.patch \
+     .signum/baseline.json .signum/mechanic_report.json .signum/holdout_report.json \
+     .signum/audit_summary.json .signum/proofpack.json .signum/approval.json \
+     .signum/policy_violations.json .signum/policy_scan.json \
+     .signum/spec_quality.json .signum/spec_validation.json \
+     .signum/repo_contract_baseline.json .signum/repo_contract_violations.json \
+     .signum/contract-hash.txt .signum/execution_context.json \
+     .signum/review_prompt_codex.txt .signum/review_prompt_gemini.txt \
+     .signum/clover_report.json .signum/intent_check.json \
+     .signum/audit_iteration_log.json .signum/repair_brief.json .signum/flaky_tests.json
+rm -rf .signum/reviews/ .signum/iterations/ .signum/receipts/ .signum/runs/ .signum/snapshots/
+echo "Working set deleted (no archive)"
+```
+
+**If user chooses "keep" or does not respond:** do nothing.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add Step 4.5 (Finalize run) — decision-based cleanup after pipeline completion
- AUTO_OK auto-archives + purges working set; HUMAN_REVIEW/AUTO_BLOCK prompt user
- Atomic archive flow (temp dir → verify → move → purge); fail-open on error
- Improved resume logic: checks resumable working set, not just file existence
- Restart now clears activeContractId and receipt chain artifacts

## Context

Issue #2: stale .signum/ artifacts confuse resume logic. Panel review (Codex + Gemini) identified 7 additional requirements beyond the initial proposal, all addressed.

## Test plan

- [x] test-receipt-chain.sh: 6/6 PASS
- [x] test-contract-dir.sh: 25/25 PASS
- [ ] Manual: run pipeline to AUTO_OK, verify auto-archive + clean working set
- [ ] Manual: run pipeline to HUMAN_REVIEW, verify prompt and each option
- [ ] Manual: verify resume logic doesn't trigger after finalized run

Closes #2