### PR TITLE
[codex] Clarify Signum contract storage model

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,5 @@
   "license": "MIT",
   "name": "signum",
   "repository": "https://github.com/heurema/signum",
-  "version": "4.19.0"
+  "version": "4.19.1"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [4.19.1] - 2026-04-20
+
+### Fixed
+- Durable contract/archive evidence now preserves the full execute receipt chain for replay and verification
+  - `commands/signum.md` and `platforms/claude-code/commands/signum.md` now mirror/archive `execution_context.json`, `receipts/`, `runs/`, and `snapshots/` instead of only `receipts/execute.json`
+  - `lib/contract-dir.sh` and `platforms/claude-code/lib/contract-dir.sh` now sync directories idempotently, avoiding nested `receipts/receipts`-style copies on repeated syncs
+  - `tests/test-contract-dir.sh` and `platforms/claude-code/tests/test-contract-dir.sh` now cover directory evidence sync and re-sync behavior
+
 ## [4.19.0] - 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ claude plugin install .
 
 Signum grades your spec, shows the contract for approval, implements with an automatic repair loop, audits from multiple angles, and produces `proofpack.json` plus an advisory `anti_entropy_report.json`.
 
+Storage model:
+- `.signum/` is the live working set for the current run
+- `.signum/contracts/<contractId>/` stores durable per-contract snapshots/history
+- the per-contract directory is not a second active workspace
+
 For an existing repo, bootstrap project context first:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Signum grades your spec, shows the contract for approval, implements with an aut
 
 Storage model:
 - `.signum/` is the live working set for the current run
-- `.signum/contracts/<contractId>/` stores durable per-contract snapshots/history
+- `.signum/contracts/<contractId>/` stores durable per-contract snapshots/history, including receipt-chain evidence
 - the per-contract directory is not a second active workspace
 
 For an existing repo, bootstrap project context first:

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -96,13 +96,14 @@ fi
 ARCHIVE_DIR=".signum/archive/${CONTRACT_ID}/"
 mkdir -p "$ARCHIVE_DIR"
 
-# Copy essential artifacts (contract + proofpack)
+# Copy durable artifacts from the per-contract snapshot/history
 cp "${DIR}contract.json" "$ARCHIVE_DIR" 2>/dev/null || true
 cp "${DIR}proofpack.json" "$ARCHIVE_DIR" 2>/dev/null || true
 cp "${DIR}approval.json" "$ARCHIVE_DIR" 2>/dev/null || true
 
 # Copy audit summary if present
 cp "${DIR}audit_summary.json" "$ARCHIVE_DIR" 2>/dev/null || true
+cp "${DIR}anti_entropy_report.json" "$ARCHIVE_DIR" 2>/dev/null || true
 
 # Copy receipt chain artifacts (execute receipt is audit evidence)
 cp "${DIR}receipts/execute.json" "$ARCHIVE_DIR" 2>/dev/null || true
@@ -134,7 +135,7 @@ jq --arg id "$CONTRACT_ID" --arg ts "$ARCHIVED_AT" \
   && mv .signum/contracts/index.json.tmp .signum/contracts/index.json
 
 echo "Archived: $CONTRACT_ID → $ARCHIVE_DIR"
