### PR TITLE
Add offline eval harness v1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,5 @@
   "license": "MIT",
   "name": "signum",
   "repository": "https://github.com/heurema/signum",
-  "version": "4.18.1"
+  "version": "4.19.0"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 .dev/
 .signum/
+__pycache__/
+*.pyc
 node_modules/
 .punk/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [4.19.0] - 2026-04-10
+
+### Added
+- Offline eval harness v1 for prompt/orchestration-sensitive changes
+  - `evals/checks.py` — deterministic invariant grader for contract/audit/proofpack semantics
+  - `evals/run.py` — snapshot runner for 6 representative fixtures with `--update-snapshots` support
+  - `evals/fixtures/*.json` + `evals/snapshots/*.json` — committed eval corpus and reviewed golden outputs
+  - `tests/test-eval-harness.sh` — shell coverage for the green path and broken-snapshot regression detection
+
+### Documentation
+- `README.md`, `docs/how-it-works.md`, and `docs/QUALITY_SCORE.md` — maintainer guidance for the new offline eval harness
+- `docs/PLANS.md` — provider-alignment intake rule plus eval-harness-first planning note
+
 ## [4.18.1] - 2026-04-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ This generates `project.intent.md`, `project.glossary.json`, and repo-level harn
 | `/signum <task>` | Run the full CONTRACT → EXECUTE → AUDIT → PACK pipeline |
 | `/signum init [--force] [--harness] [--project-root <path>]` | Bootstrap `project.intent.md` / `project.glossary.json`; `--harness` also scaffolds repo-level harness docs |
 
+## Maintenance checks
+
+For prompt/orchestration-sensitive changes, run the offline eval harness:
+
+```bash
+python3 evals/run.py
+```
+
+It is fixture-driven and snapshot-based by design. It does not call live providers and it does not extend the runtime pipeline.
+
 ## Features
 
 **Spec quality gate** — Before implementation starts, your spec is scored across seven dimensions: Testability, Negative coverage, Clarity, Scope boundedness, Completeness, Boundary cases, NL Consistency. Grade D (below 60) is a hard stop with specific feedback on what's missing. The gate runs on the specification, not the code.

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -10,7 +10,7 @@ arguments:
     required: false
 ---
 
-# Signum v4.18: Evidence-Driven Development Pipeline
+# Signum v4.19: Evidence-Driven Development Pipeline
 
 You are the Signum orchestrator. You drive a 4-phase evidence-driven pipeline:
 
@@ -27,7 +27,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.18.1",
+  "version": "4.19.0",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -3074,7 +3074,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' .signum/audit_summary.js
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.18.1" \
+  --arg signumVersion "4.19.0" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -12,6 +12,11 @@ review_cadence: monthly
 - Root command files remain canonical for shipped behavior; plan docs must not be treated as behavior truth when they disagree with `commands/signum.md`.
 - When a capability ships, update the roadmap status in the same change or immediately after. Do not leave “not started” on already shipped behavior.
 
+## Idea Intake Rule
+- Before adopting a new Signum idea from adjacent tools, research, or competitor repos, first compare it against the current approaches and stated directions of relevant providers (`Anthropic`, `OpenAI`, `Google`, and others when relevant).
+- Prefer provider-aligned ideas over clever local additions when the tradeoff is unclear.
+- Until that comparison exists, treat the idea as exploratory only — not committed roadmap work.
+
 ## Active Workstreams
 
 | Workstream | Source Doc | Status | Notes |
@@ -28,6 +33,7 @@ review_cadence: monthly
 - `init --harness` MVP now exists to bootstrap repo-level harness docs in addition to project intent/glossary.
 
 ## Next Planned Steps
+- Add an evaluation harness first; this is the current lowest-risk provider-aligned follow-up for prompt/orchestration work.
 - Decide which docs should remain hand-maintained versus eventually derived/generated.
 - Implement the first report-only anti-entropy artifact without changing the canonical root phase model.
 - Extend thin-cli planning from extraction inventory to a stable protocol/event model for `signum-core`.

--- a/docs/QUALITY_SCORE.md
+++ b/docs/QUALITY_SCORE.md
@@ -12,6 +12,7 @@ review_cadence: quarterly
 - Canonical behavior changes in `commands/signum.md` or `commands/init.md` must update the matching derived docs in the same bounded diff.
 - Root-vs-overlay behavior differences must either be removed or documented in `docs/overlay-deviations.json`.
 - Docs-only changes that affect operator understanding should pass doc parity checks.
+- Prompt/orchestration-sensitive changes should run `python3 evals/run.py`; if behavior changes intentionally, update the matching fixtures/snapshots in the same diff.
 
 ## Repo-Specific Quality Dimensions
 
@@ -40,6 +41,7 @@ review_cadence: quarterly
 | `lib/*.sh` deterministic behavior | matching `tests/test-*.sh` + direct script sanity run |
 | `commands/*.md` behavior change | docs sync + relevant deterministic tests |
 | init/bootstrap change | `tests/test-init.sh` and/or `tests/test-init-harness-scaffold.sh` |
+| prompt/orchestration change | `python3 evals/run.py` + `bash tests/test-eval-harness.sh` |
 | canonical/overlay doc change | `tests/test-doc-parity.sh` + `lib/doc-parity-check.sh` |
 | schema change | schema consumers + docs/reference sync |
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -153,6 +153,15 @@ All artifacts are written to `.signum/` (auto-added to `.gitignore`):
 | `repair_brief.json` | AUDIT | Current repair brief for engineer (v4.6+) |
 | `flaky_tests.json` | AUDIT | Flaky test tracker (v4.6+, run-local) |
 
+## Offline eval harness (v1)
+
+Signum also ships a maintainer-facing offline eval harness under `evals/`. It is intentionally not a runtime phase.
+
+- `python3 evals/run.py` evaluates 6 representative pseudo-run fixtures.
+- The grader is deterministic and snapshot-based.
+- The scope is contract/audit/proofpack semantics for prompt/orchestration work.
+- No live provider calls, no LLM judge, no trajectory evaluation.
+
 ## Project Context Bootstrap: /signum init
 
 Before running the main pipeline on an unfamiliar project, use `/signum init` to generate project context files that the Contractor agent reads automatically. Use `--harness` when you also want repo-level harness docs scaffolded.

--- a/evals/README.md
+++ b/evals/README.md
@@ -30,10 +30,14 @@ This directory contains the first offline eval harness for Signum prompt/orchest
 python3 evals/run.py
 ```
 
+When called without explicit directory flags, the runner resolves `fixtures/` and `snapshots/` relative to `evals/run.py`, not the current shell directory.
+
 Expected v1 success shape:
 - `.status == "ok"`
 - `.fixtureCount == 6`
 - `.failed == 0`
+
+No fixtures is a hard error.
 
 ## Update snapshots intentionally
 ```bash

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,43 @@
+# Signum eval harness v1
+
+This directory contains the first offline eval harness for Signum prompt/orchestration work.
+
+## Purpose
+- Catch regression in contract/audit/proofpack semantics without making live provider calls.
+- Keep representative cases in git as reviewed snapshots.
+- Give prompt/orchestration changes one cheap deterministic check before runtime complexity grows.
+
+## Scope
+- 6 curated fixture cases.
+- Deterministic grading only.
+- Snapshot comparison only.
+
+## Non-goals
+- No live provider evals.
+- No LLM judge.
+- No prompt auto-optimization.
+- No trajectory or agent-loop evaluation.
+- No root-vs-overlay parity coverage in v1.
+
+## Layout
+- `fixtures/*.json` — representative pseudo-run artifacts.
+- `snapshots/*.json` — committed expected summaries from the deterministic grader.
+- `checks.py` — invariant checks for contract/audit/proofpack semantics.
+- `run.py` — runner that compares current outputs to committed snapshots.
+
+## Run
+```bash
+python3 evals/run.py
+```
+
+Expected v1 success shape:
+- `.status == "ok"`
+- `.fixtureCount == 6`
+- `.failed == 0`
+
+## Update snapshots intentionally
+```bash
+python3 evals/run.py --update-snapshots
+```
+
+Only update snapshots when the change is intentional and reviewed as a behavior change.

