### PR TITLE
fix: deep review fixes

### DIFF
--- a/lib/contract-injection-scan.sh
+++ b/lib/contract-injection-scan.sh
@@ -40,11 +40,15 @@ jq -r '
     (.inScope // [])[] // empty,
     (.outOfScope // [])[] // empty,
     (.acceptanceCriteria // [])[].description // empty,
+    (.acceptanceCriteria // [])[].verify // empty | tostring,
     ((.assumptions // [])[] | if type == "object" then .text else . end) // empty,
     (.openQuestions // [])[] // empty,
     (.removals // [])[].reason // empty,
     (.cleanupObligations // [])[].description // empty,
-    .implementationStrategy // empty
+    .implementationStrategy // empty,
+    (.allowNewFilesUnder // [])[] // empty,
+    (.riskSignals // [])[] // empty,
+    (.contextInheritance // {} | .. | strings) // empty
   ] | .[]
 ' "$CONTRACT_FILE" 2>/dev/null | python3 -c "
 import re, sys

--- a/lib/metric-ratchet.sh
+++ b/lib/metric-ratchet.sh
@@ -14,6 +14,12 @@ set -euo pipefail
 
 DAYS_CURRENT="${1:-7}"
 DAYS_PREVIOUS="${2:-7}"
+
+if ! [[ "$DAYS_CURRENT" =~ ^[0-9]+$ ]] || ! [[ "$DAYS_PREVIOUS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: days_current and days_previous must be positive integers" >&2
+  exit 2
+fi
+
 METRICS_DIR=".signum/metrics"
 ARCHIVE_DIR=".signum/archive"
 INDEX_FILE=".signum/proofpack-index.jsonl"

--- a/lib/metric-ratchet.sh
+++ b/lib/metric-ratchet.sh
@@ -25,7 +25,11 @@ mkdir -p "$METRICS_DIR"
 collect_proofpacks() {
   local since_days="$1"
   local cutoff
-  cutoff=$(date -v-${since_days}d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -d "${since_days} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
+  cutoff=$(date -v-${since_days}d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -d "${since_days} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
+  if [ -z "$cutoff" ]; then
+    echo "ERROR: date command failed to compute cutoff" >&2
+    exit 2
+  fi
 
   # From index file (if exists)
   if [ -f "$INDEX_FILE" ]; then

--- a/lib/metric-ratchet.sh
+++ b/lib/metric-ratchet.sh
@@ -29,7 +29,7 @@ collect_proofpacks() {
 
   # From index file (if exists)
   if [ -f "$INDEX_FILE" ]; then
-    jq -c "select(.createdAt >= \"$cutoff\")" "$INDEX_FILE" 2>/dev/null
+    jq -c --arg cutoff "$cutoff" 'select(.createdAt >= $cutoff)' "$INDEX_FILE" 2>/dev/null
   fi
 
   # From archive dirs (fallback)
@@ -91,17 +91,18 @@ json.dump({
 # Collect current and previous period
 CURRENT_DATA=$(collect_proofpacks "$DAYS_CURRENT")
 TOTAL_DAYS=$((DAYS_CURRENT + DAYS_PREVIOUS))
-PREVIOUS_DATA=$(collect_proofpacks "$TOTAL_DAYS" | python3 -c "
+PREVIOUS_DATA=$(collect_proofpacks "$TOTAL_DAYS" | python3 - "$DAYS_CURRENT" <<'PYEOF'
 import json, sys
 from datetime import datetime, timedelta, timezone
-cutoff = datetime.now(timezone.utc) - timedelta(days=$DAYS_CURRENT)
+cutoff = datetime.now(timezone.utc) - timedelta(days=int(sys.argv[1]))
 cutoff_str = cutoff.strftime('%Y-%m-%dT%H:%M:%SZ')
 for line in sys.stdin:
     if line.strip():
         e = json.loads(line)
         if e.get('createdAt', '') < cutoff_str:
             print(line.strip())
-")
+PYEOF
+)
 
 CURRENT_METRICS=$(echo "$CURRENT_DATA" | compute_metrics)
 PREVIOUS_METRICS=$(echo "$PREVIOUS_DATA" | compute_metrics)
@@ -115,11 +116,11 @@ if [ "$CURRENT_COUNT" -eq 0 ] && [ "$PREVIOUS_COUNT" -eq 0 ]; then
 fi
 
 # Compare and detect regressions
-REPORT=$(python3 -c "
+REPORT=$(printf '%s\n%s' "$CURRENT_METRICS" "$PREVIOUS_METRICS" | python3 - "$DAYS_CURRENT" "$DAYS_PREVIOUS" <<'PYEOF'
 import json, sys
 
-current = json.loads('$CURRENT_METRICS')
-previous = json.loads('$PREVIOUS_METRICS')
+current = json.loads(sys.stdin.readline())
+previous = json.loads(sys.stdin.readline())
 regressions = []
 improvements = []
 
@@ -146,17 +147,20 @@ compare('avg_confidence', 'Average confidence', True)
 compare('promote_rate', 'PROMOTE rate', True)
 
 status = 'regression' if regressions else ('improved' if improvements else 'stable')
+days_current = int(sys.argv[1])
+days_previous = int(sys.argv[2])
 
 report = {
     'status': status,
-    'period': {'current_days': $DAYS_CURRENT, 'previous_days': $DAYS_PREVIOUS},
+    'period': {'current_days': days_current, 'previous_days': days_previous},
     'current': current,
     'previous': previous,
     'regressions': regressions,
     'improvements': improvements
 }
 print(json.dumps(report, indent=2))
-")
+PYEOF
+)
 
 echo "$REPORT" > "$REPORT_FILE"
 

--- a/lib/metric-ratchet.sh
+++ b/lib/metric-ratchet.sh
@@ -66,7 +66,15 @@ compute_metrics() {
   python3 -c "
 import json, sys
 
-entries = [json.loads(line) for line in sys.stdin if line.strip()]
+all_entries = [json.loads(line) for line in sys.stdin if line.strip()]
+seen = set()
+entries = []
+for e in all_entries:
+    rid = e.get('runId', '')
+    if rid and rid in seen:
+        continue
+    seen.add(rid)
+    entries.append(e)
 if not entries:
     json.dump({'count': 0}, sys.stdout)
     sys.exit(0)

--- a/lib/metric-ratchet.sh
+++ b/lib/metric-ratchet.sh
@@ -85,7 +85,7 @@ auto_block = sum(1 for e in entries if e.get('decision') == 'AUTO_BLOCK')
 human_review = sum(1 for e in entries if e.get('decision') == 'HUMAN_REVIEW')
 promotes = sum(1 for e in entries if e.get('releaseVerdict') == 'PROMOTE')
 
-confidences = [e.get('confidence', 0) for e in entries if e.get('confidence')]
+confidences = [e.get('confidence', 0) for e in entries if isinstance(e.get('confidence'), (int, float))]
 avg_confidence = sum(confidences) / len(confidences) if confidences else 0
 
 reviews = [e.get('reviewCoverage', 0) for e in entries if isinstance(e.get('reviewCoverage'), (int, float))]

--- a/lib/metric-ratchet.sh
+++ b/lib/metric-ratchet.sh
@@ -31,7 +31,7 @@ mkdir -p "$METRICS_DIR"
 collect_proofpacks() {
   local since_days="$1"
   local cutoff
-  cutoff=$(date -v-${since_days}d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -d "${since_days} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
+  cutoff=$(date -u -v-${since_days}d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "${since_days} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
   if [ -z "$cutoff" ]; then
     echo "ERROR: date command failed to compute cutoff" >&2
     exit 2

--- a/lib/policy-resolver.sh
+++ b/lib/policy-resolver.sh
@@ -23,14 +23,14 @@ resolve_model() {
 
   [ -f "$POLICY_FILE" ] || return 0
 
-  python3 -c "
+  python3 - "$role" "$risk" "$POLICY_FILE" <<'PYEOF'
 import re, sys
 
-role = '$role'
-risk = '$risk'
+role = sys.argv[1]
+risk = sys.argv[2]
 key = role + '_model'
 
-with open('$POLICY_FILE') as f:
+with open(sys.argv[3]) as f:
     text = f.read()
 
 # Parse defaults
@@ -79,7 +79,7 @@ for block in rule_blocks:
                     model = sv
 
 print(model)
-" 2>/dev/null
+PYEOF
 }
 
 # Resolve budget parameter
@@ -90,11 +90,11 @@ resolve_budget() {
 
   [ -f "$POLICY_FILE" ] || return 0
 
-  python3 -c "
+  python3 - "$param" "$POLICY_FILE" <<'PYEOF'
 import sys
 
-param = '$param'
-with open('$POLICY_FILE') as f:
+param = sys.argv[1]
+with open(sys.argv[2]) as f:
     text = f.read()
 
 in_budget = False
@@ -110,5 +110,5 @@ for line in text.split('\n'):
         if k == param:
             print(v)
             sys.exit(0)
-" 2>/dev/null
+PYEOF
 }

--- a/lib/proofpack-index.sh
+++ b/lib/proofpack-index.sh
@@ -142,7 +142,7 @@ proofpack_index_query() {
   case "$mode" in
     --since)
       local cutoff
-      cutoff=$(date -v-${value} +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -d "${value} ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
+      cutoff=$(date -u -v-${value} +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "${value} ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
       jq -sc --arg cutoff "$cutoff" '[.[] | select(.createdAt >= $cutoff)]' "$INDEX_FILE" 2>/dev/null
       ;;
     --last)

--- a/lib/proofpack-index.sh
+++ b/lib/proofpack-index.sh
@@ -22,7 +22,8 @@ _sha256() {
   elif command -v shasum >/dev/null 2>&1; then
     shasum -a 256 | awk '{print $1}'
   else
-    echo "error_no_sha256_tool"
+    echo "ERROR: no sha256 tool found" >&2
+    return 1
   fi
 }
 
@@ -88,14 +89,14 @@ proofpack_index_verify() {
     return 0
   fi
 
-  python3 -c "
+  python3 - "$INDEX_FILE" <<'PYEOF'
 import json, hashlib, sys
 
 prev_hash = 'genesis'
 line_num = 0
 errors = 0
 
-for line in open('$INDEX_FILE'):
+for line in open(sys.argv[1]):
     line_num += 1
     line = line.strip()
     if not line:
@@ -108,7 +109,7 @@ for line in open('$INDEX_FILE'):
         continue
 
     if entry.get('prev_hash') != prev_hash:
-        print(f'ERROR line {line_num}: prev_hash mismatch (expected {prev_hash[:16]}..., got {entry.get(\"prev_hash\", \"missing\")[:16]}...)')
+        print(f'ERROR line {line_num}: prev_hash mismatch (expected {prev_hash[:16]}..., got {entry.get("prev_hash", "missing")[:16]}...)')
         errors += 1
 
     # Verify chain_hash = sha256(prev_hash + proofpack_sha256)
@@ -124,7 +125,7 @@ if errors == 0:
 else:
     print(f'FAILED: {errors} errors in {line_num} entries')
     sys.exit(1)
-"
+PYEOF
 }
 
 # Query recent entries
@@ -142,7 +143,7 @@ proofpack_index_query() {
     --since)
       local cutoff
       cutoff=$(date -v-${value} +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -d "${value} ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
-      jq -sc "[.[] | select(.createdAt >= \"$cutoff\")]" "$INDEX_FILE" 2>/dev/null
+      jq -sc --arg cutoff "$cutoff" '[.[] | select(.createdAt >= $cutoff)]' "$INDEX_FILE" 2>/dev/null
       ;;
     --last)
       tail -"$value" "$INDEX_FILE" | jq -sc '.' 2>/dev/null

--- a/lib/schemas/proofpack.schema.json
+++ b/lib/schemas/proofpack.schema.json
@@ -27,7 +27,7 @@
     }
   },
   "properties": {
-    "schemaVersion": { "type": "string", "enum": ["4.0", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7"] },
+    "schemaVersion": { "type": "string", "enum": ["4.0", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8"] },
     "signumVersion": { "type": "string" },
     "createdAt": { "type": "string", "format": "date-time" },
     "runId": { "type": "string", "pattern": "^signum-" },

--- a/lib/signum-update.sh
+++ b/lib/signum-update.sh
@@ -17,7 +17,7 @@ VERSION="${1:-$(jq -r .version "$PLUGIN_ROOT/.claude-plugin/plugin.json")}"
 PLUGIN_NAME="signum"
 MARKETPLACE="emporium"
 
-if [[ -z "$VERSION" || "$VERSION" == "null" || "$VERSION" =~ [/\\] || "$VERSION" == *..* ]]; then
+if [[ -z "$VERSION" || "$VERSION" == "null" || "$VERSION" =~ [/\\] || "$VERSION" == *..* || "$VERSION" == "." ]]; then
   echo "ERROR: invalid version: $VERSION" >&2
   exit 1
 fi

--- a/lib/signum-update.sh
+++ b/lib/signum-update.sh
@@ -17,6 +17,11 @@ VERSION="${1:-$(jq -r .version "$PLUGIN_ROOT/.claude-plugin/plugin.json")}"
 PLUGIN_NAME="signum"
 MARKETPLACE="emporium"
 
+if [[ -z "$VERSION" || "$VERSION" == "null" || "$VERSION" =~ [/\\] || "$VERSION" == *..* ]]; then
+  echo "ERROR: invalid version: $VERSION" >&2
+  exit 1
+fi
+
 echo "Updating $PLUGIN_NAME to v$VERSION..."
 echo ""
 

--- a/lib/signum-update.sh
+++ b/lib/signum-update.sh
@@ -66,27 +66,29 @@ for settings_file in \
   "$HOME/.claude-profiles"/*/config/settings.json; do
   [ -f "$settings_file" ] || continue
   # Find signum entries NOT from our target marketplace
-  ORPHANS=$(python3 -c "
+  ORPHANS=$(python3 - "$settings_file" "$PLUGIN_NAME" "$MARKETPLACE" <<'PYEOF' 2>/dev/null || true
 import json, sys
-with open('$settings_file') as f:
+with open(sys.argv[1]) as f:
     s = json.load(f)
 plugins = s.get('enabledPlugins', {})
-orphans = [k for k in plugins if k.startswith('$PLUGIN_NAME@') and k != '$PLUGIN_NAME@$MARKETPLACE']
+target = sys.argv[2] + '@' + sys.argv[3]
+orphans = [k for k in plugins if k.startswith(sys.argv[2] + '@') and k != target]
 for o in orphans: print(o)
-" 2>/dev/null || true)
+PYEOF
+)
 
   if [ -n "$ORPHANS" ]; then
     for orphan in $ORPHANS; do
       echo "  Removing orphan: $orphan from $settings_file"
-      python3 -c "
-import json
-with open('$settings_file') as f:
+      python3 - "$settings_file" "$orphan" <<'PYEOF' 2>/dev/null || true
+import json, sys
+with open(sys.argv[1]) as f:
     s = json.load(f)
-s.get('enabledPlugins', {}).pop('$orphan', None)
-with open('$settings_file', 'w') as f:
+s.get('enabledPlugins', {}).pop(sys.argv[2], None)
+with open(sys.argv[1], 'w') as f:
     json.dump(s, f, indent=2)
     f.write('\n')
-" 2>/dev/null || true
+PYEOF
     done
   fi
 done
@@ -187,14 +189,16 @@ for settings_file in \
   "$HOME/.claude/settings.json" \
   "$HOME/.claude-profiles"/*/config/settings.json; do
   [ -f "$settings_file" ] || continue
-  ORPHAN_COUNT=$(python3 -c "
-import json
-with open('$settings_file') as f:
+  ORPHAN_COUNT=$(python3 - "$settings_file" "$PLUGIN_NAME" "$MARKETPLACE" <<'PYEOF' 2>/dev/null || echo 0
+import json, sys
+with open(sys.argv[1]) as f:
     s = json.load(f)
 plugins = s.get('enabledPlugins', {})
-orphans = [k for k in plugins if k.startswith('$PLUGIN_NAME@') and k != '$PLUGIN_NAME@$MARKETPLACE']
+target = sys.argv[2] + '@' + sys.argv[3]
+orphans = [k for k in plugins if k.startswith(sys.argv[2] + '@') and k != target]
 print(len(orphans))
-" 2>/dev/null || echo 0)
+PYEOF
+)
   if [ "$ORPHAN_COUNT" -gt 0 ]; then
     echo "  WARN: $ORPHAN_COUNT orphan entries in $settings_file"
     ERRORS=$((ERRORS + 1))

--- a/lib/staleness-check.sh
+++ b/lib/staleness-check.sh
@@ -114,8 +114,11 @@ fi
 # Compute SHA-256 of concatenated content
 if command -v sha256sum > /dev/null 2>&1; then
   CURRENT_HASH=$(sha256sum "$TMPFILE" | awk '{print $1}')
-else
+elif command -v shasum > /dev/null 2>&1; then
   CURRENT_HASH=$(shasum -a 256 "$TMPFILE" | awk '{print $1}')
+else
+  echo '{"check":"staleness","status":"error","summary":"No sha256 tool found (need sha256sum or shasum)","current_hash":"","stored_hash":"","missing_files":[],"findings":[]}' >&2
+  exit 1
 fi
 
 if [ "$CURRENT_HASH" = "$STORED_HASH" ]; then

--- a/lib/staleness-check.sh
+++ b/lib/staleness-check.sh
@@ -74,6 +74,7 @@ while IFS= read -r sf; do
   esac
   RESOLVED_PATH="$ROOT/$sf"
   if [ -f "$RESOLVED_PATH" ]; then
+    printf '%s\0' "$sf" >> "$TMPFILE"
     cat "$RESOLVED_PATH" >> "$TMPFILE"
   else
     MISSING_FILES_ARR=$(echo "$MISSING_FILES_ARR" | jq --arg f "$sf" '. + [$f]')

--- a/lib/sync-cache.sh
+++ b/lib/sync-cache.sh
@@ -6,8 +6,8 @@
 set -euo pipefail
 
 PLUGIN_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
-if [[ -z "$PLUGIN_VERSION" || "$PLUGIN_VERSION" == "null" ]]; then
-  echo "ERROR: could not read version from .claude-plugin/plugin.json" >&2
+if [[ -z "$PLUGIN_VERSION" || "$PLUGIN_VERSION" == "null" || "$PLUGIN_VERSION" =~ [/\\] || "$PLUGIN_VERSION" == *..* ]]; then
+  echo "ERROR: invalid version from .claude-plugin/plugin.json: $PLUGIN_VERSION" >&2
   exit 1
 fi
 CACHE_BASE="${HOME}/.claude-profiles/work/config/plugins/cache/emporium/signum"

--- a/lib/sync-cache.sh
+++ b/lib/sync-cache.sh
@@ -6,6 +6,10 @@
 set -euo pipefail
 
 PLUGIN_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+if [[ -z "$PLUGIN_VERSION" || "$PLUGIN_VERSION" == "null" ]]; then
+  echo "ERROR: could not read version from .claude-plugin/plugin.json" >&2
+  exit 1
+fi
 CACHE_BASE="${HOME}/.claude-profiles/work/config/plugins/cache/emporium/signum"
 CACHE_DIR="${CACHE_BASE}/${PLUGIN_VERSION}"
 

--- a/lib/sync-cache.sh
+++ b/lib/sync-cache.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 PLUGIN_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
-if [[ -z "$PLUGIN_VERSION" || "$PLUGIN_VERSION" == "null" || "$PLUGIN_VERSION" =~ [/\\] || "$PLUGIN_VERSION" == *..* ]]; then
+if [[ -z "$PLUGIN_VERSION" || "$PLUGIN_VERSION" == "null" || "$PLUGIN_VERSION" =~ [/\\] || "$PLUGIN_VERSION" == *..* || "$PLUGIN_VERSION" == "." ]]; then
   echo "ERROR: invalid version from .claude-plugin/plugin.json: $PLUGIN_VERSION" >&2
   exit 1
 fi

--- a/platforms/claude-code/lib/schemas/proofpack.schema.json
+++ b/platforms/claude-code/lib/schemas/proofpack.schema.json
@@ -27,7 +27,7 @@
     }
   },
   "properties": {
-    "schemaVersion": { "type": "string", "enum": ["4.0", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6"] },
+    "schemaVersion": { "type": "string", "enum": ["4.0", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8"] },
     "signumVersion": { "type": "string" },
     "createdAt": { "type": "string", "format": "date-time" },
     "runId": { "type": "string", "pattern": "^signum-" },

--- a/platforms/claude-code/lib/signum-update.sh
+++ b/platforms/claude-code/lib/signum-update.sh
@@ -17,7 +17,7 @@ VERSION="${1:-$(jq -r .version "$PLUGIN_ROOT/.claude-plugin/plugin.json")}"
 PLUGIN_NAME="signum"
 MARKETPLACE="emporium"
 
-if [[ -z "$VERSION" || "$VERSION" == "null" || "$VERSION" =~ [/\\] || "$VERSION" == *..* ]]; then
+if [[ -z "$VERSION" || "$VERSION" == "null" || "$VERSION" =~ [/\\] || "$VERSION" == *..* || "$VERSION" == "." ]]; then
   echo "ERROR: invalid version: $VERSION" >&2
   exit 1
 fi

--- a/platforms/claude-code/lib/signum-update.sh
+++ b/platforms/claude-code/lib/signum-update.sh
@@ -17,6 +17,11 @@ VERSION="${1:-$(jq -r .version "$PLUGIN_ROOT/.claude-plugin/plugin.json")}"
 PLUGIN_NAME="signum"
 MARKETPLACE="emporium"
 
+if [[ -z "$VERSION" || "$VERSION" == "null" || "$VERSION" =~ [/\\] || "$VERSION" == *..* ]]; then
+  echo "ERROR: invalid version: $VERSION" >&2
+  exit 1
+fi
+
 echo "Updating $PLUGIN_NAME to v$VERSION..."
 echo ""
 

--- a/platforms/claude-code/lib/signum-update.sh
+++ b/platforms/claude-code/lib/signum-update.sh
@@ -66,27 +66,29 @@ for settings_file in \
   "$HOME/.claude-profiles"/*/config/settings.json; do
   [ -f "$settings_file" ] || continue
   # Find signum entries NOT from our target marketplace
-  ORPHANS=$(python3 -c "
+  ORPHANS=$(python3 - "$settings_file" "$PLUGIN_NAME" "$MARKETPLACE" <<'PYEOF' 2>/dev/null || true
 import json, sys
-with open('$settings_file') as f:
+with open(sys.argv[1]) as f:
     s = json.load(f)
 plugins = s.get('enabledPlugins', {})
-orphans = [k for k in plugins if k.startswith('$PLUGIN_NAME@') and k != '$PLUGIN_NAME@$MARKETPLACE']
+target = sys.argv[2] + '@' + sys.argv[3]
+orphans = [k for k in plugins if k.startswith(sys.argv[2] + '@') and k != target]
 for o in orphans: print(o)
-" 2>/dev/null || true)
+PYEOF
+)
 
   if [ -n "$ORPHANS" ]; then
     for orphan in $ORPHANS; do
       echo "  Removing orphan: $orphan from $settings_file"
-      python3 -c "
-import json
-with open('$settings_file') as f:
+      python3 - "$settings_file" "$orphan" <<'PYEOF' 2>/dev/null || true
+import json, sys
+with open(sys.argv[1]) as f:
     s = json.load(f)
-s.get('enabledPlugins', {}).pop('$orphan', None)
-with open('$settings_file', 'w') as f:
+s.get('enabledPlugins', {}).pop(sys.argv[2], None)
+with open(sys.argv[1], 'w') as f:
     json.dump(s, f, indent=2)
     f.write('\n')
-" 2>/dev/null || true
+PYEOF
     done
   fi
 done
@@ -187,14 +189,16 @@ for settings_file in \
   "$HOME/.claude/settings.json" \
   "$HOME/.claude-profiles"/*/config/settings.json; do
   [ -f "$settings_file" ] || continue
-  ORPHAN_COUNT=$(python3 -c "
-import json
-with open('$settings_file') as f:
+  ORPHAN_COUNT=$(python3 - "$settings_file" "$PLUGIN_NAME" "$MARKETPLACE" <<'PYEOF' 2>/dev/null || echo 0
+import json, sys
+with open(sys.argv[1]) as f:
     s = json.load(f)
 plugins = s.get('enabledPlugins', {})
-orphans = [k for k in plugins if k.startswith('$PLUGIN_NAME@') and k != '$PLUGIN_NAME@$MARKETPLACE']
+target = sys.argv[2] + '@' + sys.argv[3]
+orphans = [k for k in plugins if k.startswith(sys.argv[2] + '@') and k != target]
 print(len(orphans))
-" 2>/dev/null || echo 0)
+PYEOF
+)
   if [ "$ORPHAN_COUNT" -gt 0 ]; then
     echo "  WARN: $ORPHAN_COUNT orphan entries in $settings_file"
     ERRORS=$((ERRORS + 1))


### PR DESCRIPTION
## Summary

Iterative codex deep review + fix cycle (5 iterations, 18 commits).

### Critical/High fixes:
- **Python code injection** in `policy-resolver.sh`, `metric-ratchet.sh`, `signum-update.sh`, `proofpack-index.sh` — replaced `python3 -c` with shell variable interpolation by heredoc + `sys.argv`
- **jq filter injection** in `metric-ratchet.sh`, `proofpack-index.sh` — use `--arg` instead of string interpolation
- **Unsafe `rm -rf`** in `sync-cache.sh` — validate version string is not empty/null/path-traversal
- **Path traversal** in `signum-update.sh`, `sync-cache.sh` — reject `/`, `\`, `..`, `.` in version strings
- **Missing sha256 fallback** in `staleness-check.sh` — fail with clear error instead of silent breakage
- **Incomplete injection scan** in `contract-injection-scan.sh` — scan all contract fields including `verify`, `allowNewFilesUnder`, `riskSignals`, `contextInheritance`
- **Schema version mismatch** — add 4.7 and 4.8 to `proofpack.schema.json` enum

### Medium fixes:
- **UTC timezone** for date cutoff in `metric-ratchet.sh` and `proofpack-index.sh`
- **Integer validation** for `days_current`/`days_previous` args in `metric-ratchet.sh`
- **Dot version** (`.`) rejected in path validation
- **Deduplication** of proofpacks by `runId` in `metric-ratchet.sh`
- **Zero-confidence** runs included in `avg_confidence` calculation
- **File path separator** in staleness hash for injectivity

### Synced to platforms/:
- `platforms/claude-code/lib/signum-update.sh`
- `platforms/claude-code/lib/schemas/proofpack.schema.json`

## Test plan
- [ ] Verify `policy-resolver.sh` still resolves models correctly
- [ ] Verify `metric-ratchet.sh` computes metrics without errors
- [ ] Verify `sync-cache.sh` rejects bad versions
- [ ] Verify `signum-update.sh` update cycle works end-to-end
- [ ] Verify injection scan catches Unicode in new fields