-echo "Kept: contract.json, proofpack.json, approval.json, audit_summary.json"
+echo "Kept: contract.json, proofpack.json, approval.json, audit_summary.json, anti_entropy_report.json"
 echo "Purged: intermediates (reviews, baseline, patches, prompts)"
 ```
 
@@ -433,9 +434,9 @@ If exit code is 1: **HARD STOP**. Contract contains invisible Unicode characters
 
 If exit code is 0: clean, continue.
 
-### Step 1.2.5: Initialize per-contract directory
+### Step 1.2.5: Initialize per-contract durable directory
 
-After contractor creates contract.json, extract the contractId and set up an isolated directory for this contract's artifacts.
+After contractor creates `contract.json`, extract the `contractId` and set up a per-contract durable directory. This directory is **not** the live workspace for the current run. The live working set remains under `.signum/`; the per-contract directory is a mirrored snapshot/history surface for this contract.
 
 Use the Bash tool:
 
@@ -451,13 +452,11 @@ if [ -z "$CONTRACT_ID" ] || [ "$CONTRACT_ID" = "null" ]; then
 fi
 echo "contractId: $CONTRACT_ID"
 
-# Create per-contract directory with reviews/ subdirectory
+# Create per-contract durable directory
 init_contract_dir "$CONTRACT_ID"
 
-# Copy contract.json to per-contract directory (original stays in .signum/ as working copy)
-CDIR=$(contract_dir "$CONTRACT_ID")
-cp .signum/contract.json "${CDIR}contract.json"
-echo "Archived contract.json to ${CDIR}contract.json"
+# Mirror the initial contract snapshot
+sync_contract_artifacts "$CONTRACT_ID" "contract.json"
 
 # Register contract in index.json
 register_contract "$CONTRACT_ID" "draft"
@@ -3198,11 +3197,14 @@ if [ -f lib/contract-dir.sh ]; then
   CONTRACT_ID=$(jq -r '.contractId // empty' .signum/contract.json)
   if [ -n "$CONTRACT_ID" ]; then
     update_contract_status "$CONTRACT_ID" "completed"
-    # Sync updated contract.json + proofpack to per-contract directory
-    DIR=$(contract_dir "$CONTRACT_ID")
-    cp .signum/contract.json "${DIR}" 2>/dev/null || true
-    cp .signum/proofpack.json "${DIR}" 2>/dev/null || true
-    cp .signum/anti_entropy_report.json "${DIR}" 2>/dev/null || true
+    # Sync durable artifacts for this completed contract.
+    sync_contract_artifacts "$CONTRACT_ID" \
+      "contract.json" \
+      "proofpack.json" \
+      "anti_entropy_report.json" \
+      "audit_summary.json" \
+      "approval.json" \
+      "receipts/execute.json"
     echo "Contract $CONTRACT_ID → completed"
   fi
 fi

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -27,7 +27,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.19.0",
+  "version": "4.19.1",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -104,9 +104,12 @@ cp "${DIR}approval.json" "$ARCHIVE_DIR" 2>/dev/null || true
 # Copy audit summary if present
 cp "${DIR}audit_summary.json" "$ARCHIVE_DIR" 2>/dev/null || true
 cp "${DIR}anti_entropy_report.json" "$ARCHIVE_DIR" 2>/dev/null || true
+cp "${DIR}execution_context.json" "$ARCHIVE_DIR" 2>/dev/null || true
 
-# Copy receipt chain artifacts (execute receipt is audit evidence)
-cp "${DIR}receipts/execute.json" "$ARCHIVE_DIR" 2>/dev/null || true
+# Copy receipt-chain artifacts needed for replay/verification
+cp -R "${DIR}receipts" "$ARCHIVE_DIR" 2>/dev/null || true
+cp -R "${DIR}runs" "$ARCHIVE_DIR" 2>/dev/null || true
+cp -R "${DIR}snapshots" "$ARCHIVE_DIR" 2>/dev/null || true
 
 # Purge intermediate artifacts (reviews, baseline, holdout, execute_log, prompts)
 rm -rf "${DIR}reviews/" 2>/dev/null || true
@@ -135,7 +138,7 @@ jq --arg id "$CONTRACT_ID" --arg ts "$ARCHIVED_AT" \
   && mv .signum/contracts/index.json.tmp .signum/contracts/index.json
 
 echo "Archived: $CONTRACT_ID → $ARCHIVE_DIR"
-echo "Kept: contract.json, proofpack.json, approval.json, audit_summary.json, anti_entropy_report.json"
+echo "Kept: contract.json, proofpack.json, approval.json, audit_summary.json, anti_entropy_report.json, execution_context.json, receipts/, runs/, snapshots/"
 echo "Purged: intermediates (reviews, baseline, patches, prompts)"
 ```
 
@@ -3073,7 +3076,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' .signum/audit_summary.js
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.19.0" \
+  --arg signumVersion "4.19.1" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \
@@ -3197,6 +3200,10 @@ if [ -f lib/contract-dir.sh ]; then
   CONTRACT_ID=$(jq -r '.contractId // empty' .signum/contract.json)
   if [ -n "$CONTRACT_ID" ]; then
     update_contract_status "$CONTRACT_ID" "completed"
+    RUN_ID=$(jq -r '.run_id // empty' .signum/execution_context.json 2>/dev/null || true)
+    if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+      RUN_ID=$(jq -r '.run_id // empty' .signum/receipts/execute.json 2>/dev/null || true)
+    fi
     # Sync durable artifacts for this completed contract.
     sync_contract_artifacts "$CONTRACT_ID" \
       "contract.json" \
@@ -3204,7 +3211,12 @@ if [ -f lib/contract-dir.sh ]; then
       "anti_entropy_report.json" \
       "audit_summary.json" \
       "approval.json" \
-      "receipts/execute.json"
+      "execution_context.json" \
+      "receipts" \
+      "snapshots"
+    if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
+      sync_contract_artifacts "$CONTRACT_ID" "runs/${RUN_ID}"
+    fi
     echo "Contract $CONTRACT_ID → completed"
   fi
 fi