--- a/evals/checks.py
+++ b/evals/checks.py
@@ -16,6 +16,7 @@ ALLOWED_COVERAGE_STATES = {
     "server_error",
     "runtime_error",
 }
+EXTERNAL_REVIEW_PROVIDERS = ("codex", "gemini")
 
 
 def canonical_json(data: Any) -> str:
@@ -32,6 +33,17 @@ def _check(ok: bool, check_id: str, detail: str) -> Dict[str, str]:
 
 def _is_string_list(value: Any) -> bool:
     return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _required_external_providers(risk_level: Any) -> set[str]:
+    if risk_level in {"medium", "high"}:
+        return set(EXTERNAL_REVIEW_PROVIDERS)
+    return set()
+
+
+def _is_missing_only_degradation(coverage: Dict[str, str]) -> bool:
+    degraded_states = [state for state in coverage.values() if state != "ready"]
+    return bool(degraded_states) and all(state == "missing" for state in degraded_states)
 
 
 def evaluate_fixture(fixture: Dict[str, Any]) -> Dict[str, Any]:
@@ -77,17 +89,23 @@ def evaluate_fixture(fixture: Dict[str, Any]) -> Dict[str, Any]:
         regressions = audit.get("regressions") if isinstance(audit.get("regressions"), list) else []
         critical_findings = audit.get("criticalFindings") if isinstance(audit.get("criticalFindings"), list) else []
         coverage = audit.get("externalAuditCoverage") if isinstance(audit.get("externalAuditCoverage"), dict) else {}
+        required_providers = _required_external_providers(risk_level)
+        missing_coverage_keys = sorted(required_providers - set(coverage))
+        checks.append(_check(not missing_coverage_keys, "audit.coverage_keys", f"{risk_level}-risk cases must record coverage for both codex and gemini"))
         invalid_states = {provider: state for provider, state in coverage.items() if state not in ALLOWED_COVERAGE_STATES}
         checks.append(_check(not invalid_states, "audit.coverage_states", "all provider coverage states must be recognized"))
         reduced_coverage = audit.get("reducedAuditCoverage") is True
         degraded = sorted(provider for provider, state in coverage.items() if state != "ready")
+        missing_only_degradation = _is_missing_only_degradation(coverage)
         checks.append(_check((not degraded) or reduced_coverage, "audit.reduced_coverage_flag", "reducedAuditCoverage must be true when any provider is degraded"))
-        if contract_ready and not contract_open_questions and not regressions and not critical_findings and not (reduced_coverage and risk_level in {"medium", "high"}) and not flags.get("policySensitive"):
+        if contract_ready and not contract_open_questions and not regressions and not critical_findings and not reduced_coverage and not flags.get("policySensitive"):
             checks.append(_check(verdict == "AUTO_OK", "audit.clean_case_verdict", "clean low-friction cases should land on AUTO_OK"))
         if regressions or critical_findings:
             checks.append(_check(verdict == "AUTO_BLOCK", "audit.block_on_regression", "regressions or critical findings must block"))
-        if reduced_coverage and risk_level in {"medium", "high"}:
-            checks.append(_check(verdict != "AUTO_OK", "audit.medium_high_reduced_coverage", "medium/high risk cases with reduced coverage must not claim AUTO_OK"))
+        if reduced_coverage and risk_level == "high":
+            checks.append(_check(verdict != "AUTO_OK", "audit.high_risk_reduced_coverage", "high-risk cases with reduced coverage must not claim AUTO_OK"))
+        if reduced_coverage and risk_level == "medium" and not missing_only_degradation:
+            checks.append(_check(verdict != "AUTO_OK", "audit.medium_non_missing_reduced_coverage", "medium-risk AUTO_OK is allowed only for graceful degradation caused by missing external CLIs"))
         if (not contract_ready) or contract_open_questions:
             checks.append(_check(verdict != "AUTO_OK", "audit.contract_gap_verdict", "contract gaps must not claim AUTO_OK"))
         if flags.get("policySensitive"):