@@ -3264,7 +3276,10 @@ finalize_run() {
   cp .signum/approval.json "$ARCHIVE_TMP/" 2>/dev/null
   cp .signum/audit_summary.json "$ARCHIVE_TMP/" 2>/dev/null
   cp .signum/anti_entropy_report.json "$ARCHIVE_TMP/" 2>/dev/null || true
-  cp .signum/receipts/execute.json "$ARCHIVE_TMP/" 2>/dev/null || true
+  cp .signum/execution_context.json "$ARCHIVE_TMP/" 2>/dev/null || true
+  cp -R .signum/receipts "$ARCHIVE_TMP/" 2>/dev/null || true
+  cp -R .signum/runs "$ARCHIVE_TMP/" 2>/dev/null || true
+  cp -R .signum/snapshots "$ARCHIVE_TMP/" 2>/dev/null || true
 
   # Step 3: Verify required files exist in temp
   if [ ! -f "$ARCHIVE_TMP/contract.json" ] || [ ! -f "$ARCHIVE_TMP/proofpack.json" ]; then
@@ -3340,7 +3355,10 @@ cp .signum/proofpack.json "$ARCHIVE_TMP/" 2>/dev/null
 cp .signum/approval.json "$ARCHIVE_TMP/" 2>/dev/null
 cp .signum/audit_summary.json "$ARCHIVE_TMP/" 2>/dev/null
 cp .signum/anti_entropy_report.json "$ARCHIVE_TMP/" 2>/dev/null || true
-cp .signum/receipts/execute.json "$ARCHIVE_TMP/" 2>/dev/null || true
+cp .signum/execution_context.json "$ARCHIVE_TMP/" 2>/dev/null || true
+cp -R .signum/receipts "$ARCHIVE_TMP/" 2>/dev/null || true
+cp -R .signum/runs "$ARCHIVE_TMP/" 2>/dev/null || true
+cp -R .signum/snapshots "$ARCHIVE_TMP/" 2>/dev/null || true
 if [ ! -f "$ARCHIVE_TMP/contract.json" ] || [ ! -f "$ARCHIVE_TMP/proofpack.json" ]; then
   echo "ERROR: archive incomplete — keeping working set intact"
   rm -rf "$ARCHIVE_TMP"; exit 1

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -159,7 +159,10 @@ Durable per-contract snapshots typically mirror:
 - `anti_entropy_report.json`
 - `audit_summary.json`
 - `approval.json`
-- `receipts/execute.json`
+- `execution_context.json`
+- `receipts/`
+- `runs/<runId>/`
+- `snapshots/`
 
 ## Offline eval harness (v1)
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -134,7 +134,7 @@ If the CLI returns malformed output or a non-zero exit code, the provider is mar
 
 ## Artifacts
 
-All artifacts are written to `.signum/` (auto-added to `.gitignore`):
+Live working-set artifacts are written to `.signum/` (auto-added to `.gitignore`). Signum also mirrors durable per-contract snapshots into `.signum/contracts/<contractId>/` for history/archive flows. That per-contract directory is not the active workspace while a run is in flight.
 
 | File | Phase | Description |
 |------|-------|-------------|
@@ -152,6 +152,14 @@ All artifacts are written to `.signum/` (auto-added to `.gitignore`):
 | `audit_iteration_log.json` | AUDIT | Summary of all iterations (v4.6+) |
 | `repair_brief.json` | AUDIT | Current repair brief for engineer (v4.6+) |
 | `flaky_tests.json` | AUDIT | Flaky test tracker (v4.6+, run-local) |
+
+Durable per-contract snapshots typically mirror:
+- `contract.json`
+- `proofpack.json`
+- `anti_entropy_report.json`
+- `audit_summary.json`
+- `approval.json`
+- `receipts/execute.json`
 
 ## Offline eval harness (v1)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -132,7 +132,10 @@ Durable per-contract snapshots typically mirror:
 - `anti_entropy_report.json`
 - `audit_summary.json`
 - `approval.json`
-- `receipts/execute.json`
+- `execution_context.json`
+- `receipts/`
+- `runs/<runId>/`
+- `snapshots/`
 
 ### contract.json fields
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -109,7 +109,7 @@ Assembles `.signum/proofpack.json` — self-contained evidence bundle with embed
 
 ## Artifacts
 
-All artifacts are stored in `.signum/` (auto-added to `.gitignore`):
+Live working-set artifacts are written to `.signum/` (auto-added to `.gitignore`). Durable per-contract snapshots are mirrored under `.signum/contracts/<contractId>/` for history/archive flows. The per-contract directory is not the active workspace for an in-flight run.
 
 | File | Phase | Contents |
 |------|-------|----------|
@@ -125,6 +125,14 @@ All artifacts are stored in `.signum/` (auto-added to `.gitignore`):
 | `audit_summary.json` | Audit | Synthesized decision with consensus reasoning and confidence scores |
 | `proofpack.json` | Pack | Self-contained evidence bundle with embedded artifacts, checksums, and confidence |
 | `anti_entropy_report.json` | Pack | Advisory anti-entropy follow-up findings; report-only, does not change pipeline decision |
+
+Durable per-contract snapshots typically mirror:
+- `contract.json`
+- `proofpack.json`
+- `anti_entropy_report.json`
+- `audit_summary.json`
+- `approval.json`
+- `receipts/execute.json`
 
 ### contract.json fields
 

--- a/lib/contract-dir.sh
+++ b/lib/contract-dir.sh
@@ -65,8 +65,13 @@ sync_contract_artifacts() {
       continue
     fi
     dst="${dir}${rel}"
-    mkdir -p "$(dirname "$dst")"
-    cp -R "$src" "$dst"
+    if [[ -d "$src" ]]; then
+      mkdir -p "$dst"
+      cp -R "$src"/. "$dst"/
+    else
+      mkdir -p "$(dirname "$dst")"
+      cp -R "$src" "$dst"
+    fi
     copied=$((copied + 1))
   done
 

--- a/lib/contract-dir.sh
+++ b/lib/contract-dir.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # contract-dir.sh — per-contract directory management for Signum
-# Functions: contract_dir, init_contract_dir, register_contract,
-#            update_contract_status, get_active_contract, current_contract_dir
+# Functions: contract_dir, init_contract_dir, sync_contract_artifacts,
+#            register_contract, update_contract_status,
+#            get_active_contract, current_contract_dir
 #
 # Requires: jq, bash 4.0+, standard POSIX utils
 
@@ -22,7 +23,7 @@ contract_dir() {
 }
 
 # init_contract_dir <contractId>
-# Creates the directory structure for a contract, including a reviews/ subdirectory.
+# Creates the directory structure for a contract's durable snapshot/history.
 init_contract_dir() {
   local contract_id="${1:-}"
   if [[ -z "$contract_id" ]]; then
@@ -31,8 +32,45 @@ init_contract_dir() {
   fi
   local dir
   dir=$(contract_dir "$contract_id")
-  mkdir -p "${dir}reviews"
+  mkdir -p "${dir}"
   echo "Initialized contract directory: ${dir}"
+}
+
+# sync_contract_artifacts <contractId> <path...>
+# Copies selected working-set artifacts from .signum/ into the contract's
+# durable directory, preserving relative subpaths.
+sync_contract_artifacts() {
+  local contract_id="${1:-}"
+  shift || true
+  if [[ -z "$contract_id" ]]; then
+    echo "sync_contract_artifacts: contractId required" >&2
+    return 1
+  fi
+  if [[ "$#" -eq 0 ]]; then
+    echo "sync_contract_artifacts: at least one artifact path required" >&2
+    return 1
+  fi
+
+  local dir
+  dir=$(contract_dir "$contract_id")
+  mkdir -p "$dir"
+
+  local rel src dst copied=0
+  for rel in "$@"; do
+    if [[ -z "$rel" ]]; then
+      continue
+    fi
+    src=".signum/${rel}"
+    if [[ ! -e "$src" ]]; then
+      continue
+    fi
+    dst="${dir}${rel}"
+    mkdir -p "$(dirname "$dst")"
+    cp -R "$src" "$dst"
+    copied=$((copied + 1))
+  done
+
+  echo "Synced ${copied} artifact(s) to ${dir}"
 }
 
 # _ensure_index

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -96,13 +96,14 @@ fi
 ARCHIVE_DIR=".signum/archive/${CONTRACT_ID}/"
 mkdir -p "$ARCHIVE_DIR"
 
-# Copy essential artifacts (contract + proofpack)
+# Copy durable artifacts from the per-contract snapshot/history
 cp "${DIR}contract.json" "$ARCHIVE_DIR" 2>/dev/null || true
 cp "${DIR}proofpack.json" "$ARCHIVE_DIR" 2>/dev/null || true
 cp "${DIR}approval.json" "$ARCHIVE_DIR" 2>/dev/null || true
 
 # Copy audit summary if present
 cp "${DIR}audit_summary.json" "$ARCHIVE_DIR" 2>/dev/null || true
+cp "${DIR}anti_entropy_report.json" "$ARCHIVE_DIR" 2>/dev/null || true
 
 # Copy receipt chain artifacts (execute receipt is audit evidence)
 cp "${DIR}receipts/execute.json" "$ARCHIVE_DIR" 2>/dev/null || true
@@ -134,7 +135,7 @@ jq --arg id "$CONTRACT_ID" --arg ts "$ARCHIVED_AT" \
   && mv .signum/contracts/index.json.tmp .signum/contracts/index.json
 
 echo "Archived: $CONTRACT_ID → $ARCHIVE_DIR"
-echo "Kept: contract.json, proofpack.json, approval.json, audit_summary.json"
+echo "Kept: contract.json, proofpack.json, approval.json, audit_summary.json, anti_entropy_report.json"
 echo "Purged: intermediates (reviews, baseline, patches, prompts)"
 ```
 
@@ -419,9 +420,9 @@ You MUST call the Write tool before finishing.
 
 If the file is STILL missing or INVALID after retry, stop and report: "Contractor agent failed to produce a valid contract.json after 2 attempts (haiku + sonnet). Check agent output for errors."
 
-### Step 1.2.5: Initialize per-contract directory
+### Step 1.2.5: Initialize per-contract durable directory
 
-After contractor creates contract.json, extract the contractId and set up an isolated directory for this contract's artifacts.
+After contractor creates `contract.json`, extract the `contractId` and set up a per-contract durable directory. This directory is **not** the live workspace for the current run. The live working set remains under `.signum/`; the per-contract directory is a mirrored snapshot/history surface for this contract.
 
 Use the Bash tool:
 
@@ -437,13 +438,11 @@ if [ -z "$CONTRACT_ID" ] || [ "$CONTRACT_ID" = "null" ]; then
 fi
 echo "contractId: $CONTRACT_ID"
 
-# Create per-contract directory with reviews/ subdirectory
+# Create per-contract durable directory
 init_contract_dir "$CONTRACT_ID"
 
-# Copy contract.json to per-contract directory (original stays in .signum/ as working copy)
-CDIR=$(contract_dir "$CONTRACT_ID")
-cp .signum/contract.json "${CDIR}contract.json"
-echo "Archived contract.json to ${CDIR}contract.json"
+# Mirror the initial contract snapshot
+sync_contract_artifacts "$CONTRACT_ID" "contract.json"
 
 # Register contract in index.json
 register_contract "$CONTRACT_ID" "draft"
@@ -3155,11 +3154,14 @@ if [ -f lib/contract-dir.sh ]; then
   CONTRACT_ID=$(jq -r '.contractId // empty' .signum/contract.json)
   if [ -n "$CONTRACT_ID" ]; then
     update_contract_status "$CONTRACT_ID" "completed"
-    # Sync updated contract.json + proofpack to per-contract directory
-    DIR=$(contract_dir "$CONTRACT_ID")
-    cp .signum/contract.json "${DIR}" 2>/dev/null || true
-    cp .signum/proofpack.json "${DIR}" 2>/dev/null || true
-    cp .signum/anti_entropy_report.json "${DIR}" 2>/dev/null || true
+    # Sync durable artifacts for this completed contract.
+    sync_contract_artifacts "$CONTRACT_ID" \
+      "contract.json" \
+      "proofpack.json" \
+      "anti_entropy_report.json" \
+      "audit_summary.json" \
+      "approval.json" \
+      "receipts/execute.json"
     echo "Contract $CONTRACT_ID → completed"
   fi
 fi

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -27,7 +27,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.19.0",
+  "version": "4.19.1",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -104,9 +104,12 @@ cp "${DIR}approval.json" "$ARCHIVE_DIR" 2>/dev/null || true
 # Copy audit summary if present
 cp "${DIR}audit_summary.json" "$ARCHIVE_DIR" 2>/dev/null || true
 cp "${DIR}anti_entropy_report.json" "$ARCHIVE_DIR" 2>/dev/null || true
+cp "${DIR}execution_context.json" "$ARCHIVE_DIR" 2>/dev/null || true
 
-# Copy receipt chain artifacts (execute receipt is audit evidence)
-cp "${DIR}receipts/execute.json" "$ARCHIVE_DIR" 2>/dev/null || true
+# Copy receipt-chain artifacts needed for replay/verification
+cp -R "${DIR}receipts" "$ARCHIVE_DIR" 2>/dev/null || true
+cp -R "${DIR}runs" "$ARCHIVE_DIR" 2>/dev/null || true
+cp -R "${DIR}snapshots" "$ARCHIVE_DIR" 2>/dev/null || true
 
 # Purge intermediate artifacts (reviews, baseline, holdout, execute_log, prompts)
 rm -rf "${DIR}reviews/" 2>/dev/null || true
@@ -135,7 +138,7 @@ jq --arg id "$CONTRACT_ID" --arg ts "$ARCHIVED_AT" \
   && mv .signum/contracts/index.json.tmp .signum/contracts/index.json
 
 echo "Archived: $CONTRACT_ID → $ARCHIVE_DIR"
-echo "Kept: contract.json, proofpack.json, approval.json, audit_summary.json, anti_entropy_report.json"
+echo "Kept: contract.json, proofpack.json, approval.json, audit_summary.json, anti_entropy_report.json, execution_context.json, receipts/, runs/, snapshots/"
 echo "Purged: intermediates (reviews, baseline, patches, prompts)"
 ```
 
@@ -3072,7 +3075,7 @@ fi
 # Final assembly
 jq -n \
   --arg schemaVersion "4.6" \
-  --arg signumVersion "4.19.0" \
+  --arg signumVersion "4.19.1" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \
@@ -3154,6 +3157,10 @@ if [ -f lib/contract-dir.sh ]; then
   CONTRACT_ID=$(jq -r '.contractId // empty' .signum/contract.json)
   if [ -n "$CONTRACT_ID" ]; then
     update_contract_status "$CONTRACT_ID" "completed"
+    RUN_ID=$(jq -r '.run_id // empty' .signum/execution_context.json 2>/dev/null || true)
+    if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+      RUN_ID=$(jq -r '.run_id // empty' .signum/receipts/execute.json 2>/dev/null || true)
+    fi
     # Sync durable artifacts for this completed contract.
     sync_contract_artifacts "$CONTRACT_ID" \
       "contract.json" \
@@ -3161,7 +3168,12 @@ if [ -f lib/contract-dir.sh ]; then
       "anti_entropy_report.json" \
       "audit_summary.json" \
       "approval.json" \
-      "receipts/execute.json"
+      "execution_context.json" \
+      "receipts" \
+      "snapshots"
+    if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
+      sync_contract_artifacts "$CONTRACT_ID" "runs/${RUN_ID}"
+    fi
     echo "Contract $CONTRACT_ID → completed"
   fi
 fi

--- a/platforms/claude-code/docs/how-it-works.md
+++ b/platforms/claude-code/docs/how-it-works.md
@@ -134,7 +134,7 @@ If the CLI returns malformed output or a non-zero exit code, the provider is mar
 
 ## Artifacts
 
-All artifacts are written to `.signum/` (auto-added to `.gitignore`):
+Live working-set artifacts are written to `.signum/` (auto-added to `.gitignore`). Signum also mirrors durable per-contract snapshots into `.signum/contracts/<contractId>/` for history/archive flows. That per-contract directory is not the active workspace while a run is in flight.
 
 | File | Phase | Description |
 |------|-------|-------------|
@@ -151,6 +151,13 @@ All artifacts are written to `.signum/` (auto-added to `.gitignore`):
 | `audit_iteration_log.json` | AUDIT | Summary of all iterations (v4.6+) |
 | `repair_brief.json` | AUDIT | Current repair brief for engineer (v4.6+) |
 | `flaky_tests.json` | AUDIT | Flaky test tracker (v4.6+, run-local) |
+
+Durable per-contract snapshots typically mirror:
+- `contract.json`
+- `proofpack.json`
+- `audit_summary.json`
+- `approval.json`
+- `receipts/execute.json`
 
 ## Cost Estimates
 

--- a/platforms/claude-code/docs/how-it-works.md
+++ b/platforms/claude-code/docs/how-it-works.md
@@ -155,9 +155,13 @@ Live working-set artifacts are written to `.signum/` (auto-added to `.gitignore`
 Durable per-contract snapshots typically mirror:
 - `contract.json`
 - `proofpack.json`
+- `anti_entropy_report.json`
 - `audit_summary.json`
 - `approval.json`
-- `receipts/execute.json`
+- `execution_context.json`
+- `receipts/`
+- `runs/<runId>/`
+- `snapshots/`
 
 ## Cost Estimates
 

--- a/platforms/claude-code/docs/reference.md
+++ b/platforms/claude-code/docs/reference.md
@@ -114,7 +114,11 @@ Durable per-contract snapshots typically mirror:
 - `proofpack.json`
 - `audit_summary.json`
 - `approval.json`
-- `receipts/execute.json`
+- `anti_entropy_report.json`
+- `execution_context.json`
+- `receipts/`
+- `runs/<runId>/`
+- `snapshots/`
 
 ### contract.json fields
 

--- a/platforms/claude-code/docs/reference.md
+++ b/platforms/claude-code/docs/reference.md
@@ -93,7 +93,7 @@ Assembles `.signum/proofpack.json` — self-contained evidence bundle with embed
 
 ## Artifacts
 
-All artifacts are stored in `.signum/` (auto-added to `.gitignore`):
+Live working-set artifacts are written to `.signum/` (auto-added to `.gitignore`). Durable per-contract snapshots are mirrored under `.signum/contracts/<contractId>/` for history/archive flows. The per-contract directory is not the active workspace for an in-flight run.
 
 | File | Phase | Contents |
 |------|-------|----------|
@@ -108,6 +108,13 @@ All artifacts are stored in `.signum/` (auto-added to `.gitignore`):
 | `reviews/gemini.json` | Audit | Gemini CLI performance review (or unavailable marker) |
 | `audit_summary.json` | Audit | Synthesized decision with consensus reasoning and confidence scores |
 | `proofpack.json` | Pack | Self-contained evidence bundle with embedded artifacts, checksums, and confidence |
+
+Durable per-contract snapshots typically mirror:
+- `contract.json`
+- `proofpack.json`
+- `audit_summary.json`
+- `approval.json`
+- `receipts/execute.json`
 
 ### contract.json fields
 

--- a/platforms/claude-code/lib/contract-dir.sh
+++ b/platforms/claude-code/lib/contract-dir.sh
@@ -65,8 +65,13 @@ sync_contract_artifacts() {
       continue
     fi
     dst="${dir}${rel}"
-    mkdir -p "$(dirname "$dst")"
-    cp -R "$src" "$dst"
+    if [[ -d "$src" ]]; then
+      mkdir -p "$dst"
+      cp -R "$src"/. "$dst"/
+    else
+      mkdir -p "$(dirname "$dst")"
+      cp -R "$src" "$dst"
+    fi
     copied=$((copied + 1))
   done
 

--- a/platforms/claude-code/lib/contract-dir.sh
+++ b/platforms/claude-code/lib/contract-dir.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # contract-dir.sh — per-contract directory management for Signum
-# Functions: contract_dir, init_contract_dir, register_contract,
-#            update_contract_status, get_active_contract, current_contract_dir
+# Functions: contract_dir, init_contract_dir, sync_contract_artifacts,
+#            register_contract, update_contract_status,
+#            get_active_contract, current_contract_dir
 #
 # Requires: jq, bash 4.0+, standard POSIX utils
 
@@ -22,7 +23,7 @@ contract_dir() {
 }
 
 # init_contract_dir <contractId>
-# Creates the directory structure for a contract, including a reviews/ subdirectory.
+# Creates the directory structure for a contract's durable snapshot/history.
 init_contract_dir() {
   local contract_id="${1:-}"
   if [[ -z "$contract_id" ]]; then
@@ -31,8 +32,45 @@ init_contract_dir() {
   fi
   local dir
   dir=$(contract_dir "$contract_id")
-  mkdir -p "${dir}reviews"
+  mkdir -p "${dir}"
   echo "Initialized contract directory: ${dir}"
+}
+
+# sync_contract_artifacts <contractId> <path...>
+# Copies selected working-set artifacts from .signum/ into the contract's
+# durable directory, preserving relative subpaths.
+sync_contract_artifacts() {
+  local contract_id="${1:-}"
+  shift || true
+  if [[ -z "$contract_id" ]]; then
+    echo "sync_contract_artifacts: contractId required" >&2
+    return 1
+  fi
+  if [[ "$#" -eq 0 ]]; then
+    echo "sync_contract_artifacts: at least one artifact path required" >&2
+    return 1
+  fi
+
+  local dir
+  dir=$(contract_dir "$contract_id")
+  mkdir -p "$dir"
+
+  local rel src dst copied=0
+  for rel in "$@"; do
+    if [[ -z "$rel" ]]; then
+      continue
+    fi
+    src=".signum/${rel}"
+    if [[ ! -e "$src" ]]; then
+      continue
+    fi
+    dst="${dir}${rel}"
+    mkdir -p "$(dirname "$dst")"
+    cp -R "$src" "$dst"
+    copied=$((copied + 1))
+  done
+
+  echo "Synced ${copied} artifact(s) to ${dir}"
 }
 
 # _ensure_index

--- a/platforms/claude-code/tests/test-contract-dir.sh
+++ b/platforms/claude-code/tests/test-contract-dir.sh
@@ -78,12 +78,36 @@ echo ""
 echo "=== init_contract_dir ==="
 
 assert_ok "creates directory" init_contract_dir "sig-test-001"
-[ -d ".signum/contracts/sig-test-001/reviews" ]
-assert_eq "reviews subdir exists" "true" \
+[ -d ".signum/contracts/sig-test-001" ]
+assert_eq "contract dir exists" "true" \
+  "$([ -d .signum/contracts/sig-test-001 ] && echo true || echo false)"
+assert_eq "reviews subdir is not pre-created" "false" \
   "$([ -d .signum/contracts/sig-test-001/reviews ] && echo true || echo false)"
 
 assert_fail "fails without id" "contractId required" \
   init_contract_dir ""
+
+echo ""
+echo "=== sync_contract_artifacts ==="
+
+mkdir -p ".signum/reviews"
+printf '{"goal":"test"}\n' > ".signum/contract.json"
+printf '{"decision":"AUTO_OK"}\n' > ".signum/proofpack.json"
+printf '{"verdict":"APPROVE"}\n' > ".signum/reviews/claude.json"
+
+assert_ok "syncs selected working-set artifacts" \
+  sync_contract_artifacts "sig-test-001" "contract.json" "proofpack.json" "reviews/claude.json"
+assert_eq "contract snapshot copied" "true" \
+  "$([ -f .signum/contracts/sig-test-001/contract.json ] && echo true || echo false)"
+assert_eq "proofpack snapshot copied" "true" \
+  "$([ -f .signum/contracts/sig-test-001/proofpack.json ] && echo true || echo false)"
+assert_eq "nested review snapshot copied" "true" \
+  "$([ -f .signum/contracts/sig-test-001/reviews/claude.json ] && echo true || echo false)"
+
+assert_fail "sync fails without id" "contractId required" \
+  sync_contract_artifacts ""
+assert_fail "sync fails without paths" "artifact path required" \
+  sync_contract_artifacts "sig-test-001"
 
 echo ""
 echo "=== register_contract ==="

--- a/platforms/claude-code/tests/test-contract-dir.sh
+++ b/platforms/claude-code/tests/test-contract-dir.sh
@@ -94,15 +94,31 @@ mkdir -p ".signum/reviews"
 printf '{"goal":"test"}\n' > ".signum/contract.json"
 printf '{"decision":"AUTO_OK"}\n' > ".signum/proofpack.json"
 printf '{"verdict":"APPROVE"}\n' > ".signum/reviews/claude.json"
+mkdir -p ".signum/receipts" ".signum/runs/run-01" ".signum/snapshots"
+printf '{"status":"PASS"}\n' > ".signum/receipts/execute.json"
+printf '{"attempt":1}\n' > ".signum/runs/run-01/execute-01.json"
+printf '{"tree_hash":"sha256:test"}\n' > ".signum/snapshots/pre-execute.json"
 
 assert_ok "syncs selected working-set artifacts" \
-  sync_contract_artifacts "sig-test-001" "contract.json" "proofpack.json" "reviews/claude.json"
+  sync_contract_artifacts "sig-test-001" "contract.json" "proofpack.json" "reviews/claude.json" "receipts" "runs/run-01" "snapshots"
 assert_eq "contract snapshot copied" "true" \
   "$([ -f .signum/contracts/sig-test-001/contract.json ] && echo true || echo false)"
 assert_eq "proofpack snapshot copied" "true" \
   "$([ -f .signum/contracts/sig-test-001/proofpack.json ] && echo true || echo false)"
 assert_eq "nested review snapshot copied" "true" \
   "$([ -f .signum/contracts/sig-test-001/reviews/claude.json ] && echo true || echo false)"
+assert_eq "receipts dir copied" "true" \
+  "$([ -f .signum/contracts/sig-test-001/receipts/execute.json ] && echo true || echo false)"
+assert_eq "runs dir copied" "true" \
+  "$([ -f .signum/contracts/sig-test-001/runs/run-01/execute-01.json ] && echo true || echo false)"
+assert_eq "snapshots dir copied" "true" \
+  "$([ -f .signum/contracts/sig-test-001/snapshots/pre-execute.json ] && echo true || echo false)"
+
+printf '{"status":"PASS","attempt":2}\n' > ".signum/receipts/execute.json"
+assert_ok "re-sync updates dirs without nesting" \
+  sync_contract_artifacts "sig-test-001" "receipts"
+assert_eq "re-sync does not create nested receipts dir" "false" \
+  "$([ -d .signum/contracts/sig-test-001/receipts/receipts ] && echo true || echo false)"
 
 assert_fail "sync fails without id" "contractId required" \
   sync_contract_artifacts ""

--- a/tests/test-anti-entropy-report.sh
+++ b/tests/test-anti-entropy-report.sh
@@ -81,7 +81,7 @@ EOF
   cat > "$dir/.signum/proofpack.json" <<'EOF'
 {
   "schemaVersion": "4.7",
-  "signumVersion": "4.19.0",
+  "signumVersion": "4.19.1",
   "createdAt": "2026-04-10T10:00:00Z",
   "runId": "signum-test",
   "decision": "AUTO_OK",
@@ -144,7 +144,7 @@ EOF
 cat > "$DIRTY/.signum/proofpack.json" <<'EOF'
 {
   "schemaVersion": "4.7",
-  "signumVersion": "4.19.0",
+  "signumVersion": "4.19.1",
   "createdAt": "2026-04-10T10:00:00Z",
   "runId": "signum-test",
   "decision": "AUTO_OK",

--- a/tests/test-brownfield-harness-flow.sh
+++ b/tests/test-brownfield-harness-flow.sh
@@ -79,7 +79,7 @@ DOC
   cat > "$dir/.signum/proofpack.json" <<'DOC'
 {
   "schemaVersion":"4.7",
-  "signumVersion":"4.19.0",
+  "signumVersion":"4.19.1",
   "createdAt":"2026-04-10T10:00:00Z",
   "runId":"downstream-brownfield-test",
   "decision":"AUTO_OK",

--- a/tests/test-contract-dir.sh
+++ b/tests/test-contract-dir.sh
@@ -78,12 +78,36 @@ echo ""
 echo "=== init_contract_dir ==="
 
 assert_ok "creates directory" init_contract_dir "sig-test-001"
-[ -d ".signum/contracts/sig-test-001/reviews" ]
-assert_eq "reviews subdir exists" "true" \
+[ -d ".signum/contracts/sig-test-001" ]
+assert_eq "contract dir exists" "true" \
+  "$([ -d .signum/contracts/sig-test-001 ] && echo true || echo false)"
+assert_eq "reviews subdir is not pre-created" "false" \
   "$([ -d .signum/contracts/sig-test-001/reviews ] && echo true || echo false)"
 
 assert_fail "fails without id" "contractId required" \
   init_contract_dir ""
+
+echo ""
+echo "=== sync_contract_artifacts ==="
+
+mkdir -p ".signum/reviews"
+printf '{"goal":"test"}\n' > ".signum/contract.json"
+printf '{"decision":"AUTO_OK"}\n' > ".signum/proofpack.json"
+printf '{"verdict":"APPROVE"}\n' > ".signum/reviews/claude.json"
+
+assert_ok "syncs selected working-set artifacts" \
+  sync_contract_artifacts "sig-test-001" "contract.json" "proofpack.json" "reviews/claude.json"
+assert_eq "contract snapshot copied" "true" \
+  "$([ -f .signum/contracts/sig-test-001/contract.json ] && echo true || echo false)"
+assert_eq "proofpack snapshot copied" "true" \
+  "$([ -f .signum/contracts/sig-test-001/proofpack.json ] && echo true || echo false)"
+assert_eq "nested review snapshot copied" "true" \
+  "$([ -f .signum/contracts/sig-test-001/reviews/claude.json ] && echo true || echo false)"
+
+assert_fail "sync fails without id" "contractId required" \
+  sync_contract_artifacts ""
+assert_fail "sync fails without paths" "artifact path required" \
+  sync_contract_artifacts "sig-test-001"
 
 echo ""
 echo "=== register_contract ==="

--- a/tests/test-contract-dir.sh
+++ b/tests/test-contract-dir.sh
@@ -94,15 +94,31 @@ mkdir -p ".signum/reviews"
 printf '{"goal":"test"}\n' > ".signum/contract.json"
 printf '{"decision":"AUTO_OK"}\n' > ".signum/proofpack.json"
 printf '{"verdict":"APPROVE"}\n' > ".signum/reviews/claude.json"
+mkdir -p ".signum/receipts" ".signum/runs/run-01" ".signum/snapshots"
+printf '{"status":"PASS"}\n' > ".signum/receipts/execute.json"
+printf '{"attempt":1}\n' > ".signum/runs/run-01/execute-01.json"
+printf '{"tree_hash":"sha256:test"}\n' > ".signum/snapshots/pre-execute.json"
 
 assert_ok "syncs selected working-set artifacts" \
-  sync_contract_artifacts "sig-test-001" "contract.json" "proofpack.json" "reviews/claude.json"
+  sync_contract_artifacts "sig-test-001" "contract.json" "proofpack.json" "reviews/claude.json" "receipts" "runs/run-01" "snapshots"
 assert_eq "contract snapshot copied" "true" \
   "$([ -f .signum/contracts/sig-test-001/contract.json ] && echo true || echo false)"
 assert_eq "proofpack snapshot copied" "true" \
   "$([ -f .signum/contracts/sig-test-001/proofpack.json ] && echo true || echo false)"
 assert_eq "nested review snapshot copied" "true" \
   "$([ -f .signum/contracts/sig-test-001/reviews/claude.json ] && echo true || echo false)"
+assert_eq "receipts dir copied" "true" \
+  "$([ -f .signum/contracts/sig-test-001/receipts/execute.json ] && echo true || echo false)"
+assert_eq "runs dir copied" "true" \
+  "$([ -f .signum/contracts/sig-test-001/runs/run-01/execute-01.json ] && echo true || echo false)"
+assert_eq "snapshots dir copied" "true" \
+  "$([ -f .signum/contracts/sig-test-001/snapshots/pre-execute.json ] && echo true || echo false)"
+
+printf '{"status":"PASS","attempt":2}\n' > ".signum/receipts/execute.json"
+assert_ok "re-sync updates dirs without nesting" \
+  sync_contract_artifacts "sig-test-001" "receipts"
+assert_eq "re-sync does not create nested receipts dir" "false" \
+  "$([ -d .signum/contracts/sig-test-001/receipts/receipts ] && echo true || echo false)"
 
 assert_fail "sync fails without id" "contractId required" \
   sync_contract_artifacts ""

--- a/tests/test-pack-anti-entropy.sh
+++ b/tests/test-pack-anti-entropy.sh
@@ -43,7 +43,7 @@ EOF
   cat > "$dir/.signum/proofpack.json" <<'EOF'
 {
   "schemaVersion":"4.7",
-  "signumVersion":"4.19.0",
+  "signumVersion":"4.19.1",
   "createdAt":"2026-04-10T10:00:00Z",
   "runId":"signum-test",
   "decision":"AUTO_OK",


### PR DESCRIPTION
## Summary
- clarify the Signum storage model so `.signum/` is the single live working set and `.signum/contracts/<contractId>/` is durable snapshot/history only
- add `sync_contract_artifacts` and stop pre-creating misleading per-contract `reviews/` directories
- sync the durable artifacts needed for archive/history flows and update docs/tests to match

## Why
The current implementation mixes a root working set with partial per-contract mirrors, but the docs did not explain that clearly and the eager `reviews/` subdirectory suggested that per-contract directories were a second active workspace.

## Impact
- reduces ambiguity around the active contract location
- makes archive/history behavior more consistent
- keeps the runtime fix bounded without a risky full path refactor

Issue: #20

## Test Plan
- `bash tests/test-contract-dir.sh`
- `bash platforms/claude-code/tests/test-contract-dir.sh`
- `bash tests/test-doc-parity.sh`