--- a/evals/checks.py
+++ b/evals/checks.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Deterministic checks for Signum eval harness fixtures."""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+ALLOWED_RISK_LEVELS = {"low", "medium", "high"}
+ALLOWED_VERDICTS = {"AUTO_OK", "HUMAN_REVIEW", "AUTO_BLOCK"}
+ALLOWED_COVERAGE_STATES = {
+    "ready",
+    "missing",
+    "auth_error",
+    "network_error",
+    "timeout",
+    "server_error",
+    "runtime_error",
+}
+
+
+def canonical_json(data: Any) -> str:
+    return json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def _check(ok: bool, check_id: str, detail: str) -> Dict[str, str]:
+    return {
+        "id": check_id,
+        "status": "pass" if ok else "fail",
+        "detail": detail,
+    }
+
+
+def _is_string_list(value: Any) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def evaluate_fixture(fixture: Dict[str, Any]) -> Dict[str, Any]:
+    checks: List[Dict[str, str]] = []
+
+    case_id = fixture.get("caseId")
+    risk_level = fixture.get("riskLevel")
+    flags = fixture.get("flags") if isinstance(fixture.get("flags"), dict) else {}
+    artifacts = fixture.get("artifacts") if isinstance(fixture.get("artifacts"), dict) else {}
+    contract = artifacts.get("contract") if isinstance(artifacts.get("contract"), dict) else None
+    audit = artifacts.get("auditSummary") if isinstance(artifacts.get("auditSummary"), dict) else None
+    proofpack = artifacts.get("proofpack") if isinstance(artifacts.get("proofpack"), dict) else None
+
+    checks.append(_check(isinstance(case_id, str) and bool(case_id), "fixture.case_id", "fixture must declare a non-empty caseId"))
+    checks.append(_check(risk_level in ALLOWED_RISK_LEVELS, "fixture.risk_level", "riskLevel must be one of low|medium|high"))
+    checks.append(_check(contract is not None, "contract.present", "contract artifact must be present"))
+    checks.append(_check(audit is not None, "audit.present", "audit summary artifact must be present"))
+    checks.append(_check(proofpack is not None, "proofpack.present", "proofpack artifact must be present"))
+
+    contract_ready = False
+    contract_open_questions = False
+    if contract is not None:
+        checks.append(_check(isinstance(contract.get("requiredInputsProvided"), bool), "contract.required_inputs_shape", "requiredInputsProvided must be boolean"))
+        checks.append(_check(_is_string_list(contract.get("openQuestions")), "contract.open_questions_shape", "openQuestions must be a list of strings"))
+        checks.append(_check(isinstance(contract.get("acceptanceCriteria"), list) and len(contract.get("acceptanceCriteria")) > 0, "contract.acceptance_criteria_shape", "acceptanceCriteria must be a non-empty list"))
+        contract_ready = contract.get("requiredInputsProvided") is True
+        contract_open_questions = isinstance(contract.get("openQuestions"), list) and len(contract.get("openQuestions")) > 0
+
+    verdict = None
+    regressions: List[Any] = []
+    critical_findings: List[Any] = []
+    coverage: Dict[str, str] = {}
+    reduced_coverage = False
+    if audit is not None:
+        verdict = audit.get("verdict")
+        checks.append(_check(verdict in ALLOWED_VERDICTS, "audit.verdict_shape", "verdict must be AUTO_OK | HUMAN_REVIEW | AUTO_BLOCK"))
+        checks.append(_check(isinstance(audit.get("confidence"), int), "audit.confidence_shape", "confidence must be an integer"))
+        checks.append(_check(isinstance(audit.get("reducedAuditCoverage"), bool), "audit.reduced_coverage_shape", "reducedAuditCoverage must be boolean"))
+        checks.append(_check(isinstance(audit.get("regressions"), list), "audit.regressions_shape", "regressions must be a list"))
+        checks.append(_check(isinstance(audit.get("criticalFindings"), list), "audit.critical_findings_shape", "criticalFindings must be a list"))
+        checks.append(_check(_is_string_list(audit.get("notes")), "audit.notes_shape", "notes must be a list of strings"))
+        checks.append(_check(isinstance(audit.get("externalAuditCoverage"), dict) and bool(audit.get("externalAuditCoverage")), "audit.coverage_shape", "externalAuditCoverage must be a non-empty object"))
+        regressions = audit.get("regressions") if isinstance(audit.get("regressions"), list) else []
+        critical_findings = audit.get("criticalFindings") if isinstance(audit.get("criticalFindings"), list) else []
+        coverage = audit.get("externalAuditCoverage") if isinstance(audit.get("externalAuditCoverage"), dict) else {}
+        invalid_states = {provider: state for provider, state in coverage.items() if state not in ALLOWED_COVERAGE_STATES}
+        checks.append(_check(not invalid_states, "audit.coverage_states", "all provider coverage states must be recognized"))
+        reduced_coverage = audit.get("reducedAuditCoverage") is True
+        degraded = sorted(provider for provider, state in coverage.items() if state != "ready")
+        checks.append(_check((not degraded) or reduced_coverage, "audit.reduced_coverage_flag", "reducedAuditCoverage must be true when any provider is degraded"))
+        if contract_ready and not contract_open_questions and not regressions and not critical_findings and not (reduced_coverage and risk_level in {"medium", "high"}) and not flags.get("policySensitive"):
+            checks.append(_check(verdict == "AUTO_OK", "audit.clean_case_verdict", "clean low-friction cases should land on AUTO_OK"))
+        if regressions or critical_findings:
+            checks.append(_check(verdict == "AUTO_BLOCK", "audit.block_on_regression", "regressions or critical findings must block"))
+        if reduced_coverage and risk_level in {"medium", "high"}:
+            checks.append(_check(verdict != "AUTO_OK", "audit.medium_high_reduced_coverage", "medium/high risk cases with reduced coverage must not claim AUTO_OK"))
+        if (not contract_ready) or contract_open_questions:
+            checks.append(_check(verdict != "AUTO_OK", "audit.contract_gap_verdict", "contract gaps must not claim AUTO_OK"))
+        if flags.get("policySensitive"):
+            checks.append(_check(verdict != "AUTO_OK", "audit.policy_sensitive_verdict", "policy-sensitive cases should remain gated for human review or block"))
+
+    if proofpack is not None:
+        required_sections = {
+            "runMetadata": dict,
+            "contractSummary": dict,
+            "baselineSummary": dict,
+            "implementationSummary": dict,
+            "auditSummary": dict,
+            "reviewSummaries": dict,
+            "externalAuditCoverage": dict,
+            "finalVerdict": str,
+        }
+        missing_sections = sorted(name for name, expected_type in required_sections.items() if not isinstance(proofpack.get(name), expected_type))
+        checks.append(_check(not missing_sections, "proofpack.required_sections", "proofpack must expose all required summary sections"))
+        if verdict is not None:
+            checks.append(_check(proofpack.get("finalVerdict") == verdict, "proofpack.final_verdict_match", "proofpack finalVerdict must match audit verdict"))
+        if coverage:
+            checks.append(_check(proofpack.get("externalAuditCoverage") == coverage, "proofpack.coverage_match", "proofpack coverage must mirror audit coverage"))
+
+    failed_checks = [check for check in checks if check["status"] == "fail"]
+    degraded_providers = sorted(provider for provider, state in coverage.items() if state != "ready")
+
+    return {
+        "caseId": case_id,
+        "description": fixture.get("description", ""),
+        "riskLevel": risk_level,
+        "policySensitive": bool(flags.get("policySensitive")),
+        "observedVerdict": verdict,
+        "contractReady": contract_ready and not contract_open_questions,
+        "reducedAuditCoverage": reduced_coverage,
+        "degradedProviders": degraded_providers,
+        "failedChecks": [check["id"] for check in failed_checks],
+        "failedCheckDetails": failed_checks,
+        "checkCounts": {
+            "total": len(checks),
+            "passed": len(checks) - len(failed_checks),
+            "failed": len(failed_checks),
+        },
+        "invariantStatus": "ok" if not failed_checks else "violated",
+    }

--- a/evals/fixtures/01-low-risk-happy-path.json
+++ b/evals/fixtures/01-low-risk-happy-path.json
@@ -1,0 +1,66 @@
+{
+  "caseId": "01-low-risk-happy-path",
+  "description": "Low-risk clean case with full coverage and an AUTO_OK verdict.",
+  "riskLevel": "low",
+  "flags": {},
+  "artifacts": {
+    "contract": {
+      "schemaVersion": "1.0",
+      "goal": "fixture goal",
+      "acceptanceCriteria": [
+        {
+          "id": "AC-1",
+          "description": "placeholder"
+        }
+      ],
+      "openQuestions": [],
+      "requiredInputsProvided": true
+    },
+    "auditSummary": {
+      "verdict": "AUTO_OK",
+      "confidence": 93,
+      "reducedAuditCoverage": false,
+      "regressions": [],
+      "criticalFindings": [],
+      "notes": [
+        "Deterministic checks and review summaries are aligned."
+      ],
+      "externalAuditCoverage": {
+        "codex": "ready",
+        "gemini": "ready"
+      }
+    },
+    "proofpack": {
+      "runMetadata": {
+        "runId": "fixture-run",
+        "source": "eval-harness-v1"
+      },
+      "contractSummary": {
+        "acceptanceCriteria": 1,
+        "requiredInputsProvided": true
+      },
+      "baselineSummary": {
+        "status": "captured"
+      },
+      "implementationSummary": {
+        "status": "simulated"
+      },
+      "auditSummary": {
+        "status": "simulated"
+      },
+      "reviewSummaries": {
+        "codex": {
+          "status": "simulated"
+        }
+      },
+      "externalAuditCoverage": {
+        "codex": "ready",
+        "gemini": "ready"
+      },
+      "finalVerdict": "AUTO_OK",
+      "policyFlags": {
+        "policySensitive": false
+      }
+    }
+  }
+}

--- a/evals/fixtures/02-medium-risk-graceful-degradation.json
+++ b/evals/fixtures/02-medium-risk-graceful-degradation.json
@@ -1,6 +1,6 @@
 {
-  "caseId": "02-medium-risk-reduced-coverage",
-  "description": "Medium-risk case degrades one reviewer and must stay below AUTO_OK.",
+  "caseId": "02-medium-risk-graceful-degradation",
+  "description": "Medium-risk graceful degradation with genuinely missing external CLIs may still remain AUTO_OK.",
   "riskLevel": "medium",
   "flags": {},
   "artifacts": {
@@ -17,17 +17,17 @@
       "requiredInputsProvided": true
     },
     "auditSummary": {
-      "verdict": "HUMAN_REVIEW",
-      "confidence": 81,
+      "verdict": "AUTO_OK",
+      "confidence": 83,
       "reducedAuditCoverage": true,
       "regressions": [],
       "criticalFindings": [],
       "notes": [
-        "Reduced audit coverage: gemini timeout"
+        "Reduced audit coverage: codex/gemini CLIs missing, single-model graceful degradation path."
       ],
       "externalAuditCoverage": {
-        "codex": "ready",
-        "gemini": "timeout"
+        "codex": "missing",
+        "gemini": "missing"
       }
     },
     "proofpack": {
@@ -54,10 +54,10 @@
         }
       },
       "externalAuditCoverage": {
-        "codex": "ready",
-        "gemini": "timeout"
+        "codex": "missing",
+        "gemini": "missing"
       },
-      "finalVerdict": "HUMAN_REVIEW",
+      "finalVerdict": "AUTO_OK",
       "policyFlags": {
         "policySensitive": false
       }

--- a/evals/fixtures/02-medium-risk-reduced-coverage.json
+++ b/evals/fixtures/02-medium-risk-reduced-coverage.json
@@ -1,0 +1,66 @@
+{
+  "caseId": "02-medium-risk-reduced-coverage",
+  "description": "Medium-risk case degrades one reviewer and must stay below AUTO_OK.",
+  "riskLevel": "medium",
+  "flags": {},
+  "artifacts": {
+    "contract": {
+      "schemaVersion": "1.0",
+      "goal": "fixture goal",
+      "acceptanceCriteria": [
+        {
+          "id": "AC-1",
+          "description": "placeholder"
+        }
+      ],
+      "openQuestions": [],
+      "requiredInputsProvided": true
+    },
+    "auditSummary": {
+      "verdict": "HUMAN_REVIEW",
+      "confidence": 81,
+      "reducedAuditCoverage": true,
+      "regressions": [],
+      "criticalFindings": [],
+      "notes": [
+        "Reduced audit coverage: gemini timeout"
+      ],
+      "externalAuditCoverage": {
+        "codex": "ready",
+        "gemini": "timeout"
+      }
+    },
+    "proofpack": {
+      "runMetadata": {
+        "runId": "fixture-run",
+        "source": "eval-harness-v1"
+      },
+      "contractSummary": {
+        "acceptanceCriteria": 1,
+        "requiredInputsProvided": true
+      },
+      "baselineSummary": {
+        "status": "captured"
+      },
+      "implementationSummary": {
+        "status": "simulated"
+      },
+      "auditSummary": {
+        "status": "simulated"
+      },
+      "reviewSummaries": {
+        "codex": {
+          "status": "simulated"
+        }
+      },
+      "externalAuditCoverage": {
+        "codex": "ready",
+        "gemini": "timeout"
+      },
+      "finalVerdict": "HUMAN_REVIEW",
+      "policyFlags": {
+        "policySensitive": false
+      }
+    }
+  }
+}

--- a/evals/fixtures/03-high-risk-provider-unavailable.json
+++ b/evals/fixtures/03-high-risk-provider-unavailable.json
@@ -1,0 +1,66 @@
+{
+  "caseId": "03-high-risk-provider-unavailable",
+  "description": "High-risk case with multiple degraded reviewers must remain gated.",
+  "riskLevel": "high",
+  "flags": {},
+  "artifacts": {
+    "contract": {
+      "schemaVersion": "1.0",
+      "goal": "fixture goal",
+      "acceptanceCriteria": [
+        {
+          "id": "AC-1",
+          "description": "placeholder"
+        }
+      ],
+      "openQuestions": [],
+      "requiredInputsProvided": true
+    },
+    "auditSummary": {
+      "verdict": "HUMAN_REVIEW",
+      "confidence": 72,
+      "reducedAuditCoverage": true,
+      "regressions": [],
+      "criticalFindings": [],
+      "notes": [
+        "Reduced audit coverage: codex missing, gemini network_error"
+      ],
+      "externalAuditCoverage": {
+        "codex": "missing",
+        "gemini": "network_error"
+      }
+    },
+    "proofpack": {
+      "runMetadata": {
+        "runId": "fixture-run",
+        "source": "eval-harness-v1"
+      },
+      "contractSummary": {
+        "acceptanceCriteria": 1,
+        "requiredInputsProvided": true
+      },
+      "baselineSummary": {
+        "status": "captured"
+      },
+      "implementationSummary": {
+        "status": "simulated"
+      },
+      "auditSummary": {
+        "status": "simulated"
+      },
+      "reviewSummaries": {
+        "codex": {
+          "status": "simulated"
+        }
+      },
+      "externalAuditCoverage": {
+        "codex": "missing",
+        "gemini": "network_error"
+      },
+      "finalVerdict": "HUMAN_REVIEW",
+      "policyFlags": {
+        "policySensitive": false
+      }
+    }
+  }
+}

--- a/evals/fixtures/04-ambiguous-input-missing-required-input.json
+++ b/evals/fixtures/04-ambiguous-input-missing-required-input.json
@@ -1,0 +1,68 @@
+{
+  "caseId": "04-ambiguous-input-missing-required-input",
+  "description": "Contract gaps force HUMAN_REVIEW even when artifacts are otherwise well formed.",
+  "riskLevel": "medium",
+  "flags": {},
+  "artifacts": {
+    "contract": {
+      "schemaVersion": "1.0",
+      "goal": "fixture goal",
+      "acceptanceCriteria": [
+        {
+          "id": "AC-1",
+          "description": "placeholder"
+        }
+      ],
+      "openQuestions": [
+        "Need the target proofpack field inventory from the owner."
+      ],
+      "requiredInputsProvided": false
+    },
+    "auditSummary": {
+      "verdict": "HUMAN_REVIEW",
+      "confidence": 64,
+      "reducedAuditCoverage": false,
+      "regressions": [],
+      "criticalFindings": [],
+      "notes": [
+        "Contract is incomplete; manual clarification required."
+      ],
+      "externalAuditCoverage": {
+        "codex": "ready",
+        "gemini": "ready"
+      }
+    },
+    "proofpack": {
+      "runMetadata": {
+        "runId": "fixture-run",
+        "source": "eval-harness-v1"
+      },
+      "contractSummary": {
+        "acceptanceCriteria": 1,
+        "requiredInputsProvided": true
+      },
+      "baselineSummary": {
+        "status": "captured"
+      },
+      "implementationSummary": {
+        "status": "simulated"
+      },
+      "auditSummary": {
+        "status": "simulated"
+      },
+      "reviewSummaries": {
+        "codex": {
+          "status": "simulated"
+        }
+      },
+      "externalAuditCoverage": {
+        "codex": "ready",
+        "gemini": "ready"
+      },
+      "finalVerdict": "HUMAN_REVIEW",
+      "policyFlags": {
+        "policySensitive": false
+      }
+    }
+  }
+}

--- a/evals/fixtures/05-policy-sensitive-human-review.json
+++ b/evals/fixtures/05-policy-sensitive-human-review.json
@@ -1,0 +1,68 @@
+{
+  "caseId": "05-policy-sensitive-human-review",
+  "description": "Policy-sensitive work should stay gated even with full reviewer coverage.",
+  "riskLevel": "medium",
+  "flags": {
+    "policySensitive": true
+  },
+  "artifacts": {
+    "contract": {
+      "schemaVersion": "1.0",
+      "goal": "fixture goal",
+      "acceptanceCriteria": [
+        {
+          "id": "AC-1",
+          "description": "placeholder"
+        }
+      ],
+      "openQuestions": [],
+      "requiredInputsProvided": true
+    },
+    "auditSummary": {
+      "verdict": "HUMAN_REVIEW",
+      "confidence": 79,
+      "reducedAuditCoverage": false,
+      "regressions": [],
+      "criticalFindings": [],
+      "notes": [
+        "Policy-sensitive task kept gated for manual approval."
+      ],
+      "externalAuditCoverage": {
+        "codex": "ready",
+        "gemini": "ready"
+      }
+    },
+    "proofpack": {
+      "runMetadata": {
+        "runId": "fixture-run",
+        "source": "eval-harness-v1"
+      },
+      "contractSummary": {
+        "acceptanceCriteria": 1,
+        "requiredInputsProvided": true
+      },
+      "baselineSummary": {
+        "status": "captured"
+      },
+      "implementationSummary": {
+        "status": "simulated"
+      },
+      "auditSummary": {
+        "status": "simulated"
+      },
+      "reviewSummaries": {
+        "codex": {
+          "status": "simulated"
+        }
+      },
+      "externalAuditCoverage": {
+        "codex": "ready",
+        "gemini": "ready"
+      },
+      "finalVerdict": "HUMAN_REVIEW",
+      "policyFlags": {
+        "policySensitive": true
+      }
+    }
+  }
+}

--- a/evals/fixtures/06-malformed-artifact-shape.json
+++ b/evals/fixtures/06-malformed-artifact-shape.json
@@ -1,0 +1,47 @@
+{
+  "caseId": "06-malformed-artifact-shape",
+  "description": "Malformed artifacts demonstrate the exact invariant failures the harness should pin in snapshots.",
+  "riskLevel": "low",
+  "flags": {},
+  "artifacts": {
+    "contract": {
+      "schemaVersion": "1.0",
+      "goal": "fixture goal",
+      "acceptanceCriteria": [],
+      "openQuestions": "Need clarification",
+      "requiredInputsProvided": "yes"
+    },
+    "auditSummary": {
+      "verdict": "AUTO_OK",
+      "confidence": "high",
+      "reducedAuditCoverage": false,
+      "regressions": "none",
+      "criticalFindings": [],
+      "notes": [
+        "Malformed shapes should be caught."
+      ],
+      "externalAuditCoverage": {
+        "codex": "broken"
+      }
+    },
+    "proofpack": {
+      "runMetadata": {
+        "runId": "fixture-run"
+      },
+      "baselineSummary": {
+        "status": "captured"
+      },
+      "implementationSummary": {
+        "status": "simulated"
+      },
+      "auditSummary": {
+        "status": "simulated"
+      },
+      "reviewSummaries": {},
+      "externalAuditCoverage": {
+        "codex": "broken"
+      },
+      "finalVerdict": "AUTO_BLOCK"
+    }
+  }
+}

--- a/evals/run.py
+++ b/evals/run.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Offline snapshot runner for Signum eval harness fixtures."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from checks import canonical_json, evaluate_fixture
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run Signum eval harness fixtures against committed snapshots.")
+    parser.add_argument("--fixtures-dir", default="evals/fixtures", help="Directory containing fixture JSON files")
+    parser.add_argument("--snapshots-dir", default="evals/snapshots", help="Directory containing expected snapshot JSON files")
+    parser.add_argument("--update-snapshots", action="store_true", help="Rewrite snapshots from current fixture evaluation")
+    args = parser.parse_args()
+
+    fixtures_dir = Path(args.fixtures_dir)
+    snapshots_dir = Path(args.snapshots_dir)
+    fixture_paths = sorted(fixtures_dir.glob("*.json"))
+    snapshots_dir.mkdir(parents=True, exist_ok=True)
+
+    summary: Dict[str, Any] = {
+        "status": "ok",
+        "fixtureCount": len(fixture_paths),
+        "passed": 0,
+        "failed": 0,
+        "results": [],
+    }
+
+    for fixture_path in fixture_paths:
+        try:
+            fixture = load_json(fixture_path)
+            result = evaluate_fixture(fixture)
+            snapshot_path = snapshots_dir / fixture_path.name
+            result_blob = canonical_json(result)
+
+            if args.update_snapshots:
+                snapshot_path.write_text(result_blob)
+                snapshot_status = "written"
+                reasons: List[str] = []
+                summary["passed"] += 1
+            else:
+                if not snapshot_path.exists():
+                    snapshot_status = "missing"
+                    reasons = [f"snapshot missing: {snapshot_path}"]
+                    summary["failed"] += 1
+                    summary["status"] = "error"
+                else:
+                    expected_blob = canonical_json(load_json(snapshot_path))
+                    if expected_blob == result_blob:
+                        snapshot_status = "match"
+                        reasons = []
+                        summary["passed"] += 1
+                    else:
+                        snapshot_status = "mismatch"
+                        reasons = [f"snapshot differs: {snapshot_path}"]
+                        summary["failed"] += 1
+                        summary["status"] = "error"
+
+            summary["results"].append(
+                {
+                    "caseId": result.get("caseId"),
+                    "snapshotStatus": snapshot_status,
+                    "observedVerdict": result.get("observedVerdict"),
+                    "invariantStatus": result.get("invariantStatus"),
+                    "failedChecks": result.get("failedChecks", []),
+                    "reasons": reasons,
+                }
+            )
+        except Exception as exc:  # pragma: no cover - surfaced in JSON for shell tests
+            summary["status"] = "error"
+            summary["failed"] += 1
+            summary["results"].append(
+                {
+                    "caseId": fixture_path.stem,
+                    "snapshotStatus": "error",
+                    "observedVerdict": None,
+                    "invariantStatus": "error",
+                    "failedChecks": ["runner.exception"],
+                    "reasons": [str(exc)],
+                }
+            )
+
+    print(canonical_json(summary), end="")
+    return 0 if summary["status"] == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/run.py
+++ b/evals/run.py
@@ -15,16 +15,16 @@ def load_json(path: Path) -> Dict[str, Any]:
 
 
 def main() -> int:
+    script_dir = Path(__file__).resolve().parent
     parser = argparse.ArgumentParser(description="Run Signum eval harness fixtures against committed snapshots.")
-    parser.add_argument("--fixtures-dir", default="evals/fixtures", help="Directory containing fixture JSON files")
-    parser.add_argument("--snapshots-dir", default="evals/snapshots", help="Directory containing expected snapshot JSON files")
+    parser.add_argument("--fixtures-dir", help="Directory containing fixture JSON files")
+    parser.add_argument("--snapshots-dir", help="Directory containing expected snapshot JSON files")
     parser.add_argument("--update-snapshots", action="store_true", help="Rewrite snapshots from current fixture evaluation")
     args = parser.parse_args()
 
-    fixtures_dir = Path(args.fixtures_dir)
-    snapshots_dir = Path(args.snapshots_dir)
+    fixtures_dir = Path(args.fixtures_dir) if args.fixtures_dir else script_dir / "fixtures"
+    snapshots_dir = Path(args.snapshots_dir) if args.snapshots_dir else script_dir / "snapshots"
     fixture_paths = sorted(fixtures_dir.glob("*.json"))
-    snapshots_dir.mkdir(parents=True, exist_ok=True)
 
     summary: Dict[str, Any] = {
         "status": "ok",
@@ -33,6 +33,24 @@ def main() -> int:
         "failed": 0,
         "results": [],
     }
+
+    if not fixture_paths:
+        summary["status"] = "error"
+        summary["failed"] = 1
+        summary["results"].append(
+            {
+                "caseId": None,
+                "snapshotStatus": "error",
+                "observedVerdict": None,
+                "invariantStatus": "error",
+                "failedChecks": ["runner.no_fixtures"],
+                "reasons": [f"no fixture files found in {fixtures_dir.resolve()}"],
+            }
+        )
+        print(canonical_json(summary), end="")
+        return 1
+
+    snapshots_dir.mkdir(parents=True, exist_ok=True)
 
     for fixture_path in fixture_paths:
         try:

--- a/evals/snapshots/01-low-risk-happy-path.json
+++ b/evals/snapshots/01-low-risk-happy-path.json
@@ -1,0 +1,18 @@
+{
+  "caseId": "01-low-risk-happy-path",
+  "checkCounts": {
+    "failed": 0,
+    "passed": 21,
+    "total": 21
+  },
+  "contractReady": true,
+  "degradedProviders": [],
+  "description": "Low-risk clean case with full coverage and an AUTO_OK verdict.",
+  "failedCheckDetails": [],
+  "failedChecks": [],
+  "invariantStatus": "ok",
+  "observedVerdict": "AUTO_OK",
+  "policySensitive": false,
+  "reducedAuditCoverage": false,
+  "riskLevel": "low"
+}

--- a/evals/snapshots/01-low-risk-happy-path.json
+++ b/evals/snapshots/01-low-risk-happy-path.json
@@ -2,8 +2,8 @@
   "caseId": "01-low-risk-happy-path",
   "checkCounts": {
     "failed": 0,
-    "passed": 21,
-    "total": 21
+    "passed": 22,
+    "total": 22
   },
   "contractReady": true,
   "degradedProviders": [],

--- a/evals/snapshots/02-medium-risk-graceful-degradation.json
+++ b/evals/snapshots/02-medium-risk-graceful-degradation.json
@@ -1,5 +1,5 @@
 {
-  "caseId": "02-medium-risk-reduced-coverage",
+  "caseId": "02-medium-risk-graceful-degradation",
   "checkCounts": {
     "failed": 0,
     "passed": 21,
@@ -7,13 +7,14 @@
   },
   "contractReady": true,
   "degradedProviders": [
+    "codex",
     "gemini"
   ],
-  "description": "Medium-risk case degrades one reviewer and must stay below AUTO_OK.",
+  "description": "Medium-risk graceful degradation with genuinely missing external CLIs may still remain AUTO_OK.",
   "failedCheckDetails": [],
   "failedChecks": [],
   "invariantStatus": "ok",
-  "observedVerdict": "HUMAN_REVIEW",
+  "observedVerdict": "AUTO_OK",
   "policySensitive": false,
   "reducedAuditCoverage": true,
   "riskLevel": "medium"

--- a/evals/snapshots/02-medium-risk-reduced-coverage.json
+++ b/evals/snapshots/02-medium-risk-reduced-coverage.json
@@ -1,0 +1,20 @@
+{
+  "caseId": "02-medium-risk-reduced-coverage",
+  "checkCounts": {
+    "failed": 0,
+    "passed": 21,
+    "total": 21
+  },
+  "contractReady": true,
+  "degradedProviders": [
+    "gemini"
+  ],
+  "description": "Medium-risk case degrades one reviewer and must stay below AUTO_OK.",
+  "failedCheckDetails": [],
+  "failedChecks": [],
+  "invariantStatus": "ok",
+  "observedVerdict": "HUMAN_REVIEW",
+  "policySensitive": false,
+  "reducedAuditCoverage": true,
+  "riskLevel": "medium"
+}

--- a/evals/snapshots/03-high-risk-provider-unavailable.json
+++ b/evals/snapshots/03-high-risk-provider-unavailable.json
@@ -2,8 +2,8 @@
   "caseId": "03-high-risk-provider-unavailable",
   "checkCounts": {
     "failed": 0,
-    "passed": 21,
-    "total": 21
+    "passed": 22,
+    "total": 22
   },
   "contractReady": true,
   "degradedProviders": [

--- a/evals/snapshots/03-high-risk-provider-unavailable.json
+++ b/evals/snapshots/03-high-risk-provider-unavailable.json
@@ -1,0 +1,21 @@
+{
+  "caseId": "03-high-risk-provider-unavailable",
+  "checkCounts": {
+    "failed": 0,
+    "passed": 21,
+    "total": 21
+  },
+  "contractReady": true,
+  "degradedProviders": [
+    "codex",
+    "gemini"
+  ],
+  "description": "High-risk case with multiple degraded reviewers must remain gated.",
+  "failedCheckDetails": [],
+  "failedChecks": [],
+  "invariantStatus": "ok",
+  "observedVerdict": "HUMAN_REVIEW",
+  "policySensitive": false,
+  "reducedAuditCoverage": true,
+  "riskLevel": "high"
+}

--- a/evals/snapshots/04-ambiguous-input-missing-required-input.json
+++ b/evals/snapshots/04-ambiguous-input-missing-required-input.json
@@ -2,8 +2,8 @@
   "caseId": "04-ambiguous-input-missing-required-input",
   "checkCounts": {
     "failed": 0,
-    "passed": 21,
-    "total": 21
+    "passed": 22,
+    "total": 22
   },
   "contractReady": false,
   "degradedProviders": [],

--- a/evals/snapshots/04-ambiguous-input-missing-required-input.json
+++ b/evals/snapshots/04-ambiguous-input-missing-required-input.json
@@ -1,0 +1,18 @@
+{
+  "caseId": "04-ambiguous-input-missing-required-input",
+  "checkCounts": {
+    "failed": 0,
+    "passed": 21,
+    "total": 21
+  },
+  "contractReady": false,
+  "degradedProviders": [],
+  "description": "Contract gaps force HUMAN_REVIEW even when artifacts are otherwise well formed.",
+  "failedCheckDetails": [],
+  "failedChecks": [],
+  "invariantStatus": "ok",
+  "observedVerdict": "HUMAN_REVIEW",
+  "policySensitive": false,
+  "reducedAuditCoverage": false,
+  "riskLevel": "medium"
+}

--- a/evals/snapshots/05-policy-sensitive-human-review.json
+++ b/evals/snapshots/05-policy-sensitive-human-review.json
@@ -2,8 +2,8 @@
   "caseId": "05-policy-sensitive-human-review",
   "checkCounts": {
     "failed": 0,
-    "passed": 21,
-    "total": 21
+    "passed": 22,
+    "total": 22
   },
   "contractReady": true,
   "degradedProviders": [],

--- a/evals/snapshots/05-policy-sensitive-human-review.json
+++ b/evals/snapshots/05-policy-sensitive-human-review.json
@@ -1,0 +1,18 @@
+{
+  "caseId": "05-policy-sensitive-human-review",
+  "checkCounts": {
+    "failed": 0,
+    "passed": 21,
+    "total": 21
+  },
+  "contractReady": true,
+  "degradedProviders": [],
+  "description": "Policy-sensitive work should stay gated even with full reviewer coverage.",
+  "failedCheckDetails": [],
+  "failedChecks": [],
+  "invariantStatus": "ok",
+  "observedVerdict": "HUMAN_REVIEW",
+  "policySensitive": true,
+  "reducedAuditCoverage": false,
+  "riskLevel": "medium"
+}

--- a/evals/snapshots/06-malformed-artifact-shape.json
+++ b/evals/snapshots/06-malformed-artifact-shape.json
@@ -2,8 +2,8 @@
   "caseId": "06-malformed-artifact-shape",
   "checkCounts": {
     "failed": 10,
-    "passed": 11,
-    "total": 21
+    "passed": 12,
+    "total": 22
   },
   "contractReady": false,
   "degradedProviders": [

--- a/evals/snapshots/06-malformed-artifact-shape.json
+++ b/evals/snapshots/06-malformed-artifact-shape.json
@@ -1,0 +1,82 @@
+{
+  "caseId": "06-malformed-artifact-shape",
+  "checkCounts": {
+    "failed": 10,
+    "passed": 11,
+    "total": 21
+  },
+  "contractReady": false,
+  "degradedProviders": [
+    "codex"
+  ],
+  "description": "Malformed artifacts demonstrate the exact invariant failures the harness should pin in snapshots.",
+  "failedCheckDetails": [
+    {
+      "detail": "requiredInputsProvided must be boolean",
+      "id": "contract.required_inputs_shape",
+      "status": "fail"
+    },
+    {
+      "detail": "openQuestions must be a list of strings",
+      "id": "contract.open_questions_shape",
+      "status": "fail"
+    },
+    {
+      "detail": "acceptanceCriteria must be a non-empty list",
+      "id": "contract.acceptance_criteria_shape",
+      "status": "fail"
+    },
+    {
+      "detail": "confidence must be an integer",
+      "id": "audit.confidence_shape",
+      "status": "fail"
+    },
+    {
+      "detail": "regressions must be a list",
+      "id": "audit.regressions_shape",
+      "status": "fail"
+    },
+    {
+      "detail": "all provider coverage states must be recognized",
+      "id": "audit.coverage_states",
+      "status": "fail"
+    },
+    {
+      "detail": "reducedAuditCoverage must be true when any provider is degraded",
+      "id": "audit.reduced_coverage_flag",
+      "status": "fail"
+    },
+    {
+      "detail": "contract gaps must not claim AUTO_OK",
+      "id": "audit.contract_gap_verdict",
+      "status": "fail"
+    },
+    {
+      "detail": "proofpack must expose all required summary sections",
+      "id": "proofpack.required_sections",
+      "status": "fail"
+    },
+    {
+      "detail": "proofpack finalVerdict must match audit verdict",
+      "id": "proofpack.final_verdict_match",
+      "status": "fail"
+    }
+  ],
+  "failedChecks": [
+    "contract.required_inputs_shape",
+    "contract.open_questions_shape",
+    "contract.acceptance_criteria_shape",
+    "audit.confidence_shape",
+    "audit.regressions_shape",
+    "audit.coverage_states",
+    "audit.reduced_coverage_flag",
+    "audit.contract_gap_verdict",
+    "proofpack.required_sections",
+    "proofpack.final_verdict_match"
+  ],
+  "invariantStatus": "violated",
+  "observedVerdict": "AUTO_OK",
+  "policySensitive": false,
+  "reducedAuditCoverage": false,
+  "riskLevel": "low"
+}

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -10,7 +10,7 @@ arguments:
     required: false
 ---
 
-# Signum v4.18: Evidence-Driven Development Pipeline
+# Signum v4.19: Evidence-Driven Development Pipeline
 
 You are the Signum orchestrator. You drive a 4-phase evidence-driven pipeline:
 
@@ -27,7 +27,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.18.1",
+  "version": "4.19.0",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -3073,7 +3073,7 @@ fi
 # Final assembly
 jq -n \
   --arg schemaVersion "4.6" \
-  --arg signumVersion "4.18.1" \
+  --arg signumVersion "4.19.0" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/tests/test-anti-entropy-report.sh
+++ b/tests/test-anti-entropy-report.sh
@@ -81,7 +81,7 @@ EOF
   cat > "$dir/.signum/proofpack.json" <<'EOF'
 {
   "schemaVersion": "4.7",
-  "signumVersion": "4.18.1",
+  "signumVersion": "4.19.0",
   "createdAt": "2026-04-10T10:00:00Z",
   "runId": "signum-test",
   "decision": "AUTO_OK",
@@ -144,7 +144,7 @@ EOF
 cat > "$DIRTY/.signum/proofpack.json" <<'EOF'
 {
   "schemaVersion": "4.7",
-  "signumVersion": "4.18.1",
+  "signumVersion": "4.19.0",
   "createdAt": "2026-04-10T10:00:00Z",
   "runId": "signum-test",
   "decision": "AUTO_OK",

--- a/tests/test-brownfield-harness-flow.sh
+++ b/tests/test-brownfield-harness-flow.sh
@@ -79,7 +79,7 @@ DOC
   cat > "$dir/.signum/proofpack.json" <<'DOC'
 {
   "schemaVersion":"4.7",
-  "signumVersion":"4.18.1",
+  "signumVersion":"4.19.0",
   "createdAt":"2026-04-10T10:00:00Z",
   "runId":"downstream-brownfield-test",
   "decision":"AUTO_OK",

--- a/tests/test-eval-harness.sh
+++ b/tests/test-eval-harness.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# test-eval-harness.sh -- tests for evals/run.py
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RUNNER="$SCRIPT_DIR/../evals/run.py"
+
+passed=0
+failed=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+assert_pass() {
+  local name="$1"; shift
+  local output
+  if output=$("$@" 2>&1); then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s — exited non-zero: %s\n' "$name" "$output"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_equals() {
+  local name="$1" actual="$2" expected="$3"
+  if [ "$actual" = "$expected" ]; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s — expected "%s", got "%s"\n' "$name" "$expected" "$actual"
+    failed=$((failed + 1))
+  fi
+}
+
+echo "=== Harness existence ==="
+assert_pass "runner file exists" test -f "$RUNNER"
+assert_pass "runner is executable after chmod" chmod +x "$RUNNER"
+assert_pass "checks file exists" test -f "$SCRIPT_DIR/../evals/checks.py"
+assert_pass "fixtures directory exists" test -d "$SCRIPT_DIR/../evals/fixtures"
+assert_pass "snapshots directory exists" test -d "$SCRIPT_DIR/../evals/snapshots"
+
+echo ""
+echo "=== Success path ==="
+SUCCESS_OUTPUT="$(python3 "$RUNNER")"
+assert_equals "success status ok" "$(echo "$SUCCESS_OUTPUT" | jq -r '.status')" "ok"
+assert_equals "fixture count is 6" "$(echo "$SUCCESS_OUTPUT" | jq -r '.fixtureCount')" "6"
+assert_equals "no harness failures" "$(echo "$SUCCESS_OUTPUT" | jq -r '.failed')" "0"
+assert_equals "malformed case stays pinned" "$(echo "$SUCCESS_OUTPUT" | jq -r '.results[] | select(.caseId=="06-malformed-artifact-shape") | .invariantStatus')" "violated"
+
+echo ""
+echo "=== Broken snapshot path ==="
+cp -R "$SCRIPT_DIR/../evals" "$WORK/evals"
+python3 - "$WORK/evals/snapshots/01-low-risk-happy-path.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+data = json.loads(path.read_text())
+data['observedVerdict'] = 'HUMAN_REVIEW'
+path.write_text(json.dumps(data, indent=2) + '\n')
+PY
+
+set +e
+BROKEN_OUTPUT="$(python3 "$RUNNER" --fixtures-dir "$WORK/evals/fixtures" --snapshots-dir "$WORK/evals/snapshots" 2>&1)"
+BROKEN_RC=$?
+set -e
+assert_equals "broken snapshot exits non-zero" "$BROKEN_RC" "1"
+assert_equals "broken snapshot status error" "$(echo "$BROKEN_OUTPUT" | jq -r '.status')" "error"
+assert_equals "broken snapshot mismatch count" "$(echo "$BROKEN_OUTPUT" | jq '[.results[] | select(.snapshotStatus=="mismatch")] | length')" "1"
+assert_equals "broken snapshot case id" "$(echo "$BROKEN_OUTPUT" | jq -r '.results[] | select(.snapshotStatus=="mismatch") | .caseId')" "01-low-risk-happy-path"
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $passed"
+echo "Failed: $failed"
+echo ""
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+fi

--- a/tests/test-eval-harness.sh
+++ b/tests/test-eval-harness.sh
@@ -50,6 +50,171 @@ assert_equals "no harness failures" "$(echo "$SUCCESS_OUTPUT" | jq -r '.failed')
 assert_equals "malformed case stays pinned" "$(echo "$SUCCESS_OUTPUT" | jq -r '.results[] | select(.caseId=="06-malformed-artifact-shape") | .invariantStatus')" "violated"
 
 echo ""
+echo "=== Absolute runner path ==="
+pushd "$WORK" >/dev/null
+ABS_OUTPUT="$(python3 "$RUNNER")"
+popd >/dev/null
+assert_equals "absolute path runner status ok" "$(echo "$ABS_OUTPUT" | jq -r '.status')" "ok"
+assert_equals "absolute path runner fixture count is 6" "$(echo "$ABS_OUTPUT" | jq -r '.fixtureCount')" "6"
+
+echo ""
+echo "=== Empty fixture directory ==="
+mkdir -p "$WORK/empty-fixtures" "$WORK/empty-snapshots"
+set +e
+EMPTY_OUTPUT="$(python3 "$RUNNER" --fixtures-dir "$WORK/empty-fixtures" --snapshots-dir "$WORK/empty-snapshots" 2>&1)"
+EMPTY_RC=$?
+set -e
+assert_equals "empty fixture dir exits non-zero" "$EMPTY_RC" "1"
+assert_equals "empty fixture dir status error" "$(echo "$EMPTY_OUTPUT" | jq -r '.status')" "error"
+assert_equals "empty fixture dir failure code" "$(echo "$EMPTY_OUTPUT" | jq -r '.results[0].failedChecks[0]')" "runner.no_fixtures"
+
+echo ""
+echo "=== Coverage semantics ==="
+MEDIUM_MISSING_OUTPUT="$(python3 - "$SCRIPT_DIR/../evals/checks.py" <<'PY'
+import importlib.util
+import json
+import sys
+
+spec = importlib.util.spec_from_file_location("eval_checks", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+fixture = {
+    "caseId": "medium-missing-auto-ok",
+    "riskLevel": "medium",
+    "flags": {},
+    "artifacts": {
+        "contract": {
+            "schemaVersion": "1.0",
+            "goal": "fixture goal",
+            "acceptanceCriteria": [{"id": "AC-1", "description": "placeholder"}],
+            "openQuestions": [],
+            "requiredInputsProvided": True,
+        },
+        "auditSummary": {
+            "verdict": "AUTO_OK",
+            "confidence": 88,
+            "reducedAuditCoverage": True,
+            "regressions": [],
+            "criticalFindings": [],
+            "notes": ["Both external CLIs are genuinely missing."],
+            "externalAuditCoverage": {"codex": "missing", "gemini": "missing"},
+        },
+        "proofpack": {
+            "runMetadata": {"runId": "fixture-run"},
+            "contractSummary": {"acceptanceCriteria": 1},
+            "baselineSummary": {"status": "captured"},
+            "implementationSummary": {"status": "simulated"},
+            "auditSummary": {"status": "simulated"},
+            "reviewSummaries": {},
+            "externalAuditCoverage": {"codex": "missing", "gemini": "missing"},
+            "finalVerdict": "AUTO_OK",
+        },
+    },
+}
+print(json.dumps(module.evaluate_fixture(fixture)))
+PY
+)"
+assert_equals "medium missing degradation stays valid" "$(echo "$MEDIUM_MISSING_OUTPUT" | jq -r '.invariantStatus')" "ok"
+assert_equals "medium missing degradation has zero failed checks" "$(echo "$MEDIUM_MISSING_OUTPUT" | jq -r '.checkCounts.failed')" "0"
+
+MEDIUM_TIMEOUT_OUTPUT="$(python3 - "$SCRIPT_DIR/../evals/checks.py" <<'PY'
+import importlib.util
+import json
+import sys
+
+spec = importlib.util.spec_from_file_location("eval_checks", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+fixture = {
+    "caseId": "medium-timeout-auto-ok",
+    "riskLevel": "medium",
+    "flags": {},
+    "artifacts": {
+        "contract": {
+            "schemaVersion": "1.0",
+            "goal": "fixture goal",
+            "acceptanceCriteria": [{"id": "AC-1", "description": "placeholder"}],
+            "openQuestions": [],
+            "requiredInputsProvided": True,
+        },
+        "auditSummary": {
+            "verdict": "AUTO_OK",
+            "confidence": 88,
+            "reducedAuditCoverage": True,
+            "regressions": [],
+            "criticalFindings": [],
+            "notes": ["Gemini timed out."],
+            "externalAuditCoverage": {"codex": "ready", "gemini": "timeout"},
+        },
+        "proofpack": {
+            "runMetadata": {"runId": "fixture-run"},
+            "contractSummary": {"acceptanceCriteria": 1},
+            "baselineSummary": {"status": "captured"},
+            "implementationSummary": {"status": "simulated"},
+            "auditSummary": {"status": "simulated"},
+            "reviewSummaries": {},
+            "externalAuditCoverage": {"codex": "ready", "gemini": "timeout"},
+            "finalVerdict": "AUTO_OK",
+        },
+    },
+}
+print(json.dumps(module.evaluate_fixture(fixture)))
+PY
+)"
+assert_equals "medium timeout AUTO_OK is rejected" "$(echo "$MEDIUM_TIMEOUT_OUTPUT" | jq -r '.invariantStatus')" "violated"
+assert_equals "medium timeout failure code is pinned" "$(echo "$MEDIUM_TIMEOUT_OUTPUT" | jq -r '.failedChecks | index("audit.medium_non_missing_reduced_coverage") != null')" "true"
+
+HIGH_MISSING_KEY_OUTPUT="$(python3 - "$SCRIPT_DIR/../evals/checks.py" <<'PY'
+import importlib.util
+import json
+import sys
+
+spec = importlib.util.spec_from_file_location("eval_checks", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+fixture = {
+    "caseId": "high-missing-gemini-key",
+    "riskLevel": "high",
+    "flags": {},
+    "artifacts": {
+        "contract": {
+            "schemaVersion": "1.0",
+            "goal": "fixture goal",
+            "acceptanceCriteria": [{"id": "AC-1", "description": "placeholder"}],
+            "openQuestions": [],
+            "requiredInputsProvided": True,
+        },
+        "auditSummary": {
+            "verdict": "AUTO_OK",
+            "confidence": 88,
+            "reducedAuditCoverage": False,
+            "regressions": [],
+            "criticalFindings": [],
+            "notes": ["Coverage key is missing."],
+            "externalAuditCoverage": {"codex": "ready"},
+        },
+        "proofpack": {
+            "runMetadata": {"runId": "fixture-run"},
+            "contractSummary": {"acceptanceCriteria": 1},
+            "baselineSummary": {"status": "captured"},
+            "implementationSummary": {"status": "simulated"},
+            "auditSummary": {"status": "simulated"},
+            "reviewSummaries": {},
+            "externalAuditCoverage": {"codex": "ready"},
+            "finalVerdict": "AUTO_OK",
+        },
+    },
+}
+print(json.dumps(module.evaluate_fixture(fixture)))
+PY
+)"
+assert_equals "high risk missing coverage key is rejected" "$(echo "$HIGH_MISSING_KEY_OUTPUT" | jq -r '.invariantStatus')" "violated"
+assert_equals "high risk missing coverage key failure is pinned" "$(echo "$HIGH_MISSING_KEY_OUTPUT" | jq -r '.failedChecks | index("audit.coverage_keys") != null')" "true"
+
+echo ""
 echo "=== Broken snapshot path ==="
 cp -R "$SCRIPT_DIR/../evals" "$WORK/evals"
 python3 - "$WORK/evals/snapshots/01-low-risk-happy-path.json" <<'PY'

--- a/tests/test-pack-anti-entropy.sh
+++ b/tests/test-pack-anti-entropy.sh
@@ -43,7 +43,7 @@ EOF
   cat > "$dir/.signum/proofpack.json" <<'EOF'
 {
   "schemaVersion":"4.7",
-  "signumVersion":"4.18.1",
+  "signumVersion":"4.19.0",
   "createdAt":"2026-04-10T10:00:00Z",
   "runId":"signum-test",
   "decision":"AUTO_OK",


### PR DESCRIPTION
## Summary
- add a self-contained offline eval harness under `evals/` with 6 fixtures, deterministic checks, and committed snapshots
- add `tests/test-eval-harness.sh` to cover the harness success path and broken-snapshot regression detection
- document the maintainer-facing eval harness in `README.md`, `docs/how-it-works.md`, and `docs/QUALITY_SCORE.md`
- record the provider-alignment planning rule in `docs/PLANS.md`
- bump Signum version surfaces to `4.19.0` and add the changelog entry for the eval harness release
- ignore Python cache artifacts generated by the new stdlib-based harness tooling

## Issue ID
- none

## Test Plan
- `python3 evals/run.py`
- `bash tests/test-eval-harness.sh`
- `bash tests/test-doc-parity.sh`
- `bash tests/test-pack-anti-entropy.sh`
- `bash tests/test-anti-entropy-report.sh`
- `bash tests/test-brownfield-harness-flow.sh`
