### PR TITLE
feat: add pi-native Signum runtime MVP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+- pi-native Signum runtime MVP from this repo root
+  - root `package.json` now exposes the repo as a pi-installable package with `pi.extensions`
+  - native `/signum` command for pi under `platforms/pi/`
+  - pi runtime support for `explain`, `init --harness`, `archive`, `close`, and `/signum <task>`
+  - pi task path now covers CONTRACT -> EXECUTE -> AUDIT -> PACK
+  - runtime policy-wrapped engineer tools, execute receipts, audit artifacts, and proofpack generation
+  - `tests/test-pi-extension.sh` plus optional live smoke `tests/test-pi-full-pipeline.sh`
+
+### Notes
+- pi AUDIT currently ships as single-pass for MVP coverage; iterative AUDIT parity remains deferred explicitly
+
 ## [4.19.1] - 2026-04-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ AI can generate a function in seconds; telling you whether it is correct takes l
 
 ## Install
 
+### Claude Code
+
 <!-- INSTALL:START -->
 ```bash
 claude plugin marketplace add heurema/emporium
@@ -50,11 +52,43 @@ claude plugin install .
 
 </details>
 
+### pi
+
+Signum also ships a native pi runtime from this same repo. The root package is the install surface.
+
+```bash
+pi install . -l
+```
+
+Then run inside pi:
+
+```text
+/signum explain
+/signum init --harness
+/signum your task here
+```
+
+For local non-interactive smoke work only, you may use:
+
+```bash
+SIGNUM_PI_AUTO_APPROVE=1 pi --no-extensions -e ./platforms/pi/extensions/signum/index.ts --mode json --no-session '/signum your task here'
+```
+
+`SIGNUM_PI_AUTO_APPROVE=1` is development-only and not the normal approval UX.
+
 ## Quick start
+
+### Claude Code
 
 ```bash
 # Run — describe what you want to build
 /signum "your task description"
+```
+
+### pi
+
+```text
+/signum your task description
 ```
 
 Signum grades your spec, shows the contract for approval, implements with an automatic repair loop, audits from multiple angles, and produces `proofpack.json` plus an advisory `anti_entropy_report.json`.

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -25,7 +25,7 @@ review_cadence: monthly
 | Root anti-entropy / RECONCILE design | `docs/plans/2026-04-10-root-anti-entropy-reconcile-design.md` | active | Current recommendation: report-only anti-entropy first, no root Phase 5 mutation |
 | Thin CLI extraction | `docs/thin-cli-extraction-plan.md` | active | Tracks deterministic-core extraction to Rust / `signum-core` |
 | Iterative audit behavior | `docs/plans/2026-03-15-iterative-audit-design.md` | active | Design reference for review/fix loop behavior |
-| pi native integration | `docs/plans/2026-04-20-pi-native-integration-plan.md` | proposed | Command-first pi extension surface, root npm packaging, shared `lib/*` reuse first |
+| pi native integration | `docs/plans/2026-04-20-pi-native-integration-plan.md` | active | MVP shipped in repo overlay; current follow-up is docs, tests, and release hardening |
 
 ## Recent Resolved Planning Debt
 - Canonical source policy is now documented in `docs/reference.md`.
@@ -39,7 +39,7 @@ review_cadence: monthly
 - Implement the first report-only anti-entropy artifact without changing the canonical root phase model.
 - Extend thin-cli planning from extraction inventory to a stable protocol/event model for `signum-core`.
 - Decide whether `README.md` and `CHANGELOG.md` need an immediate sync pass for `init --harness`.
-- Validate the package/layout/runtime boundary for pi-native `/signum` before starting large parity work.
+- Finish Slice 6 for pi-native `/signum`: root docs sync, full-pipeline smoke coverage, and release hardening.
 
 ## Archive Rules
 - Keep active planning docs under `docs/plans/`.

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -25,6 +25,7 @@ review_cadence: monthly
 | Root anti-entropy / RECONCILE design | `docs/plans/2026-04-10-root-anti-entropy-reconcile-design.md` | active | Current recommendation: report-only anti-entropy first, no root Phase 5 mutation |
 | Thin CLI extraction | `docs/thin-cli-extraction-plan.md` | active | Tracks deterministic-core extraction to Rust / `signum-core` |
 | Iterative audit behavior | `docs/plans/2026-03-15-iterative-audit-design.md` | active | Design reference for review/fix loop behavior |
+| pi native integration | `docs/plans/2026-04-20-pi-native-integration-plan.md` | proposed | Command-first pi extension surface, root npm packaging, shared `lib/*` reuse first |
 
 ## Recent Resolved Planning Debt
 - Canonical source policy is now documented in `docs/reference.md`.
@@ -38,6 +39,7 @@ review_cadence: monthly
 - Implement the first report-only anti-entropy artifact without changing the canonical root phase model.
 - Extend thin-cli planning from extraction inventory to a stable protocol/event model for `signum-core`.
 - Decide whether `README.md` and `CHANGELOG.md` need an immediate sync pass for `init --harness`.
+- Validate the package/layout/runtime boundary for pi-native `/signum` before starting large parity work.
 
 ## Archive Rules
 - Keep active planning docs under `docs/plans/`.

--- a/docs/plans/2026-04-20-pi-native-integration-plan.md
+++ b/docs/plans/2026-04-20-pi-native-integration-plan.md
@@ -1,0 +1,501 @@
+# Signum for pi — Native Extension Implementation Plan
+
+> **For agentic workers:** keep this workstream bounded. Do **not** combine: (1) pi runtime work, (2) large deterministic-core rewrites, and (3) unrelated root pipeline changes in one diff. Implement in slices.
+
+**Goal:** Add first-class pi support directly in this repository, expose Signum as a native `/signum` command inside pi, and make the repo installable as a pi package via npm.
+
+**Architecture:** Keep the root repo as the canonical Signum source. Add a new `platforms/pi/` runtime surface implemented as a TypeScript pi extension. Use code-based orchestration in TypeScript, not a skill or prompt-template entrypoint. Reuse shared deterministic `lib/*` scripts through TypeScript adapter modules for the first tranche. Publish from the repo root with a `pi` manifest that points at the pi extension entrypoint.
+
+**Tech Stack:** TypeScript (ESM), pi extension API, pi SDK, Node.js `child_process`, existing bash/jq/python deterministic scripts, npm packaging.
+
+**Primary UX decision:** no skills for the main entrypoint. The user-facing interface is a native pi command:
+
+```text
+/signum explain
+/signum init --harness
+/signum <task>
+/signum archive <contractId>
+/signum close <contractId>
+```
+
+---
+
+## Locked Decisions
+
+1. **Develop in this repo**, not in a separate `signum-pi` fork/repo.
+2. **Primary interface is `/signum`**, implemented as a pi extension command.
+3. **No skill-based primary entrypoint** for the pi integration.
+4. **Publish from repo root via npm** so users can install through `pi install npm:...` later.
+5. **Reuse `lib/*` first**, rather than rewriting the entire deterministic core to TypeScript now.
+6. **Runtime policy enforcement must be TS-native** during engineer execution; post-hoc shell checks alone are insufficient.
+7. **`platforms/pi/` is an overlay/runtime surface**, not a new canonical source of pipeline truth.
+
+---
+
+## Non-Goals for the First Tranche
+
+- No full TypeScript rewrite of `lib/*`
+- No separate standalone Signum app outside pi
+- No separate npm package repo unless the pi runtime later outgrows this repo
+- No skill-only or prompt-template-only Signum workflow for pi
+- No attempt to merge pi and Claude runtime surfaces into one shared command file
+- No broad redesign of contract/proofpack schemas just for pi packaging
+
+---
+
+## Delivery Strategy
+
+Ship this in **bounded slices**:
+
+1. **Package + extension foundation**
+2. **Command surface + init/explain/archive/close**
+3. **Role session launcher + CONTRACT flow**
+4. **Engineer execution boundary + policy enforcement**
+5. **AUDIT + PACK integration**
+6. **Docs, packaging, release hardening**
+
+This keeps the work aligned with repo policy: do not mix docs, deterministic-core rewrites, and orchestration changes all at once.
+
+---
+
+## Target Layout
+
+```text
+package.json
+platforms/
+  pi/
+    README.md
+    extensions/
+      signum/
+        index.ts
+        orchestrator.ts
+        args.ts
+        models.ts
+        ui.ts
+        state.ts
+        paths.ts
+        phases/
+          explain.ts
+          init.ts
+          contract.ts
+          execute.ts
+          audit.ts
+          pack.ts
+          archive.ts
+          close.ts
+        runtime/
+          role-session.ts
+          policy-tools.ts
+          script-adapters/
+            anti-entropy.ts
+            dsl.ts
+            init-scan.ts
+            policy-scan.ts
+            contract-dir.ts
+    agents/
+      contractor.md
+      engineer.md
+      reviewer-semantic.md
+      reviewer-security.md
+      reviewer-performance.md
+      synthesizer.md
+      init-synthesizer.md
+```
+
+Notes:
+- `platforms/pi/agents/` are runtime prompt assets for pi; they are **not** exposed as user skills.
+- Shared deterministic assets remain in root `lib/`.
+- If tiny helpers are easier to port than reuse (for example contract index helpers), that is allowed only when it reduces orchestration complexity and keeps on-disk formats unchanged.
+
+---
+
+## Slice 1 — Package + Extension Foundation
+
+### Task 1: Add npm package metadata at repo root
+
+**Files:**
+- Create: `package.json`
+- Optional: `package-lock.json`
+
+- [ ] Add root `package.json` with:
+  - package name (target: `@heurema/signum`, final name after availability check)
+  - version aligned with Signum release versioning
+  - `type: "module"`
+  - `keywords` including `pi-package`
+  - `pi.extensions` pointing to `./platforms/pi/extensions/signum/index.ts`
+  - `files` allowlist including `platforms/pi/**`, `lib/**`, `agents/**`, `LICENSE`, and runtime-required docs/assets
+- [ ] Keep packaging explicit via `files`; avoid relying on implicit npm inclusion.
+- [ ] Add minimal scripts:
+  - `check`
+  - `pack:dry-run`
+  - `test:pi` (placeholder allowed in first slice)
+- [ ] Verify `npm pack --dry-run` includes all runtime assets required by the extension.
+
+### Task 2: Add pi platform scaffold
+
+**Files:**
+- Create: `platforms/pi/README.md`
+- Create: `platforms/pi/extensions/signum/index.ts`
+- Create: `platforms/pi/extensions/signum/orchestrator.ts`
+
+- [ ] Create the `platforms/pi/` directory structure.
+- [ ] Add a minimal extension entrypoint that registers `/signum`.
+- [ ] Add a minimal orchestrator skeleton that can route to subcommands.
+- [ ] Document local development in `platforms/pi/README.md`.
+
+### Task 3: Verify local install path
+
+- [ ] Confirm local dev flow works with:
+  - `pi --no-extensions -e ./platforms/pi/extensions/signum/index.ts`
+  - `pi install . -l`
+- [ ] Record the expected local install workflow in `platforms/pi/README.md`.
+
+**Exit criteria for Slice 1:**
+- Repo can be treated as a pi package locally.
+- pi loads the extension from this repo.
+- `/signum` command is registered, even if it only prints a placeholder.
+
+---
+
+## Slice 2 — Native Command Surface
+
+### Task 4: Implement argument parsing and subcommand routing
+
+**Files:**
+- Create: `platforms/pi/extensions/signum/args.ts`
+- Modify: `platforms/pi/extensions/signum/orchestrator.ts`
+
+- [ ] Parse these forms:
+  - `explain`
+  - `init [--force] [--harness] [--project-root <path>]`
+  - `archive [contractId]`
+  - `close [contractId]`
+  - default freeform task
+- [ ] Keep parsing deterministic and testable.
+- [ ] Reject ambiguous combinations with explicit user-facing messages.
+
+### Task 5: Implement `/signum explain`
+
+**Files:**
+- Create: `platforms/pi/extensions/signum/phases/explain.ts`
+
+- [ ] Return a structured summary of the pi-native workflow.
+- [ ] Keep the output aligned with canonical Signum phases.
+- [ ] Do not claim pi-specific behavior that is not yet implemented.
+
+### Task 6: Implement `/signum init`, `/signum archive`, `/signum close`
+
+**Files:**
+- Create: `platforms/pi/extensions/signum/phases/init.ts`
+- Create: `platforms/pi/extensions/signum/phases/archive.ts`
+- Create: `platforms/pi/extensions/signum/phases/close.ts`
+- Create or reuse: `platforms/pi/extensions/signum/runtime/script-adapters/contract-dir.ts`
+
+- [ ] `/signum init`:
+  - reuse `lib/init-scanner.sh` and `lib/init-harness-scaffold.sh`
+  - use pi-native UI for review/accept flows
+  - write files directly from the extension runtime, not via heredoc shell
+- [ ] `/signum archive` and `/signum close`:
+  - keep `.signum/contracts/index.json` format compatible with existing Signum behavior
+  - reuse shell helpers or port tiny directory/index helpers to TS without changing file formats
+- [ ] Confirm these paths work before starting the main task pipeline.
+
+### Task 7: Add run-state detection + resume/restart flow
+
+**Files:**
+- Create: `platforms/pi/extensions/signum/state.ts`
+- Modify: `platforms/pi/extensions/signum/ui.ts`
+
+- [ ] Detect:
+  - no run
+  - contract-only run
+  - resumable run
+- [ ] Present user choice through `ctx.ui.select()`:
+  - resume
+  - restart
+  - cancel
+- [ ] On restart, clear only the known `.signum/` working-set artifacts.
+- [ ] Preserve per-contract archives and completed proofpacks.
+
+**Exit criteria for Slice 2:**
+- `/signum explain`, `/signum init`, `/signum archive`, `/signum close` all work natively in pi.
+- Resume/restart decision logic exists before default task execution is added.
+
+---
+
+## Slice 3 — Role Session Launcher + CONTRACT Flow
+
+### Task 8: Build a reusable role session launcher
+
+**Files:**
+- Create: `platforms/pi/extensions/signum/runtime/role-session.ts`
+- Create: `platforms/pi/extensions/signum/models.ts`
+- Create: `platforms/pi/extensions/signum/paths.ts`
+
+**Implementation choice:** use **pi SDK sessions** as the primary execution mechanism for contractor/engineer/reviewers/synthesizer.
+
+- [ ] Build a `RoleSessionRunner` abstraction that can:
+  - launch an isolated pi agent session programmatically
+  - choose model/provider per role
+  - set role-specific tools
+  - inject role prompt assets from `platforms/pi/agents/`
+  - capture final text + structured tool events
+- [ ] Keep the launcher behind an interface so a subprocess fallback remains possible if SDK nesting proves unreliable.
+- [ ] Do not depend on skills to load role instructions.
+
+### Task 9: Add pi-specific role prompt assets
+
+**Files:**
+- Create: `platforms/pi/agents/*.md`
+
+- [ ] Create pi-specific prompt assets for:
+  - contractor
+  - engineer
+  - reviewer-semantic
+  - reviewer-security
+  - reviewer-performance
+  - synthesizer
+  - init-synthesizer
+- [ ] Normalize tool references to pi semantics (`read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`).
+- [ ] Preserve canonical Signum behavior wherever practical.
+- [ ] Document intentional pi-only deviations if they are required.
+
+### Task 10: Implement CONTRACT phase in TypeScript
+
+**Files:**
+- Create: `platforms/pi/extensions/signum/phases/contract.ts`
+- Create: `platforms/pi/extensions/signum/runtime/script-adapters/*.ts`
+
+- [ ] Run contractor role through the role session launcher.
+- [ ] Validate `.signum/contract.json` exists and is structurally valid.
+- [ ] Reuse deterministic checks from `lib/*` where already extracted:
+  - contract injection scan
+  - prose/glossary/terminology/overlap/assumption/ADR/staleness checks
+- [ ] Re-implement **inline orchestrator-only logic** from `commands/signum.md` as TS modules where no reusable `lib/*` exists yet:
+  - spec quality scoring
+  - holdout count gate
+  - contract summary extraction
+  - approval checklist handling
+- [ ] Use pi-native UI for the human approval checklist.
+- [ ] Write `.signum/approval.json` and anchor the contract hash after user approval.
+
+### Task 11: Add `/signum <task>` happy-path entry into CONTRACT only
+
+- [ ] Wire the default `/signum <task>` path to stop after CONTRACT until approval and artifact writing are correct.
+- [ ] Do not begin engineer execution until CONTRACT flow is stable.
+
+**Exit criteria for Slice 3:**
+- `/signum <task>` can produce a contract, show a summary, ask for approval, and write the expected CONTRACT artifacts.
+- No skills are involved in the entrypoint.
+
+---
+
+## Slice 4 — Engineer Execution Boundary + Runtime Policy Enforcement
+
+### Task 12: Implement policy-aware tool wrappers
+
+**Files:**
+- Create: `platforms/pi/extensions/signum/runtime/policy-tools.ts`
+
+- [ ] Wrap engineer tools so runtime enforcement happens before mutation:
+  - `read`
+  - `edit`
+  - `write`
+  - `bash`
+- [ ] Enforce:
+  - allowed paths from `inScope` / `allowNewFilesUnder`
+  - deny patterns from `contract-policy.json`
+  - path deletion rules for removals
+  - file-count limits if policy requires them
+  - optional network denial
+- [ ] Do not rely solely on prompt discipline for engineer scope control.
+
+### Task 13: Implement EXECUTE phase using SDK session + wrapped tools
+
+**Files:**
+- Create: `platforms/pi/extensions/signum/phases/execute.ts`
+
+- [ ] Capture baseline deterministically before engineer execution.
+- [ ] Generate `contract-engineer.json` and `contract-policy.json`.
+- [ ] Launch engineer with the wrapped tool set.
+- [ ] Preserve existing `.signum/execute_log.json` and `.signum/combined.patch` behavior.
+- [ ] Support repair-loop attempts bounded by policy.
+
+### Task 14: Add scope/policy violation handling
+
+- [ ] When engineer violates policy, stop the run cleanly with a structured message.
+- [ ] Persist violation data to `.signum/` artifacts.
+- [ ] Keep behavior compatible with existing proof/audit expectations.
+
+**Exit criteria for Slice 4:**
+- Engineer execution is runtime-constrained, not just post-hoc checked.
+- Scope violations are blocked during execution.
+
+---
+
+## Slice 5 — AUDIT + PACK
+
+### Task 15: Implement AUDIT phase orchestration
+
+**Files:**
+- Create: `platforms/pi/extensions/signum/phases/audit.ts`
+
+- [ ] Reuse deterministic shell/core steps where possible:
+  - mechanic
+  - policy scan
+  - holdout execution
+- [ ] Launch reviewer roles in parallel where risk requires it.
+- [ ] Route reviewers to different model families/providers where available.
+- [ ] Keep reduced-coverage behavior explicit when providers are unavailable.
+
+### Task 16: Implement synthesizer flow
+
+- [ ] Feed reviewer outputs + deterministic reports into a synthesizer role session.
+- [ ] Preserve Signum decision semantics:
+  - `AUTO_OK`
+  - `AUTO_BLOCK`
+  - `HUMAN_REVIEW`
+- [ ] Keep reasoning structured and artifact-compatible.
+
+### Task 17: Implement PACK phase
+
+**Files:**
+- Create: `platforms/pi/extensions/signum/phases/pack.ts`
+
+- [ ] Build `proofpack.json` in the same `.signum/` artifact model used by existing Signum.
+- [ ] Reuse anti-entropy report generation where possible.
+- [ ] Sync working-copy artifacts into per-contract directories.
+- [ ] Preserve archive/index compatibility.
+
+### Task 18: Decide parity scope for iterative audit
+
+**Decision for first shipping slice:**
+- MVP may ship with **single-pass AUDIT** if iterative audit would delay the first usable pi-native release too much.
+- Iterative audit must then be tracked as an explicit parity follow-up, not silently dropped.
+
+- [ ] If iterative audit is deferred, document the gap and keep the runtime architecture ready for it.
+- [ ] If implemented immediately, do it in a dedicated slice after single-pass audit is stable.
+
+**Exit criteria for Slice 5:**
+- pi-native Signum can run the full task path through PACK for at least the MVP coverage target.
+
+---
+
+## Slice 6 — UI, Docs, Packaging, Release Hardening
+
+### Task 19: Add pi-native UI affordances
+
+**Files:**
+- Create/Modify: `platforms/pi/extensions/signum/ui.ts`
+
+- [ ] Add phase progress status via `ctx.ui.setStatus()`.
+- [ ] Add optional widget for current phase / checklist / reviewer progress.
+- [ ] Use `ctx.ui.confirm()` and `ctx.ui.select()` for approval and resume flows.
+- [ ] Keep the first version simple; custom overlay UI is optional follow-up work.
+
+### Task 20: Update documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/reference.md`
+- Modify: `docs/PLANS.md`
+- Modify as needed: `CHANGELOG.md`
+- Create/Modify: `platforms/pi/README.md`
+
+- [ ] Add pi install/use documentation.
+- [ ] Keep root docs explicit about canonical vs overlay behavior.
+- [ ] Document that pi support is command-first, not skill-first.
+- [ ] Document package install and local dev/test workflow.
+
+### Task 21: Add tests
+
+**Files:**
+- Create: pi-specific test harness under `tests/` or `platforms/pi/tests/`
+
+- [ ] Add adapter tests for shared script wrappers.
+- [ ] Add argument parser tests.
+- [ ] Add artifact-state tests for resume/restart/archive/close.
+- [ ] Add at least one end-to-end smoke test for `/signum explain` and `/signum init`.
+- [ ] Add at least one fixture-driven task smoke test for CONTRACT-only and full pipeline MVP.
+- [ ] Add `npm pack --dry-run` verification to release/test workflow.
+
+### Task 22: Prepare npm publish path
+
+- [ ] Verify package contents are stable.
+- [ ] Confirm final npm name availability.
+- [ ] Decide whether the first release is:
+  - published under the canonical Signum package name, or
+  - published under a temporary preview tag.
+- [ ] Document install command for end users.
+
+**Exit criteria for Slice 6:**
+- Repo can be packed and locally installed as a pi package.
+- Docs explain how pi support is installed and used.
+
+---
+
+## MVP Scope Recommendation
+
+To avoid stalling the workstream, the first pi-native release should target this minimum scope:
+
+### Required for MVP
+- Root npm package installable by pi
+- Native `/signum` command
+- `/signum explain`
+- `/signum init --harness`
+- `/signum archive`
+- `/signum close`
+- `/signum <task>` through CONTRACT -> EXECUTE -> AUDIT -> PACK
+- Runtime policy-wrapped engineer tools
+- Reuse of shared `lib/*` scripts through TS adapters
+
+### Allowed to defer after MVP
+- Iterative audit loop parity
+- Fancy custom overlay UI
+- Large-scale TypeScript port of deterministic scripts
+- Separate standalone Signum app outside pi
+
+---
+
+## Acceptance Criteria for This Workstream
+
+The workstream is successful when all of the following are true:
+
+1. A user can install the current repo as a pi package locally.
+2. A user can invoke Signum in pi through `/signum`, with no skill required.
+3. The pi runtime keeps `.signum/` artifact layout compatible with existing Signum expectations.
+4. Engineer execution is constrained by real runtime policy wrappers.
+5. Shared deterministic scripts are reused successfully through TS adapters.
+6. npm packaging includes all runtime assets needed by the pi extension.
+7. The implementation lives in this repo and does not require a parallel fork.
+
+---
+
+## Risks and Mitigations
+
+### Risk: SDK session nesting is harder than expected
+**Mitigation:** keep a thin `RoleSessionRunner` interface so subprocess-backed pi sessions remain a fallback.
+
+### Risk: packaging omits runtime assets (`lib/*`, prompt files)
+**Mitigation:** use `files` allowlist + `npm pack --dry-run` in tests.
+
+### Risk: engineer policy enforcement is weaker than Claude runtime assumptions
+**Mitigation:** implement wrapped tools before claiming full task-path support.
+
+### Risk: parity drift between root Signum prompts and pi prompt assets
+**Mitigation:** document pi-specific prompt assets as overlay/runtime assets and review intentional deviations.
+
+### Risk: big-bang scope creep
+**Mitigation:** ship bounded slices and keep iterative audit / custom UI as explicit follow-up work if needed.
+
+---
+
+## Immediate Next Step
+
+Start with **Slice 1 only**:
+- add root package metadata
+- add `platforms/pi/` scaffold
+- register a minimal `/signum` command
+- confirm local install with `pi install . -l`
+
+Do not start the full task-path orchestration before packaging and command registration are stable.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -18,11 +18,36 @@ If a derived doc disagrees with root `commands/signum.md`, treat the command fil
 
 ## Usage
 
+### Canonical runtime
+
 ```
 /signum <task description>
 ```
 
 Signum parses the task description and runs the full 4-phase pipeline automatically.
+
+### pi runtime overlay
+
+The pi-native runtime lives under `platforms/pi/` and exposes the same primary entrypoint as a native pi command:
+
+```text
+/signum explain
+/signum init --harness
+/signum <task description>
+/signum archive <contractId>
+/signum close <contractId>
+```
+
+Install surface for pi is the repo root package:
+
+```bash
+pi install . -l
+```
+
+Important parity note:
+- the pi runtime currently ships **single-pass AUDIT**
+- root `commands/signum.md` remains canonical
+- iterative AUDIT parity is tracked as explicit follow-up work, not silently dropped
 
 ## Examples
 
@@ -86,6 +111,8 @@ Hard stop if `openQuestions` is non-empty — the user must answer before procee
 
 Outputs: `.signum/baseline.json`, `.signum/combined.patch`, `.signum/execute_log.json`.
 
+In the pi runtime, EXECUTE also emits `.signum/receipts/execute.json` and per-run receipt history under `.signum/runs/<runId>/`.
+
 ### Phase 3: AUDIT
 
 Five independent verification layers:
@@ -103,6 +130,8 @@ Synthesizer agent applies deterministic rules:
 
 Pre-existing failures (checks that failed in baseline AND still fail) no longer auto-block.
 
+In the pi runtime overlay, AUDIT currently runs as a **single-pass** flow for MVP coverage. The iterative review/fix loop remains a parity follow-up.
+
 ### Phase 4: PACK
 
 Assembles `.signum/proofpack.json` — self-contained evidence bundle with embedded artifact contents, SHA-256 checksums, and confidence score.
@@ -117,6 +146,7 @@ Live working-set artifacts are written to `.signum/` (auto-added to `.gitignore`
 | `baseline.json` | Execute | Pre-change lint/typecheck/test exit codes |
 | `combined.patch` | Execute | Full git diff of all changes |
 | `execute_log.json` | Execute | Attempt history, check results, status |
+| `receipts/execute.json` | Execute | Boundary-verification receipt for execute → audit transition |
 | `mechanic_report.json` | Audit | Lint, typecheck, test results with baseline comparison and regression flags |
 | `holdout_report.json` | Audit | Holdout scenario pass/fail counts |
 | `reviews/claude.json` | Audit | Claude opus semantic review |

--- a/package.json
+++ b/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@heurema/signum",
+  "version": "4.19.0",
+  "description": "Evidence-driven development pipeline with multi-model code review",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://github.com/heurema/signum",
+  "repository": "https://github.com/heurema/signum",
+  "bugs": {
+    "url": "https://github.com/heurema/signum/issues"
+  },
+  "keywords": [
+    "dev-pipeline",
+    "code-review",
+    "multi-model",
+    "evidence-driven",
+    "proofpack",
+    "pi",
+    "pi-package"
+  ],
+  "scripts": {
+    "check": "npm run pack:dry-run && npm run test:pi",
+    "pack:dry-run": "npm pack --dry-run",
+    "test:pi": "bash tests/test-pi-extension.sh"
+  },
+  "files": [
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    "commands/**",
+    "agents/**",
+    "lib/**",
+    "platforms/pi/**"
+  ],
+  "peerDependencies": {
+    "@mariozechner/pi-ai": "*",
+    "@mariozechner/pi-coding-agent": "*"
+  },
+  "pi": {
+    "extensions": [
+      "./platforms/pi/extensions/signum/index.ts"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "check": "npm run pack:dry-run && npm run test:pi",
     "pack:dry-run": "npm pack --dry-run",
-    "test:pi": "bash tests/test-pi-extension.sh"
+    "test:pi": "bash tests/test-pi-extension.sh",
+    "test:pi:live": "bash tests/test-pi-full-pipeline.sh"
   },
   "files": [
     "README.md",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "check": "npm run pack:dry-run && npm run test:pi",
     "pack:dry-run": "npm pack --dry-run",
-    "test:pi": "bash tests/test-pi-extension.sh",
+    "test:pi": "bash tests/test-pi-extension.sh && bash tests/test-pi-verify-normalizer.sh",
     "test:pi:live": "bash tests/test-pi-full-pipeline.sh"
   },
   "files": [

--- a/platforms/pi/README.md
+++ b/platforms/pi/README.md
@@ -5,7 +5,7 @@ The root `commands/signum.md` remains the canonical pipeline source; this direct
 
 ## Current status
 
-Slice 5 is in progress:
+Slice 6 is in progress:
 - repo root is packable as a pi package
 - pi can load the extension from this repository
 - `/signum explain` returns a pi-native status summary aligned to Signum phases
@@ -70,12 +70,19 @@ Do not rely on `SIGNUM_PI_AUTO_APPROVE=1` for normal usage. It exists only to ex
 
 This path exercises the root `package.json` + `pi` manifest, which is the intended install surface for the pi-native Signum package.
 
-## Packaging check
+## Packaging and test checks
 
 Verify package contents before shipping:
 
 ```bash
 npm run pack:dry-run
+npm run test:pi
+```
+
+Optional live full-pipeline smoke:
+
+```bash
+SIGNUM_PI_LIVE_SMOKE=1 npm run test:pi:live
 ```
 
 The package manifest uses an explicit `files` allowlist so the pi extension, shared `lib/` scripts, and prompt assets can be shipped intentionally.

--- a/platforms/pi/README.md
+++ b/platforms/pi/README.md
@@ -1,0 +1,81 @@
+# Signum for pi
+
+`platforms/pi/` is the pi-native runtime overlay for Signum.
+The root `commands/signum.md` remains the canonical pipeline source; this directory contains the pi-specific extension surface.
+
+## Current status
+
+Slice 5 is in progress:
+- repo root is packable as a pi package
+- pi can load the extension from this repository
+- `/signum explain` returns a pi-native status summary aligned to Signum phases
+- `/signum init` runs the deterministic scan, uses pi-native review/accept UI, and writes files from the extension runtime
+- `/signum archive` and `/signum close` manage contract state natively in TypeScript
+- `/signum <task>` now runs CONTRACT -> EXECUTE -> AUDIT -> PACK in pi
+- engineer execution uses runtime policy-wrapped `read` / `edit` / `write` / `bash` tools
+- AUDIT runs as a single-pass pi-native flow with mechanic, policy scan, holdouts, reviewer sessions, and deterministic synthesis
+- PACK writes `proofpack.json`, `anti_entropy_report.json`, and syncs artifacts into the per-contract directory
+- iterative AUDIT parity is still deferred explicitly; it is not silently dropped
+
+## Local development
+
+From the repo root, use one of these flows.
+
+### Quick smoke test
+
+Use `--extension` for fast one-off loading:
+
+```bash
+pi --no-extensions -e ./platforms/pi/extensions/signum/index.ts
+```
+
+Then run one of:
+
+```text
+/signum explain
+/signum init --harness
+/signum archive sig-20260314-a1b2
+/signum close sig-20260314-a1b2
+```
+
+Use this mode for quick validation. Because the extension is loaded directly from the CLI flag, restart pi after edits instead of relying on `/reload`.
+
+### Package install from this repo
+
+Install the current repo as a project-local pi package:
+
+```bash
+pi install . -l
+```
+
+Then start pi in this repo and run:
+
+```text
+/signum explain
+```
+
+If you want to exercise the native init flow, use interactive pi so the command can open review/accept dialogs:
+
+```text
+/signum init --harness
+```
+
+For non-interactive development smoke tests of `/signum <task>`, the pi runtime also supports a developer-only approval bypass:
+
+```bash
+SIGNUM_PI_AUTO_APPROVE=1 pi --no-extensions -e ./platforms/pi/extensions/signum/index.ts --mode json --no-session '/signum your task here'
+```
+
+Do not rely on `SIGNUM_PI_AUTO_APPROVE=1` for normal usage. It exists only to exercise CONTRACT/EXECUTE/AUDIT/PACK flows without a live TUI confirmation step.
+
+This path exercises the root `package.json` + `pi` manifest, which is the intended install surface for the pi-native Signum package.
+
+## Packaging check
+
+Verify package contents before shipping:
+
+```bash
+npm run pack:dry-run
+```
+
+The package manifest uses an explicit `files` allowlist so the pi extension, shared `lib/` scripts, and prompt assets can be shipped intentionally.

--- a/platforms/pi/agents/contractor.md
+++ b/platforms/pi/agents/contractor.md
@@ -1,0 +1,104 @@
+---
+name: contractor
+description: Generate a Signum contract.json from a user request inside pi
+model: haiku
+tools: [read, grep, find, ls, bash, write, edit]
+---
+
+You are the Contractor agent for the pi-native Signum runtime.
+
+Your job is to transform a natural-language task into a precise, verifiable `.signum/contract.json`.
+
+## Inputs
+
+You receive:
+- `FEATURE_REQUEST`: the user task
+- `PROJECT_ROOT`: absolute path to the target project
+
+## Requirements
+
+1. Read only the files you need.
+2. Scan the codebase just enough to determine likely scope, risk, and verification approach.
+3. Prefer existing project context when available:
+   - `project.intent.md`
+   - `project.glossary.json`
+   - `modules.yaml`
+   - `.signum/contracts/index.json`
+4. Write exactly one main artifact: `.signum/contract.json`
+5. Do not modify product code.
+
+## Contract requirements
+
+Write JSON matching Signum contract schema v3.8 with at least these fields:
+- `schemaVersion`: `"3.8"`
+- `contractId`: `sig-YYYYMMDD-<hash>`
+- `status`: `"draft"`
+- `timestamps.createdAt`: current UTC timestamp
+- `goal`
+- `inScope`
+- `outOfScope`
+- `acceptanceCriteria`
+- `assumptions`
+- `openQuestions`
+- `riskLevel`
+- `riskSignals`
+- `requiredInputsProvided`
+- `implementationStrategy`
+
+Also include when possible:
+- `allowNewFilesUnder`
+- `glossaryVersion`
+- `contextInheritance`
+- `holdoutScenarios`
+- `parentContractId`
+- `relatedContractIds`
+- `readinessForPlanning`
+
+## Acceptance criteria rules
+
+- Use IDs like `AC1`, `AC2`, ...
+- Every AC must have a `description`
+- Every AC must have `visibility: "visible"`
+- Every AC must include `verify`
+- Prefer typed DSL `verify.steps` over legacy string commands
+- Use negative AC language where appropriate (`must not`, `reject`, `prevent`, `fail`) so the contract can be tested robustly
+
+## Holdout rules
+
+Generate hidden holdout scenarios the engineer should not optimize for directly.
+- low risk: optional
+- medium risk: at least 2
+- high risk: at least 5
+- Include negative or boundary scenarios
+- Put them in `holdoutScenarios`
+- Prefer typed DSL verification here too
+
+## Risk rules
+
+Assess risk deterministically:
+- low: narrow change, small scope, single main surface
+- medium: several files, multiple surfaces, or moderate blast radius
+- high: broad scope, security-sensitive area, data/schema/migration/auth/payment/credential/session/tls/oauth risk
+
+## Blocking behavior
+
+If the request is ambiguous or missing critical context:
+- set `requiredInputsProvided` to `false`
+- add specific user-facing items to `openQuestions`
+- still write `.signum/contract.json`
+
+## Scope guidance
+
+- Keep `inScope` minimal
+- Use `outOfScope` for plausible but intentionally excluded work
+- Use `allowNewFilesUnder` only when new files are needed
+
+## Output discipline
+
+- Write `.signum/contract.json`
+- If you revise it, overwrite the same file
+- Do not write explanations to other files
+- After writing the contract, your final message should be either:
+  1. the exact JSON contract again, or
+  2. a very short note confirming the file was written plus risk/open-question summary
+- Do not leave the run without either writing the file or emitting the JSON contract in your final message

--- a/platforms/pi/agents/contractor.md
+++ b/platforms/pi/agents/contractor.md
@@ -61,6 +61,23 @@ Also include when possible:
 - Every AC must have `visibility: "visible"`
 - Every AC must include `verify`
 - Prefer typed DSL `verify.steps` over legacy string commands
+- In pi contracts, keep verify steps within the supported portable dialect:
+  - `readFile`
+  - `run`
+  - `gitDiffFiles`
+  - `assertContains`
+  - `assertNotContains`
+  - `assertNotContainsAny`
+  - `assertJsonPathEquals`
+  - `assertEquals`
+  - `assertMatches`
+  - `assertOnlyPathsChanged`
+  - `assertNotModified`
+  - `assertFileExists`
+  - `assertReferenceMatchesImplementation`
+  - `assertSemanticAlignment`
+- Prefer exact file/path assertions over vague semantic-only checks when possible
+- Use `text` for string assertions instead of mixing `text` and `value` unless a scalar equality check is intended
 - Use negative AC language where appropriate (`must not`, `reject`, `prevent`, `fail`) so the contract can be tested robustly
 
 ## Holdout rules
@@ -71,7 +88,7 @@ Generate hidden holdout scenarios the engineer should not optimize for directly.
 - high risk: at least 5
 - Include negative or boundary scenarios
 - Put them in `holdoutScenarios`
-- Prefer typed DSL verification here too
+- Prefer the same portable typed DSL verification here too
 
 ## Risk rules
 

--- a/platforms/pi/agents/engineer.md
+++ b/platforms/pi/agents/engineer.md
@@ -1,0 +1,10 @@
+---
+name: engineer
+description: Implement against a Signum contract within pi
+model: sonnet
+tools: [read, grep, find, ls, bash, write, edit]
+---
+
+You are the pi-native Signum Engineer.
+Implement code against the approved contract artifacts in `.signum/`.
+Respect runtime policy wrappers and never modify files outside approved scope.

--- a/platforms/pi/agents/init-synthesizer.md
+++ b/platforms/pi/agents/init-synthesizer.md
@@ -1,0 +1,9 @@
+---
+name: init-synthesizer
+description: Synthesize project.intent.md and project.glossary.json for pi-native Signum init
+model: sonnet
+tools: [read, grep, find, ls]
+---
+
+You synthesize `project.intent.md` and `project.glossary.json` from deterministic init scan signals.
+Follow source precedence strictly, preserve explicit non-goals only, and emit structured drafts.

--- a/platforms/pi/agents/reviewer-performance.md
+++ b/platforms/pi/agents/reviewer-performance.md
@@ -1,0 +1,44 @@
+---
+name: reviewer-performance
+description: Performance reviewer for Signum audit inside pi
+model: sonnet
+tools: [read, grep, find, ls, bash, write]
+---
+
+You are the performance reviewer for the pi-native Signum audit flow.
+
+Focus only on:
+- algorithmic complexity regressions
+- excessive I/O or repeated work
+- unnecessary allocations or copies
+- scalability regressions
+- latency-sensitive hot-path issues
+
+Do not report style, formatting, security, or generic correctness feedback.
+
+When invoked, read the contract, patch, mechanic report, and any optional review context named in the prompt.
+Return a strict JSON review object with this shape:
+
+{
+  "verdict": "APPROVE" | "REJECT" | "CONDITIONAL",
+  "reviewedFiles": ["path"],
+  "findings": [
+    {
+      "file": "path/to/file",
+      "line": 1,
+      "severity": "CRITICAL" | "MAJOR" | "MINOR",
+      "category": "performance",
+      "comment": "one-sentence performance defect description",
+      "evidence": "exact supporting code or diff line"
+    }
+  ],
+  "summary": "brief conclusion"
+}
+
+Rules:
+- REJECT requires at least one CRITICAL finding.
+- CONDITIONAL requires at least one MAJOR finding and no CRITICAL findings.
+- APPROVE means only MINOR or no findings.
+- If no real issues are found, emit APPROVE with an empty findings array.
+- If the prompt gives you an output path, write the JSON there.
+- If writing fails, emit ONLY the JSON object as final text.

--- a/platforms/pi/agents/reviewer-security.md
+++ b/platforms/pi/agents/reviewer-security.md
@@ -1,0 +1,45 @@
+---
+name: reviewer-security
+description: Security reviewer for Signum audit inside pi
+model: sonnet
+tools: [read, grep, find, ls, bash, write]
+---
+
+You are the security reviewer for the pi-native Signum audit flow.
+
+Focus only on:
+- trust boundary violations
+- auth or permission bypasses
+- secrets exposure
+- injection risks
+- command execution or path traversal issues
+- unsafe security-sensitive defaults
+
+Do not report style, formatting, performance, or generic correctness feedback.
+
+When invoked, read the contract, patch, mechanic report, and any optional review context named in the prompt.
+Return a strict JSON review object with this shape:
+
+{
+  "verdict": "APPROVE" | "REJECT" | "CONDITIONAL",
+  "reviewedFiles": ["path"],
+  "findings": [
+    {
+      "file": "path/to/file",
+      "line": 1,
+      "severity": "CRITICAL" | "MAJOR" | "MINOR",
+      "category": "security",
+      "comment": "one-sentence security defect description",
+      "evidence": "exact supporting code or diff line"
+    }
+  ],
+  "summary": "brief conclusion"
+}
+
+Rules:
+- REJECT requires at least one CRITICAL finding.
+- CONDITIONAL requires at least one MAJOR finding and no CRITICAL findings.
+- APPROVE means only MINOR or no findings.
+- If no real issues are found, emit APPROVE with an empty findings array.
+- If the prompt gives you an output path, write the JSON there.
+- If writing fails, emit ONLY the JSON object as final text.

--- a/platforms/pi/agents/reviewer-semantic.md
+++ b/platforms/pi/agents/reviewer-semantic.md
@@ -1,0 +1,43 @@
+---
+name: reviewer-semantic
+description: Semantic reviewer for Signum audit inside pi
+model: sonnet
+tools: [read, grep, find, ls, bash, write]
+---
+
+You are the semantic reviewer for the pi-native Signum audit flow.
+
+Focus on:
+- correctness defects
+- requirement coverage gaps
+- regressions against current behavior
+- behavioral mismatches between the contract and the patch
+
+Do not report style, formatting, naming, or documentation-only preferences.
+
+When invoked, read the contract, patch, mechanic report, and any optional review context named in the prompt.
+Return a strict JSON review object with this shape:
+
+{
+  "verdict": "APPROVE" | "REJECT" | "CONDITIONAL",
+  "reviewedFiles": ["path"],
+  "findings": [
+    {
+      "file": "path/to/file",
+      "line": 1,
+      "severity": "CRITICAL" | "MAJOR" | "MINOR",
+      "category": "correctness" | "bug" | "missing",
+      "comment": "one-sentence defect description",
+      "evidence": "exact supporting code or diff line"
+    }
+  ],
+  "summary": "brief conclusion"
+}
+
+Rules:
+- REJECT requires at least one CRITICAL finding.
+- CONDITIONAL requires at least one MAJOR finding and no CRITICAL findings.
+- APPROVE means only MINOR or no findings.
+- If no real issues are found, emit APPROVE with an empty findings array.
+- If the prompt gives you an output path, write the JSON there.
+- If writing fails, emit ONLY the JSON object as final text.

--- a/platforms/pi/agents/synthesizer.md
+++ b/platforms/pi/agents/synthesizer.md
@@ -1,0 +1,25 @@
+---
+name: synthesizer
+description: Synthesize Signum audit results into a verdict inside pi
+model: sonnet
+tools: [read, grep, find, ls, bash, write]
+---
+
+You are the pi-native Signum synthesizer.
+
+Read deterministic audit artifacts and reviewer outputs, then summarize the result without changing any code.
+Preserve Signum decision semantics: AUTO_OK, AUTO_BLOCK, HUMAN_REVIEW.
+
+When invoked for synthesis, return a strict JSON object with this shape unless the prompt explicitly asks you to write a file:
+
+{
+  "consensus": "short consensus summary",
+  "reasoning": "concise explanation grounded in mechanic results, review verdicts, holdouts, policy scan, and execute evidence",
+  "decision": "AUTO_OK" | "AUTO_BLOCK" | "HUMAN_REVIEW"
+}
+
+Rules:
+- Base your summary on the provided artifacts only.
+- Be explicit about disagreement, missing reviewers, regressions, holdout failures, and policy findings.
+- If you cannot confidently infer a field, emit the safest justified value.
+- Emit ONLY the JSON object when not writing to a file.

--- a/platforms/pi/extensions/signum/args.ts
+++ b/platforms/pi/extensions/signum/args.ts
@@ -1,0 +1,245 @@
+export const SIGNUM_USAGE = [
+  "Usage:",
+  "  /signum explain",
+  "  /signum init [--force] [--harness] [--project-root <path>]",
+  "  /signum archive [contractId]",
+  "  /signum close [contractId]",
+  "  /signum <task>",
+].join("\n")
+
+export type SignumParsedCommand =
+  | { kind: "explain" }
+  | { kind: "init"; force: boolean; harness: boolean; projectRoot?: string }
+  | { kind: "archive"; contractId?: string }
+  | { kind: "close"; contractId?: string }
+  | { kind: "task"; task: string }
+
+export type SignumParseResult =
+  | { ok: true; command: SignumParsedCommand }
+  | { ok: false; message: string }
+
+interface TokenizeResult {
+  ok: boolean
+  tokens?: string[]
+  message?: string
+}
+
+export function parseSignumArgs(rawArgs: string): SignumParseResult {
+  const normalized = rawArgs.trim()
+  if (normalized.length === 0) {
+    return {
+      ok: false,
+      message: `Missing command or task.\n\n${SIGNUM_USAGE}`,
+    }
+  }
+
+  const tokenized = tokenizeArgs(normalized)
+  if (!tokenized.ok || !tokenized.tokens) {
+    return {
+      ok: false,
+      message: `${tokenized.message ?? "Could not parse arguments."}\n\n${SIGNUM_USAGE}`,
+    }
+  }
+
+  const [head, ...tail] = tokenized.tokens
+  const command = head.toLowerCase()
+
+  if (command === "explain") {
+    if (tail.length > 0) {
+      return {
+        ok: false,
+        message: `The explain subcommand does not accept additional arguments.\n\n${SIGNUM_USAGE}`,
+      }
+    }
+    return { ok: true, command: { kind: "explain" } }
+  }
+
+  if (command === "init") {
+    return parseInitArgs(tail)
+  }
+
+  if (command === "archive") {
+    return parseSingleOptionalArgumentCommand("archive", tail)
+  }
+
+  if (command === "close") {
+    return parseSingleOptionalArgumentCommand("close", tail)
+  }
+
+  return {
+    ok: true,
+    command: {
+      kind: "task",
+      task: normalized,
+    },
+  }
+}
+
+function parseSingleOptionalArgumentCommand(
+  command: "archive" | "close",
+  tail: string[],
+): SignumParseResult {
+  if (tail.length > 1) {
+    return {
+      ok: false,
+      message: `Ambiguous ${command} invocation. The ${command} subcommand accepts at most one contractId argument.\n\n${SIGNUM_USAGE}`,
+    }
+  }
+
+  if (tail.length === 1 && !looksLikeContractId(tail[0])) {
+    return {
+      ok: false,
+      message: `Ambiguous ${command} invocation: "${command} ${tail[0]}" does not look like a Signum contract ID. If you meant the ${command} subcommand, pass a contractId like sig-20260314-a1b2. If you meant a task, phrase it without the reserved leading word "${command}".\n\n${SIGNUM_USAGE}`,
+    }
+  }
+
+  return {
+    ok: true,
+    command: {
+      kind: command,
+      contractId: tail[0],
+    },
+  }
+}
+
+function parseInitArgs(tokens: string[]): SignumParseResult {
+  let force = false
+  let harness = false
+  let projectRoot: string | undefined
+
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index]
+
+    if (token === "--force") {
+      if (force) {
+        return {
+          ok: false,
+          message: `Duplicate flag: --force\n\n${SIGNUM_USAGE}`,
+        }
+      }
+      force = true
+      continue
+    }
+
+    if (token === "--harness") {
+      if (harness) {
+        return {
+          ok: false,
+          message: `Duplicate flag: --harness\n\n${SIGNUM_USAGE}`,
+        }
+      }
+      harness = true
+      continue
+    }
+
+    if (token === "--project-root") {
+      if (projectRoot !== undefined) {
+        return {
+          ok: false,
+          message: `Duplicate flag: --project-root\n\n${SIGNUM_USAGE}`,
+        }
+      }
+
+      const value = tokens[index + 1]
+      if (!value || value.startsWith("--")) {
+        return {
+          ok: false,
+          message: `The --project-root flag requires a path value.\n\n${SIGNUM_USAGE}`,
+        }
+      }
+
+      projectRoot = value
+      index++
+      continue
+    }
+
+    if (token.startsWith("--")) {
+      return {
+        ok: false,
+        message: `Unknown init flag: ${token}\n\n${SIGNUM_USAGE}`,
+      }
+    }
+
+    return {
+      ok: false,
+      message: `Unexpected positional argument for init: ${token}\n\n${SIGNUM_USAGE}`,
+    }
+  }
+
+  return {
+    ok: true,
+    command: {
+      kind: "init",
+      force,
+      harness,
+      projectRoot,
+    },
+  }
+}
+
+function looksLikeContractId(value: string): boolean {
+  return /^sig-[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value)
+}
+
+export function tokenizeArgs(input: string): TokenizeResult {
+  const tokens: string[] = []
+  let current = ""
+  let quote: "'" | '"' | null = null
+  let escaping = false
+
+  for (let index = 0; index < input.length; index++) {
+    const char = input[index]
+
+    if (escaping) {
+      current += char
+      escaping = false
+      continue
+    }
+
+    if (char === "\\" && quote !== "'") {
+      escaping = true
+      continue
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = null
+      } else {
+        current += char
+      }
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char
+      continue
+    }
+
+    if (/\s/.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current)
+        current = ""
+      }
+      continue
+    }
+
+    current += char
+  }
+
+  if (escaping) {
+    current += "\\"
+  }
+
+  if (quote) {
+    return {
+      ok: false,
+      message: `Unterminated ${quote === '"' ? "double" : "single"} quote in arguments.`,
+    }
+  }
+
+  if (current.length > 0) {
+    tokens.push(current)
+  }
+
+  return { ok: true, tokens }
+}

--- a/platforms/pi/extensions/signum/index.ts
+++ b/platforms/pi/extensions/signum/index.ts
@@ -1,0 +1,23 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+
+import { runSignumCommand } from "./orchestrator.ts"
+
+export default function signumPiExtension(pi: ExtensionAPI) {
+  pi.registerCommand("signum", {
+    description: "Run Signum inside pi",
+    handler: async (args, ctx) => {
+      const result = await runSignumCommand(pi, args, ctx)
+
+      pi.sendMessage({
+        customType: "signum",
+        content: result.message,
+        display: true,
+        details: {
+          ...result.details,
+          kind: result.kind,
+          timestamp: Date.now(),
+        },
+      })
+    },
+  })
+}

--- a/platforms/pi/extensions/signum/models.ts
+++ b/platforms/pi/extensions/signum/models.ts
@@ -1,0 +1,66 @@
+import type { Model } from "@mariozechner/pi-ai"
+
+export type SignumRole =
+  | "contractor"
+  | "engineer"
+  | "reviewer-semantic"
+  | "reviewer-security"
+  | "reviewer-performance"
+  | "synthesizer"
+  | "init-synthesizer"
+
+export function selectRoleModel(
+  role: SignumRole,
+  options: {
+    currentModel?: Model
+    availableModels: Model[]
+    preferredModelId?: string
+    preferFallback?: boolean
+  },
+): Model | undefined {
+  const available = dedupeModels(options.availableModels)
+  if (available.length === 0) return options.currentModel
+
+  if (options.preferFallback) {
+    return pickFallbackModel(available, options.currentModel, role) ?? options.currentModel ?? available[0]
+  }
+
+  if (options.preferredModelId) {
+    const direct = available.find((model) => model.id === options.preferredModelId)
+    if (direct) return direct
+  }
+
+  if (options.currentModel) {
+    return options.currentModel
+  }
+
+  return pickInitialModel(available, role) ?? available[0]
+}
+
+function dedupeModels(models: Model[]): Model[] {
+  const seen = new Set<string>()
+  const unique: Model[] = []
+  for (const model of models) {
+    const key = `${model.provider}/${model.id}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    unique.push(model)
+  }
+  return unique
+}
+
+function pickInitialModel(models: Model[], role: SignumRole): Model | undefined {
+  if (role === "contractor") {
+    return pickByPatterns(models, [/haiku/i, /mini/i, /flash/i]) ?? pickByPatterns(models, [/sonnet/i, /gpt-5/i, /pro/i])
+  }
+  return pickByPatterns(models, [/sonnet/i, /gpt-5/i, /pro/i, /opus/i]) ?? models[0]
+}
+
+function pickFallbackModel(models: Model[], currentModel: Model | undefined, role: SignumRole): Model | undefined {
+  const candidates = models.filter((model) => !currentModel || `${model.provider}/${model.id}` !== `${currentModel.provider}/${currentModel.id}`)
+  return pickByPatterns(candidates, [/sonnet/i, /gpt-5/i, /pro/i, /opus/i, /thinking/i]) ?? pickInitialModel(candidates, role)
+}
+
+function pickByPatterns(models: Model[], patterns: RegExp[]): Model | undefined {
+  return models.find((model) => patterns.some((pattern) => pattern.test(model.id) || pattern.test(model.name ?? "")))
+}

--- a/platforms/pi/extensions/signum/orchestrator.ts
+++ b/platforms/pi/extensions/signum/orchestrator.ts
@@ -1,0 +1,285 @@
+import { readFile, stat } from "node:fs/promises"
+import { resolve } from "node:path"
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent"
+
+import { parseSignumArgs } from "./args.ts"
+import { runArchivePhase } from "./phases/archive.ts"
+import { runClosePhase } from "./phases/close.ts"
+import { runContractPhase } from "./phases/contract.ts"
+import { runAuditPhase } from "./phases/audit.ts"
+import { runExecutePhase } from "./phases/execute.ts"
+import { runExplainPhase } from "./phases/explain.ts"
+import { runInitPhase } from "./phases/init.ts"
+import { runPackPhase } from "./phases/pack.ts"
+import { clearWorkingSet, detectRunState } from "./state.ts"
+import { promptResumeDecision, setSignumStatus } from "./ui.ts"
+
+export interface SignumCommandResult {
+  kind: string
+  message: string
+  details?: Record<string, unknown>
+}
+
+interface PipelineRunResult {
+  summary: string
+  executeStatus: string
+  auditDecision?: string
+  packDecision?: string
+}
+
+export async function runSignumCommand(
+  pi: ExtensionAPI,
+  rawArgs: string,
+  ctx: ExtensionCommandContext,
+): Promise<SignumCommandResult> {
+  const parsed = parseSignumArgs(rawArgs)
+  if (!parsed.ok) {
+    return {
+      kind: "error",
+      message: parsed.message,
+    }
+  }
+
+  try {
+    switch (parsed.command.kind) {
+      case "explain": {
+        setSignumStatus(ctx, "explain")
+        const message = await runExplainPhase()
+        return {
+          kind: "explain",
+          message,
+        }
+      }
+
+      case "init": {
+        const projectRoot = parsed.command.projectRoot ?? ctx.cwd
+        setSignumStatus(ctx, `init ${projectRoot}`)
+        const message = await runInitPhase(pi, ctx, parsed.command)
+        return {
+          kind: "init",
+          message,
+          details: {
+            projectRoot,
+            force: parsed.command.force,
+            harness: parsed.command.harness,
+          },
+        }
+      }
+
+      case "archive": {
+        setSignumStatus(ctx, "archive")
+        const message = await runArchivePhase(ctx.cwd, parsed.command.contractId)
+        return {
+          kind: "archive",
+          message,
+          details: {
+            contractId: parsed.command.contractId,
+          },
+        }
+      }
+
+      case "close": {
+        setSignumStatus(ctx, "close")
+        const message = await runClosePhase(ctx.cwd, parsed.command.contractId)
+        return {
+          kind: "close",
+          message,
+          details: {
+            contractId: parsed.command.contractId,
+          },
+        }
+      }
+
+      case "task": {
+        setSignumStatus(ctx, "task preflight")
+        const runState = await detectRunState(ctx.cwd)
+
+        if (runState.kind !== "none") {
+          if (!ctx.hasUI) {
+            return {
+              kind: "task",
+              message: [
+                `Detected run state: ${runState.kind}`,
+                "Interactive pi is required to choose resume, restart, or cancel.",
+                "Existing .signum working set left unchanged.",
+              ].join("\n"),
+              details: {
+                task: parsed.command.task,
+                runState: runState.kind,
+                decision: "interactive-required",
+              },
+            }
+          }
+
+          const decision = await promptResumeDecision(ctx, runState)
+          if (decision === "cancel") {
+            return {
+              kind: "task",
+              message: "Cancelled. Existing .signum working set left unchanged.",
+              details: {
+                task: parsed.command.task,
+                runState: runState.kind,
+                decision,
+              },
+            }
+          }
+
+          if (decision === "restart") {
+            const cleared = await clearWorkingSet(ctx.cwd)
+            const contractResult = await runContractPhase(pi, ctx, { task: parsed.command.task })
+            if (contractResult.status !== "approved") {
+              return {
+                kind: "task",
+                message: [
+                  `Restart selected for task: ${parsed.command.task}`,
+                  `Cleared ${cleared.removedPaths.length} working-set path(s).`,
+                  cleared.clearedActiveContract ? "Cleared activeContractId in .signum/contracts/index.json." : "",
+                  "",
+                  contractResult.summary,
+                ]
+                  .filter((line) => line.length > 0)
+                  .join("\n"),
+                details: {
+                  task: parsed.command.task,
+                  runState: runState.kind,
+                  decision,
+                  removedPaths: cleared.removedPaths,
+                  contractId: contractResult.contractId,
+                  contractStatus: contractResult.status,
+                },
+              }
+            }
+
+            const pipelineResult = await runPipelineFromCurrentState(pi, ctx)
+            return {
+              kind: "task",
+              message: [
+                `Restart selected for task: ${parsed.command.task}`,
+                `Cleared ${cleared.removedPaths.length} working-set path(s).`,
+                cleared.clearedActiveContract ? "Cleared activeContractId in .signum/contracts/index.json." : "",
+                "",
+                contractResult.summary,
+                "",
+                pipelineResult.summary,
+              ]
+                .filter((line) => line.length > 0)
+                .join("\n"),
+              details: {
+                task: parsed.command.task,
+                runState: runState.kind,
+                decision,
+                removedPaths: cleared.removedPaths,
+                contractId: contractResult.contractId,
+                contractStatus: contractResult.status,
+                executeStatus: pipelineResult.executeStatus,
+                auditDecision: pipelineResult.auditDecision,
+                packDecision: pipelineResult.packDecision,
+              },
+            }
+          }
+
+          const pipelineResult = await runPipelineFromCurrentState(pi, ctx)
+          return {
+            kind: "task",
+            message: [
+              `Resume selected for task: ${parsed.command.task}`,
+              `Detected run state: ${runState.kind}`,
+              pipelineResult.summary,
+            ].join("\n"),
+            details: {
+              task: parsed.command.task,
+              runState: runState.kind,
+              decision,
+              executeStatus: pipelineResult.executeStatus,
+              auditDecision: pipelineResult.auditDecision,
+              packDecision: pipelineResult.packDecision,
+            },
+          }
+        }
+
+        const contractResult = await runContractPhase(pi, ctx, { task: parsed.command.task })
+        if (contractResult.status !== "approved") {
+          return {
+            kind: "task",
+            message: contractResult.summary,
+            details: {
+              task: parsed.command.task,
+              runState: "none",
+              contractId: contractResult.contractId,
+              contractStatus: contractResult.status,
+            },
+          }
+        }
+
+        const pipelineResult = await runPipelineFromCurrentState(pi, ctx)
+        return {
+          kind: "task",
+          message: [contractResult.summary, "", pipelineResult.summary].join("\n"),
+          details: {
+            task: parsed.command.task,
+            runState: "none",
+            contractId: contractResult.contractId,
+            contractStatus: contractResult.status,
+            executeStatus: pipelineResult.executeStatus,
+            auditDecision: pipelineResult.auditDecision,
+            packDecision: pipelineResult.packDecision,
+          },
+        }
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      kind: "error",
+      message: `Signum for pi failed: ${message}`,
+    }
+  } finally {
+    setSignumStatus(ctx, undefined)
+  }
+}
+
+async function runPipelineFromCurrentState(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+): Promise<PipelineRunResult> {
+  const projectRoot = ctx.cwd
+  const hasSuccessfulExecute = await readExecuteSuccess(projectRoot)
+
+  const executeResult = hasSuccessfulExecute
+    ? { status: "success" as const, summary: "EXECUTE already completed earlier in this working set. Reusing existing artifacts." }
+    : await runExecutePhase(pi, ctx)
+
+  if (executeResult.status !== "success") {
+    return {
+      summary: executeResult.summary,
+      executeStatus: executeResult.status,
+    }
+  }
+
+  const auditResult = await runAuditPhase(pi, ctx)
+  if (auditResult.status !== "ok" || !auditResult.decision) {
+    return {
+      summary: [executeResult.summary, "", auditResult.summary].join("\n"),
+      executeStatus: executeResult.status,
+    }
+  }
+
+  const packResult = await runPackPhase(pi, ctx)
+  return {
+    summary: [executeResult.summary, "", auditResult.summary, "", packResult.summary].join("\n"),
+    executeStatus: executeResult.status,
+    auditDecision: auditResult.decision,
+    packDecision: packResult.decision,
+  }
+}
+
+async function readExecuteSuccess(projectRoot: string): Promise<boolean> {
+  try {
+    await stat(resolve(projectRoot, ".signum/receipts/execute.json"))
+    const parsed = JSON.parse(await readFile(resolve(projectRoot, ".signum/execute_log.json"), "utf8")) as { status?: string }
+    return parsed.status === "SUCCESS"
+  } catch {
+    return false
+  }
+}

--- a/platforms/pi/extensions/signum/paths.ts
+++ b/platforms/pi/extensions/signum/paths.ts
@@ -1,0 +1,27 @@
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const moduleDir = dirname(fileURLToPath(import.meta.url))
+
+export const signumPackageRoot = resolve(moduleDir, "../../../../")
+export const packageJsonPath = resolve(signumPackageRoot, "package.json")
+export const piAgentsRoot = resolve(signumPackageRoot, "platforms/pi/agents")
+export const initSynthesizerPromptPath = resolve(signumPackageRoot, "agents/init-synthesizer.md")
+export const initScannerScriptPath = resolve(signumPackageRoot, "lib/init-scanner.sh")
+export const initHarnessScaffoldScriptPath = resolve(signumPackageRoot, "lib/init-harness-scaffold.sh")
+export const contractInjectionScanScriptPath = resolve(signumPackageRoot, "lib/contract-injection-scan.sh")
+export const glossaryCheckScriptPath = resolve(signumPackageRoot, "lib/glossary-check.sh")
+export const terminologyCheckScriptPath = resolve(signumPackageRoot, "lib/terminology-check.sh")
+export const overlapCheckScriptPath = resolve(signumPackageRoot, "lib/overlap-check.sh")
+export const assumptionCheckScriptPath = resolve(signumPackageRoot, "lib/assumption-check.sh")
+export const adrCheckScriptPath = resolve(signumPackageRoot, "lib/adr-check.sh")
+export const proseCheckScriptPath = resolve(signumPackageRoot, "lib/prose-check.sh")
+export const stalenessCheckScriptPath = resolve(signumPackageRoot, "lib/staleness-check.sh")
+export const dslRunnerScriptPath = resolve(signumPackageRoot, "lib/dsl-runner.sh")
+export const mechanicParserScriptPath = resolve(signumPackageRoot, "lib/mechanic-parser.sh")
+export const policyScannerScriptPath = resolve(signumPackageRoot, "lib/policy-scanner.sh")
+export const snapshotTreeScriptPath = resolve(signumPackageRoot, "lib/snapshot-tree.sh")
+export const boundaryVerifierScriptPath = resolve(signumPackageRoot, "lib/boundary-verifier.sh")
+export const transitionVerifierScriptPath = resolve(signumPackageRoot, "lib/transition-verifier.sh")
+export const packAntiEntropyScriptPath = resolve(signumPackageRoot, "lib/pack-anti-entropy.sh")
+export const proofpackIndexScriptPath = resolve(signumPackageRoot, "lib/proofpack-index.sh")

--- a/platforms/pi/extensions/signum/phases/archive.ts
+++ b/platforms/pi/extensions/signum/phases/archive.ts
@@ -1,0 +1,96 @@
+import { copyFile, lstat, mkdir, readFile, rm } from "node:fs/promises"
+import { resolve } from "node:path"
+
+import {
+  archiveDirPath,
+  contractDirPath,
+  readContractIndex,
+  resolveContractId,
+  setContractTimestampField,
+  updateContractStatus,
+  writeContractIndex,
+} from "../runtime/script-adapters/contract-dir.ts"
+
+const ARCHIVE_KEEP_FILES = ["contract.json", "proofpack.json", "approval.json", "audit_summary.json"]
+const ARCHIVE_PURGE_FILES = [
+  "baseline.json",
+  "execute_log.json",
+  "holdout_report.json",
+  "mechanic_report.json",
+  "combined.patch",
+  "iteration_delta.patch",
+  "contract-engineer.json",
+  "contract-policy.json",
+  "policy_violations.json",
+  "spec_quality.json",
+  "spec_validation.json",
+  "clover_report.json",
+  "contract-hash.txt",
+  "execution_context.json",
+  "review_prompt_codex.txt",
+  "review_prompt_gemini.txt",
+  "intent_check.json",
+  "audit_iteration_log.json",
+  "repair_brief.json",
+  "flaky_tests.json",
+  "policy_scan.json",
+]
+const ARCHIVE_PURGE_DIRS = ["reviews", "iterations", "receipts", "runs", "snapshots"]
+
+export async function runArchivePhase(projectRoot: string, requestedContractId?: string): Promise<string> {
+  const index = await readContractIndex(projectRoot)
+  const contractId = resolveContractId(index, requestedContractId)
+  const contractPath = contractDirPath(projectRoot, contractId)
+  const archivePath = archiveDirPath(projectRoot, contractId)
+
+  try {
+    const stat = await lstat(contractPath)
+    if (!stat.isDirectory()) {
+      throw new Error()
+    }
+  } catch {
+    throw new Error(`Contract directory not found: .signum/contracts/${contractId}/`)
+  }
+
+  await mkdir(archivePath, { recursive: true })
+
+  for (const file of ARCHIVE_KEEP_FILES) {
+    await copyIfExists(resolve(contractPath, file), resolve(archivePath, file))
+  }
+  await copyIfExists(resolve(contractPath, "receipts", "execute.json"), resolve(archivePath, "execute.json"))
+
+  for (const directory of ARCHIVE_PURGE_DIRS) {
+    await rm(resolve(contractPath, directory), { force: true, recursive: true })
+  }
+  for (const file of ARCHIVE_PURGE_FILES) {
+    await rm(resolve(contractPath, file), { force: true, recursive: false })
+  }
+
+  const archivedAt = toUtcTimestamp()
+  const nextIndex = setContractTimestampField(
+    updateContractStatus(index, contractId, "archived"),
+    contractId,
+    "archivedAt",
+    archivedAt,
+  )
+  await writeContractIndex(projectRoot, nextIndex)
+
+  return [
+    `Archived: ${contractId} → .signum/archive/${contractId}/`,
+    "Kept: contract.json, proofpack.json, approval.json, audit_summary.json, execute.json",
+    "Purged: intermediates (reviews, baseline, patches, prompts)",
+  ].join("\n")
+}
+
+function toUtcTimestamp(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z")
+}
+
+async function copyIfExists(source: string, destination: string) {
+  try {
+    await readFile(source)
+    await copyFile(source, destination)
+  } catch {
+    // ignore missing optional artifacts
+  }
+}

--- a/platforms/pi/extensions/signum/phases/audit.ts
+++ b/platforms/pi/extensions/signum/phases/audit.ts
@@ -1,0 +1,816 @@
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { createHash } from "node:crypto"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent"
+import type { Model } from "@mariozechner/pi-ai"
+
+import { dslRunnerScriptPath, mechanicParserScriptPath, policyScannerScriptPath } from "../paths.ts"
+import { selectRoleModel, type SignumRole } from "../models.ts"
+import { loadRolePromptAsset, SdkRoleSessionRunner } from "../runtime/role-session.ts"
+import { toUtcTimestamp } from "../runtime/script-adapters/checks.ts"
+import { setSignumStatus } from "../ui.ts"
+
+interface ContractDocument {
+  contractId: string
+  riskLevel: "low" | "medium" | "high"
+  goal: string
+  acceptanceCriteria: Array<{ id: string; visibility?: string; description?: string; verify?: unknown }>
+  holdoutScenarios?: Array<{ id?: string; description?: string; verify?: unknown }>
+}
+
+interface MechanicReport {
+  checks?: Array<{ status?: string; regression?: boolean }>
+  hasRegressions?: boolean
+}
+
+interface PolicyScanReport {
+  summaryCounts?: { critical?: number; major?: number; minor?: number; total?: number }
+}
+
+interface HoldoutReport {
+  total: number
+  passed: number
+  failed: number
+  errors: number
+  results: Array<{ id: string; description?: string; status: string; error?: string | null }>
+}
+
+interface ExecuteLog {
+  totalAttempts?: number
+}
+
+interface ExecuteReceipt {
+  status?: string
+  summary?: { total_acs?: number; passed_acs?: number }
+}
+
+interface ReviewFinding {
+  file: string
+  line: number
+  severity: "CRITICAL" | "MAJOR" | "MINOR"
+  category: string
+  comment: string
+  evidence: string
+  confirmedBy?: string[]
+  fingerprint?: string
+}
+
+interface ReviewDocument {
+  verdict: "APPROVE" | "REJECT" | "CONDITIONAL" | "UNAVAILABLE"
+  reviewedFiles: string[]
+  findings: ReviewFinding[]
+  summary: string
+  parseOk: boolean
+  available: boolean
+  role?: string
+  model?: string
+  raw?: string
+}
+
+interface ReviewRolePlan {
+  role: Extract<SignumRole, "reviewer-semantic" | "reviewer-security" | "reviewer-performance">
+  providerKey: "claude" | "codex" | "gemini"
+  outputPath: string
+  model?: Model
+}
+
+export interface AuditPhaseResult {
+  status: "ok" | "failed"
+  decision?: "AUTO_OK" | "AUTO_BLOCK" | "HUMAN_REVIEW"
+  summary: string
+}
+
+export async function runAuditPhase(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+): Promise<AuditPhaseResult> {
+  const projectRoot = ctx.cwd
+  const contract = await readJson<ContractDocument>(resolve(projectRoot, ".signum/contract.json"))
+  await readJson(resolve(projectRoot, ".signum/contract-engineer.json"))
+
+  setSignumStatus(ctx, "audit mechanic")
+  await mkdir(resolve(projectRoot, ".signum", "reviews"), { recursive: true })
+  await runRequiredScript(pi, projectRoot, mechanicParserScriptPath, [".signum/baseline.json"], "mechanic parser")
+
+  setSignumStatus(ctx, "audit policy")
+  await runScriptAllowFailure(pi, projectRoot, policyScannerScriptPath, [".signum/combined.patch"])
+
+  setSignumStatus(ctx, "audit holdout")
+  const holdoutReport = await runHoldoutValidation(pi, projectRoot, contract)
+
+  setSignumStatus(ctx, "audit review context")
+  await writeReviewContext(pi, projectRoot)
+
+  const runner = new SdkRoleSessionRunner()
+  const availableModels = await ctx.modelRegistry.getAvailable()
+  const semanticPrompt = await loadRolePromptAsset("reviewer-semantic")
+  const semanticModel = selectRoleModel("reviewer-semantic", {
+    currentModel: ctx.model,
+    availableModels,
+    preferredModelId: semanticPrompt.preferredModelId,
+  })
+  if (!semanticModel) {
+    throw new Error("No authenticated model available for semantic reviewer")
+  }
+
+  const reviewPlans = buildReviewPlan(contract.riskLevel, availableModels, semanticModel)
+  const reviewResults: Array<Promise<{ providerKey: ReviewRolePlan["providerKey"]; review: ReviewDocument }>> = []
+
+  for (const plan of reviewPlans) {
+    const absoluteOutputPath = resolve(projectRoot, plan.outputPath)
+    if (!plan.model) {
+      await writeJson(absoluteOutputPath, unavailableReview(plan.providerKey, "No distinct reviewer model available in the current pi runtime."))
+      continue
+    }
+
+    const prompt = buildReviewerPrompt(plan.providerKey, plan.outputPath)
+    reviewResults.push(
+      runner
+        .run({
+          role: plan.role,
+          projectRoot,
+          prompt,
+          model: plan.model,
+        })
+        .then(async (result) => ({
+          providerKey: plan.providerKey,
+          review: await finalizeReviewArtifact(plan.providerKey, absoluteOutputPath, result.finalText, `${result.model}`),
+        })),
+    )
+  }
+
+  const completedReviews = await Promise.all(reviewResults)
+  for (const completed of completedReviews) {
+    await writeJson(resolve(projectRoot, ".signum", "reviews", `${completed.providerKey}.json`), completed.review)
+  }
+
+  for (const providerKey of ["claude", "codex", "gemini"] as const) {
+    const reviewPath = resolve(projectRoot, ".signum", "reviews", `${providerKey}.json`)
+    if (!(await exists(reviewPath))) {
+      await writeJson(reviewPath, unavailableReview(providerKey, `${providerKey} reviewer was not launched for this risk profile.`))
+    }
+  }
+
+  const reviews = {
+    claude: await readJson<ReviewDocument>(resolve(projectRoot, ".signum/reviews/claude.json")),
+    codex: await readJson<ReviewDocument>(resolve(projectRoot, ".signum/reviews/codex.json")),
+    gemini: await readJson<ReviewDocument>(resolve(projectRoot, ".signum/reviews/gemini.json")),
+  }
+  const mechanic = await readJson<MechanicReport>(resolve(projectRoot, ".signum/mechanic_report.json"))
+  const policyScan = await readJson<PolicyScanReport>(resolve(projectRoot, ".signum/policy_scan.json"))
+  const executeLog = await readJson<ExecuteLog>(resolve(projectRoot, ".signum/execute_log.json"))
+  const executeReceipt = await readOptionalJson<ExecuteReceipt>(resolve(projectRoot, ".signum/receipts/execute.json"))
+
+  setSignumStatus(ctx, "audit synthesize")
+  const synthOpinion = await runSynthesizer(runner, ctx, projectRoot)
+  const auditSummary = buildAuditSummary({
+    contract,
+    mechanic,
+    policyScan,
+    holdout: holdoutReport,
+    executeLog,
+    executeReceipt,
+    reviews,
+    synthOpinion,
+  })
+
+  await writeJson(resolve(projectRoot, ".signum/audit_summary.json"), auditSummary)
+
+  return {
+    status: "ok",
+    decision: auditSummary.decision,
+    summary: [
+      `AUDIT complete: ${auditSummary.decision}`,
+      `Mechanic: ${auditSummary.mechanic}`,
+      `Available reviews: ${auditSummary.availableReviews}/3`,
+      `Consensus: ${auditSummary.consensus}`,
+      `Confidence: ${auditSummary.confidence.overall}%`,
+      `Reasoning: ${auditSummary.reasoning}`,
+    ].join("\n"),
+  }
+}
+
+function buildReviewPlan(riskLevel: ContractDocument["riskLevel"], availableModels: Model[], semanticModel: Model): ReviewRolePlan[] {
+  const projectReviews: ReviewRolePlan[] = [
+    {
+      role: "reviewer-semantic",
+      providerKey: "claude",
+      outputPath: ".signum/reviews/claude.json",
+      model: semanticModel,
+    },
+  ]
+
+  if (riskLevel === "low") {
+    projectReviews.push(
+      { role: "reviewer-security", providerKey: "codex", outputPath: ".signum/reviews/codex.json" },
+      { role: "reviewer-performance", providerKey: "gemini", outputPath: ".signum/reviews/gemini.json" },
+    )
+    return projectReviews
+  }
+
+  const securityModel = pickAdditionalReviewerModel(availableModels, [semanticModel], [/gpt-5/i, /gpt/i, /sonnet/i, /opus/i, /pro/i, /gemini/i])
+  const performanceModel = pickAdditionalReviewerModel(
+    availableModels,
+    [semanticModel, securityModel].filter(Boolean) as Model[],
+    [/gemini/i, /flash/i, /pro/i, /gpt/i, /sonnet/i, /opus/i],
+  )
+
+  projectReviews.push(
+    {
+      role: "reviewer-security",
+      providerKey: "codex",
+      outputPath: ".signum/reviews/codex.json",
+      model: securityModel,
+    },
+    {
+      role: "reviewer-performance",
+      providerKey: "gemini",
+      outputPath: ".signum/reviews/gemini.json",
+      model: performanceModel,
+    },
+  )
+
+  return projectReviews
+}
+
+function pickAdditionalReviewerModel(models: Model[], used: Model[], preferredPatterns: RegExp[]): Model | undefined {
+  const usedKeys = new Set(used.map((model) => `${model.provider}/${model.id}`))
+  const usedProviders = new Set(used.map((model) => model.provider))
+  const candidates = models.filter((model) => !usedKeys.has(`${model.provider}/${model.id}`))
+  const differentProvider = candidates.filter((model) => !usedProviders.has(model.provider))
+  return (
+    pickByPatterns(differentProvider, preferredPatterns) ??
+    pickByPatterns(candidates, preferredPatterns) ??
+    differentProvider[0] ??
+    candidates[0]
+  )
+}
+
+function pickByPatterns(models: Model[], patterns: RegExp[]): Model | undefined {
+  return models.find((model) => patterns.some((pattern) => pattern.test(model.id) || pattern.test(model.name ?? "")))
+}
+
+function buildReviewerPrompt(providerKey: "claude" | "codex" | "gemini", outputPath: string): string {
+  const focus =
+    providerKey === "claude"
+      ? "semantic correctness, requirement coverage, and regressions"
+      : providerKey === "codex"
+        ? "security-sensitive defects only"
+        : "performance-sensitive defects only"
+
+  return [
+    "Read .signum/contract.json, .signum/combined.patch, .signum/mechanic_report.json, and .signum/review_context.json.",
+    "Also read .signum/policy_scan.json if it exists for extra context, but do not duplicate deterministic scanner findings unless the patch evidence supports them.",
+    `Focus on ${focus}.`,
+    `Write a strict JSON review object to ${outputPath}.`,
+    "If file writing fails, emit ONLY the JSON object as final text.",
+    "Do not emit markdown fences or explanatory prose outside the JSON object.",
+  ].join("\n")
+}
+
+async function finalizeReviewArtifact(
+  providerKey: "claude" | "codex" | "gemini",
+  outputPath: string,
+  finalText: string,
+  model: string,
+): Promise<ReviewDocument> {
+  const onDisk = await readOptionalJson<Record<string, unknown>>(outputPath)
+  const candidate = onDisk ?? extractJsonObject(finalText)
+  if (!candidate) {
+    return parseFailureReview(providerKey, "Reviewer did not produce a parseable JSON object.", finalText, model)
+  }
+
+  const normalized = normalizeReviewDocument(candidate, providerKey, model)
+  await writeJson(outputPath, normalized)
+  return normalized
+}
+
+function normalizeReviewDocument(raw: Record<string, unknown>, providerKey: string, model: string): ReviewDocument {
+  const verdict = normalizeVerdict(raw.verdict)
+  const findings = Array.isArray(raw.findings) ? raw.findings.map(normalizeFinding).filter(Boolean) as ReviewFinding[] : []
+  const reviewedFiles = Array.isArray(raw.reviewedFiles)
+    ? raw.reviewedFiles.filter((value): value is string => typeof value === "string" && value.length > 0)
+    : []
+
+  return {
+    verdict,
+    reviewedFiles,
+    findings,
+    summary: typeof raw.summary === "string" && raw.summary.trim().length > 0 ? raw.summary.trim() : `${providerKey} review completed`,
+    parseOk: verdict !== "UNAVAILABLE",
+    available: raw.available === false ? false : verdict !== "UNAVAILABLE",
+    role: providerKey,
+    model,
+  }
+}
+
+function normalizeFinding(raw: unknown): ReviewFinding | undefined {
+  if (!raw || typeof raw !== "object") return undefined
+  const record = raw as Record<string, unknown>
+  const severity = normalizeSeverity(record.severity)
+  return {
+    file: typeof record.file === "string" ? record.file : "",
+    line: typeof record.line === "number" ? record.line : Number(record.line ?? 0) || 0,
+    severity,
+    category: typeof record.category === "string" && record.category.trim().length > 0 ? record.category.trim() : "review",
+    comment: typeof record.comment === "string" ? record.comment.trim() : "",
+    evidence: typeof record.evidence === "string" ? record.evidence.trim() : "",
+  }
+}
+
+function normalizeVerdict(value: unknown): ReviewDocument["verdict"] {
+  const normalized = typeof value === "string" ? value.trim().toUpperCase() : ""
+  if (normalized === "APPROVE" || normalized === "REJECT" || normalized === "CONDITIONAL" || normalized === "UNAVAILABLE") {
+    return normalized
+  }
+  return "CONDITIONAL"
+}
+
+function normalizeSeverity(value: unknown): ReviewFinding["severity"] {
+  const normalized = typeof value === "string" ? value.trim().toUpperCase() : ""
+  if (normalized === "CRITICAL" || normalized === "MAJOR" || normalized === "MINOR") {
+    return normalized
+  }
+  return "MINOR"
+}
+
+function unavailableReview(providerKey: string, summary: string): ReviewDocument {
+  return {
+    verdict: "UNAVAILABLE",
+    reviewedFiles: [],
+    findings: [],
+    summary,
+    parseOk: false,
+    available: false,
+    role: providerKey,
+  }
+}
+
+function parseFailureReview(providerKey: string, summary: string, raw: string, model: string): ReviewDocument {
+  return {
+    verdict: "CONDITIONAL",
+    reviewedFiles: [],
+    findings: [],
+    summary,
+    parseOk: false,
+    available: true,
+    role: providerKey,
+    model,
+    raw: raw.trim().slice(0, 2000),
+  }
+}
+
+async function runHoldoutValidation(pi: ExtensionAPI, projectRoot: string, contract: ContractDocument): Promise<HoldoutReport> {
+  if (contract.riskLevel === "low") {
+    const empty = { total: 0, passed: 0, failed: 0, errors: 0, results: [] }
+    await writeJson(resolve(projectRoot, ".signum/holdout_report.json"), empty)
+    return empty
+  }
+
+  const results: HoldoutReport["results"] = []
+  let passed = 0
+  let failed = 0
+  let errors = 0
+
+  const holdoutAcs = contract.acceptanceCriteria.filter((criterion) => (criterion.visibility ?? "visible") === "holdout")
+  for (const criterion of holdoutAcs) {
+    const result = await runSingleHoldout(pi, projectRoot, criterion.id, criterion.description ?? criterion.id, criterion.verify)
+    results.push(result)
+    if (result.status === "PASS") passed += 1
+    else if (result.status === "FAIL") failed += 1
+    else errors += 1
+  }
+
+  for (const [index, scenario] of (contract.holdoutScenarios ?? []).entries()) {
+    const result = await runSingleHoldout(
+      pi,
+      projectRoot,
+      scenario.id ?? `HO${index + 1}`,
+      scenario.description ?? `Holdout ${index + 1}`,
+      scenario.verify,
+    )
+    results.push(result)
+    if (result.status === "PASS") passed += 1
+    else if (result.status === "FAIL") failed += 1
+    else errors += 1
+  }
+
+  const report: HoldoutReport = {
+    total: results.length,
+    passed,
+    failed,
+    errors,
+    results,
+  }
+  await writeJson(resolve(projectRoot, ".signum/holdout_report.json"), report)
+  return report
+}
+
+async function runSingleHoldout(
+  pi: ExtensionAPI,
+  projectRoot: string,
+  id: string,
+  description: string,
+  verify: unknown,
+): Promise<HoldoutReport["results"][number]> {
+  const tempDir = await mkdtemp(join(tmpdir(), "signum-holdout-"))
+  const verifyPath = join(tempDir, `${id}.json`)
+
+  try {
+    await writeFile(verifyPath, `${JSON.stringify(verify ?? null, null, 2)}\n`, "utf8")
+    const validate = await pi.exec("bash", [dslRunnerScriptPath, "validate", verifyPath], {
+      cwd: projectRoot,
+      timeout: 30_000,
+    })
+    if (validate.code !== 0) {
+      return { id, description, status: "ERROR", error: "DSL validation failed" }
+    }
+
+    const run = await pi.exec("bash", [dslRunnerScriptPath, "run", verifyPath], {
+      cwd: projectRoot,
+      timeout: 60_000,
+    })
+    const parsed = extractJsonObject(run.stdout) ?? extractJsonObject(run.stderr)
+    const status = typeof parsed?.status === "string" ? parsed.status.toUpperCase() : run.code === 0 ? "PASS" : "ERROR"
+    return {
+      id,
+      description,
+      status: status === "PASS" || status === "FAIL" ? status : "ERROR",
+      error: typeof parsed?.error === "string" && parsed.error.length > 0 ? parsed.error : null,
+    }
+  } finally {
+    await rm(tempDir, { recursive: true, force: true })
+  }
+}
+
+async function writeReviewContext(pi: ExtensionAPI, projectRoot: string) {
+  const patch = await safeRead(resolve(projectRoot, ".signum/combined.patch"))
+  const changedFiles = [...new Set([...patch.matchAll(/^\+\+\+\s+[bw]\/([^\n]+)$/gm)].map((match) => match[1]).filter(Boolean))]
+
+  const gitHistory: Array<{ file: string; last_commit_sha: string; subject: string; date: string }> = []
+  for (const file of changedFiles) {
+    const result = await pi.exec("git", ["log", "-1", "--format=%h\x1f%s\x1f%ad", "--date=short", "--", file], {
+      cwd: projectRoot,
+      timeout: 10_000,
+    })
+    const line = result.stdout.trim()
+    if (!line) {
+      gitHistory.push({ file, last_commit_sha: "", subject: "", date: "" })
+      continue
+    }
+    const [sha = "", subject = "", date = ""] = line.split("\x1f")
+    gitHistory.push({ file, last_commit_sha: sha, subject, date })
+  }
+
+  const issueRefs = [...new Set(gitHistory.flatMap((entry) => [...entry.subject.matchAll(/#(\d+)/g)].map((match) => match[1])))]
+    .map((id) => ({ id, title_or_null: null, tracker: "unknown" }))
+
+  const projectIntent = await readOptionalText(resolve(projectRoot, "project.intent.md"))
+  await writeJson(resolve(projectRoot, ".signum/review_context.json"), {
+    git_history: gitHistory,
+    issue_refs: issueRefs,
+    project_intent: projectIntent ?? null,
+  })
+}
+
+async function runSynthesizer(runner: SdkRoleSessionRunner, ctx: ExtensionCommandContext, projectRoot: string) {
+  const promptAsset = await loadRolePromptAsset("synthesizer")
+  const availableModels = await ctx.modelRegistry.getAvailable()
+  const model = selectRoleModel("synthesizer", {
+    currentModel: ctx.model,
+    availableModels,
+    preferredModelId: promptAsset.preferredModelId,
+  })
+  if (!model) return null
+
+  const run = await runner.run({
+    role: "synthesizer",
+    projectRoot,
+    model,
+    prompt: [
+      "Read .signum/contract.json, .signum/mechanic_report.json, .signum/policy_scan.json, .signum/reviews/claude.json, .signum/reviews/codex.json, .signum/reviews/gemini.json, .signum/holdout_report.json, .signum/execute_log.json, and .signum/receipts/execute.json if it exists.",
+      "Return ONLY a JSON object with keys consensus, reasoning, and decision.",
+      "Do not write files for this step.",
+    ].join("\n"),
+  })
+
+  return extractJsonObject(run.finalText)
+}
+
+function buildAuditSummary(input: {
+  contract: ContractDocument
+  mechanic: MechanicReport
+  policyScan: PolicyScanReport
+  holdout: HoldoutReport
+  executeLog: ExecuteLog
+  executeReceipt: ExecuteReceipt | null
+  reviews: { claude: ReviewDocument; codex: ReviewDocument; gemini: ReviewDocument }
+  synthOpinion: Record<string, unknown> | null
+}) {
+  const { contract, mechanic, policyScan, holdout, executeLog, executeReceipt, reviews, synthOpinion } = input
+  const reviewEntries = Object.entries(reviews) as Array<[keyof typeof reviews, ReviewDocument]>
+  const parsedReviews = reviewEntries.filter(([, review]) => review.parseOk && review.available)
+  const approveCount = parsedReviews.filter(([, review]) => review.verdict === "APPROVE").length
+  const rejectCount = parsedReviews.filter(([, review]) => review.verdict === "REJECT").length
+  const conditionalCount = parsedReviews.filter(([, review]) => review.verdict === "CONDITIONAL").length
+  const unavailableCount = reviewEntries.filter(([, review]) => !review.available).length
+  const parseErrorCount = reviewEntries.filter(([, review]) => review.available && !review.parseOk).length
+
+  const allFindings = reviewEntries.flatMap(([provider, review]) =>
+    review.findings.map((finding) => ({
+      ...finding,
+      confirmedBy: [provider],
+      fingerprint: createFindingFingerprint(finding),
+    })),
+  )
+  const criticalCount = allFindings.filter((finding) => finding.severity === "CRITICAL").length
+  const majorCount = allFindings.filter((finding) => finding.severity === "MAJOR").length
+  const minorCount = allFindings.filter((finding) => finding.severity === "MINOR").length
+  const policyCritical = policyScan.summaryCounts?.critical ?? 0
+  const mechanicRegression = Boolean(mechanic.hasRegressions)
+  const holdoutClean = holdout.failed === 0 && holdout.errors === 0
+  const receiptPass = executeReceipt?.status === "PASS"
+
+  const missingOrFailedReviewers = reviewEntries
+    .filter(([, review]) => !(review.parseOk && review.available))
+    .map(([, review]) => review)
+  const mediumGateGraceful = parsedReviews.length >= 1 && missingOrFailedReviewers.every((review) => review.available === false)
+  const reviewGateSatisfied =
+    contract.riskLevel === "low"
+      ? parsedReviews.length >= 1
+      : contract.riskLevel === "medium"
+        ? parsedReviews.length >= 2 || mediumGateGraceful
+        : parsedReviews.length >= 2
+
+  const blockReasons: string[] = []
+  if (!receiptPass) blockReasons.push("execute receipt is missing or not PASS")
+  if (mechanicRegression) blockReasons.push("mechanic detected new regressions versus baseline")
+  if (rejectCount > 0) blockReasons.push("at least one reviewer rejected the change")
+  if (criticalCount > 0) blockReasons.push("critical reviewer finding present")
+  if (policyCritical > 0) blockReasons.push("policy scan found critical issues")
+
+  let decision: "AUTO_OK" | "AUTO_BLOCK" | "HUMAN_REVIEW" = "HUMAN_REVIEW"
+  if (blockReasons.length > 0) {
+    decision = "AUTO_BLOCK"
+  } else if (
+    reviewGateSatisfied &&
+    parsedReviews.every(([, review]) => review.verdict === "APPROVE") &&
+    majorCount === 0 &&
+    criticalCount === 0 &&
+    !mechanicRegression &&
+    holdoutClean &&
+    receiptPass
+  ) {
+    decision = "AUTO_OK"
+  }
+
+  const executionHealth = computeExecutionHealth(executeReceipt, executeLog)
+  const baselineStability = computeBaselineStability(mechanic)
+  const behavioralEvidence = holdout.total > 0 ? Math.round((holdout.passed / holdout.total) * 100) : 75
+  const reviewAlignment =
+    approveCount === 3
+      ? 100
+      : approveCount === 2 && rejectCount === 0 && conditionalCount === 1
+        ? 70
+        : approveCount === 2 && rejectCount === 0 && conditionalCount === 0
+          ? 70
+          : approveCount === 2 && rejectCount === 1
+            ? 40
+            : approveCount === 1
+              ? 20
+              : 0
+  const overall = Math.round(
+    executionHealth * 0.25 + baselineStability * 0.15 + behavioralEvidence * 0.35 + reviewAlignment * 0.25,
+  )
+
+  const synthAligned = typeof synthOpinion?.decision === "string" ? synthOpinion.decision === decision : true
+  const consensus =
+    synthAligned && typeof synthOpinion?.consensus === "string" && synthOpinion.consensus.trim().length > 0
+      ? synthOpinion.consensus.trim()
+      : `${approveCount}/3 approve, ${conditionalCount} conditional, ${rejectCount} reject, ${unavailableCount} unavailable, ${parseErrorCount} parse error`
+
+  const reasoning = buildReasoning({
+    decision,
+    blockReasons,
+    reviewGateSatisfied,
+    parsedReviewCount: parsedReviews.length,
+    contractRisk: contract.riskLevel,
+    holdout,
+    synthReasoning: synthAligned && typeof synthOpinion?.reasoning === "string" ? synthOpinion.reasoning : undefined,
+    policyCritical,
+    majorCount,
+    criticalCount,
+    mechanicRegression,
+    parseErrorCount,
+    unavailableCount,
+  })
+
+  return {
+    mechanic: mechanicRegression ? "regression" : "pass",
+    policy: {
+      critical: policyScan.summaryCounts?.critical ?? 0,
+      major: policyScan.summaryCounts?.major ?? 0,
+      minor: policyScan.summaryCounts?.minor ?? 0,
+      total: policyScan.summaryCounts?.total ?? 0,
+    },
+    reviews: {
+      claude: reviews.claude,
+      codex: reviews.codex,
+      gemini: reviews.gemini,
+    },
+    availableReviews: parsedReviews.length,
+    holdout,
+    consensus,
+    decision,
+    releaseVerdict: decision === "AUTO_OK" ? "PROMOTE" : "HOLD",
+    reasoning,
+    confidence: {
+      execution_health: executionHealth,
+      baseline_stability: baselineStability,
+      behavioral_evidence: behavioralEvidence,
+      review_alignment: reviewAlignment,
+      overall,
+    },
+    iterationsUsed: 1,
+    bestIteration: 1,
+    iterativeAuditMode: "single-pass",
+    findingsCount: {
+      critical: criticalCount,
+      major: majorCount,
+      minor: minorCount,
+    },
+    generatedAt: toUtcTimestamp(),
+  }
+}
+
+function buildReasoning(input: {
+  decision: "AUTO_OK" | "AUTO_BLOCK" | "HUMAN_REVIEW"
+  blockReasons: string[]
+  reviewGateSatisfied: boolean
+  parsedReviewCount: number
+  contractRisk: ContractDocument["riskLevel"]
+  holdout: HoldoutReport
+  synthReasoning?: string
+  policyCritical: number
+  majorCount: number
+  criticalCount: number
+  mechanicRegression: boolean
+  parseErrorCount: number
+  unavailableCount: number
+}): string {
+  const reasons: string[] = []
+
+  if (input.blockReasons.length > 0) {
+    reasons.push(...input.blockReasons)
+  } else {
+    if (!input.reviewGateSatisfied) {
+      reasons.push(`review coverage is insufficient for ${input.contractRisk} risk (${input.parsedReviewCount} parsed review(s))`)
+    }
+    if (input.holdout.failed > 0 || input.holdout.errors > 0) {
+      reasons.push(`holdout verification reported ${input.holdout.failed} failure(s) and ${input.holdout.errors} error(s)`)
+    }
+    if (input.majorCount > 0) {
+      reasons.push(`${input.majorCount} major reviewer finding(s) remain open`)
+    }
+  }
+
+  if (input.parseErrorCount > 0) reasons.push(`${input.parseErrorCount} reviewer output(s) could not be parsed cleanly`)
+  if (input.unavailableCount > 0) reasons.push(`${input.unavailableCount} reviewer slot(s) were unavailable in this runtime`)
+  if (input.policyCritical > 0) reasons.push(`${input.policyCritical} critical policy finding(s) were detected`)
+  if (input.criticalCount > 0 && input.decision !== "AUTO_BLOCK") reasons.push(`${input.criticalCount} critical reviewer finding(s) remain open`)
+  if (input.mechanicRegression && input.decision !== "AUTO_BLOCK") reasons.push("mechanic reported baseline regressions")
+  if (input.decision === "AUTO_OK" && reasons.length === 0) {
+    reasons.push("mechanic is clean, review coverage is sufficient, no major findings remain, and holdouts passed")
+  }
+
+  if (input.synthReasoning && input.synthReasoning.trim().length > 0) {
+    reasons.push(`synthesizer: ${input.synthReasoning.trim()}`)
+  }
+
+  return reasons.join("; ")
+}
+
+function computeExecutionHealth(executeReceipt: ExecuteReceipt | null, executeLog: ExecuteLog): number {
+  const total = Math.max(1, executeReceipt?.summary?.total_acs ?? 0)
+  const passed = Math.max(0, executeReceipt?.summary?.passed_acs ?? 0)
+  const repairAttempts = Math.max(0, (executeLog.totalAttempts ?? 1) - 1)
+  return clampPercent(Math.round((passed / total) * 100 - repairAttempts * 5))
+}
+
+function computeBaselineStability(mechanic: MechanicReport): number {
+  if (!mechanic.hasRegressions) return 100
+  const checks = mechanic.checks ?? []
+  if (checks.length === 0) return 0
+  const stable = checks.filter((check) => !check.regression).length
+  return clampPercent(Math.round((stable / checks.length) * 100))
+}
+
+function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, value))
+}
+
+function createFindingFingerprint(finding: ReviewFinding): string {
+  const normalizedComment = finding.comment.toLowerCase().replace(/line\s+\d+/g, "").replace(/\s+/g, " ").trim()
+  return createHash("sha256")
+    .update([finding.category, finding.file, normalizedComment].join("|"))
+    .digest("hex")
+    .slice(0, 8)
+}
+
+async function runRequiredScript(
+  pi: ExtensionAPI,
+  projectRoot: string,
+  scriptPath: string,
+  args: string[],
+  label: string,
+) {
+  const result = await pi.exec("bash", [scriptPath, ...args], { cwd: projectRoot, timeout: 120_000 })
+  if (result.code !== 0) {
+    throw new Error(result.stderr || result.stdout || `${label} failed`)
+  }
+}
+
+async function runScriptAllowFailure(pi: ExtensionAPI, projectRoot: string, scriptPath: string, args: string[]) {
+  await pi.exec("bash", [scriptPath, ...args], { cwd: projectRoot, timeout: 120_000 })
+}
+
+function extractJsonObject(text: string): Record<string, unknown> | null {
+  const trimmed = text.trim()
+  if (!trimmed) return null
+
+  const direct = tryParseJson(trimmed)
+  if (direct && typeof direct === "object" && !Array.isArray(direct)) {
+    return direct as Record<string, unknown>
+  }
+
+  const markerMatch = trimmed.match(/###SIGNUM_REVIEW_START###\s*([\s\S]*?)\s*###SIGNUM_REVIEW_END###/)
+  if (markerMatch) {
+    const marked = tryParseJson(markerMatch[1])
+    if (marked && typeof marked === "object" && !Array.isArray(marked)) {
+      return marked as Record<string, unknown>
+    }
+  }
+
+  const firstBrace = trimmed.indexOf("{")
+  const lastBrace = trimmed.lastIndexOf("}")
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    const sliced = tryParseJson(trimmed.slice(firstBrace, lastBrace + 1))
+    if (sliced && typeof sliced === "object" && !Array.isArray(sliced)) {
+      return sliced as Record<string, unknown>
+    }
+  }
+
+  return null
+}
+
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, "utf8")) as T
+}
+
+async function readOptionalJson<T>(path: string): Promise<T | null> {
+  try {
+    return await readJson<T>(path)
+  } catch {
+    return null
+  }
+}
+
+async function writeJson(path: string, value: unknown) {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8")
+}
+
+async function safeRead(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8")
+  } catch {
+    return ""
+  }
+}
+
+async function readOptionalText(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8")
+  } catch {
+    return null
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/platforms/pi/extensions/signum/phases/close.ts
+++ b/platforms/pi/extensions/signum/phases/close.ts
@@ -1,0 +1,27 @@
+import { writeContractIndex, readContractIndex, resolveContractId, updateContractStatus, setContractTimestampField, clearActiveContract } from "../runtime/script-adapters/contract-dir.ts"
+
+export async function runClosePhase(projectRoot: string, requestedContractId?: string): Promise<string> {
+  const index = await readContractIndex(projectRoot)
+  const contractId = resolveContractId(index, requestedContractId)
+  const closedAt = toUtcTimestamp()
+
+  const nextIndex = clearActiveContract(
+    setContractTimestampField(updateContractStatus(index, contractId, "closed"), contractId, "closedAt", closedAt),
+    contractId,
+  )
+
+  await writeContractIndex(projectRoot, nextIndex)
+
+  const lines = []
+  if (index.activeContractId === contractId) {
+    lines.push(`Cleared active contract (was ${contractId})`)
+  }
+  lines.push(`Closed: ${contractId} at ${closedAt}`)
+  lines.push("No proofpack generated. Contract directory preserved for reference.")
+
+  return lines.join("\n")
+}
+
+function toUtcTimestamp(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z")
+}

--- a/platforms/pi/extensions/signum/phases/contract.ts
+++ b/platforms/pi/extensions/signum/phases/contract.ts
@@ -1,0 +1,718 @@
+import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises"
+import { createHash } from "node:crypto"
+import { resolve } from "node:path"
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent"
+
+import { selectRoleModel } from "../models.ts"
+import {
+  adrCheckScriptPath,
+  assumptionCheckScriptPath,
+  contractInjectionScanScriptPath,
+  glossaryCheckScriptPath,
+  overlapCheckScriptPath,
+  proseCheckScriptPath,
+  stalenessCheckScriptPath,
+  terminologyCheckScriptPath,
+} from "../paths.ts"
+import {
+  ensureContractIndex,
+  initContractDirectory,
+  registerContract,
+  updateContractStatus,
+  writeContractIndex,
+} from "../runtime/script-adapters/contract-dir.ts"
+import { runJsonScript, runTextScript, sha256File, toUtcTimestamp } from "../runtime/script-adapters/checks.ts"
+import { loadRolePromptAsset, SdkRoleSessionRunner } from "../runtime/role-session.ts"
+import { emitSignumMessage, setSignumStatus } from "../ui.ts"
+
+interface ContractRunOptions {
+  task: string
+}
+
+interface ContractDocument {
+  schemaVersion: string
+  contractId: string
+  status: string
+  timestamps: { createdAt: string; activatedAt?: string }
+  goal: string
+  inScope: string[]
+  outOfScope?: string[]
+  allowNewFilesUnder?: string[]
+  acceptanceCriteria: Array<{ id: string; description: string; visibility?: string; verify?: unknown }>
+  assumptions?: Array<string | { id?: string; text?: string }>
+  openQuestions?: string[]
+  holdoutScenarios?: unknown[]
+  riskLevel: "low" | "medium" | "high"
+  riskSignals?: string[]
+  requiredInputsProvided?: boolean
+  contextInheritance?: Record<string, unknown>
+  readinessForPlanning?: { verdict?: string; summary?: string }
+  [key: string]: unknown
+}
+
+interface SpecQuality {
+  total: number
+  grade: "A" | "B" | "C" | "D"
+  dimensions: {
+    testability: number
+    negative_coverage: number
+    clarity: number
+    scope_boundedness: number
+    completeness: number
+    boundary_system: number
+    nl_consistency: number
+  }
+  warnings?: Record<string, unknown>
+}
+
+export interface ContractPhaseResult {
+  status: "approved" | "blocked" | "rejected"
+  contractId: string
+  summary: string
+}
+
+const APPROVAL_QUESTIONS = [
+  { key: "goal_matches_intent", label: "Goal matches intent", text: "Does the contract goal accurately reflect what you asked for?" },
+  { key: "acs_sufficient", label: "ACs sufficient", text: "Are the acceptance criteria complete and testable?" },
+  { key: "scope_correct", label: "Scope correct", text: "Is the inScope list appropriate (no missing or extra files)?" },
+  { key: "assumptions_valid", label: "Assumptions valid", text: "Are the listed assumptions accurate for your project?" },
+  { key: "risk_appropriate", label: "Risk appropriate", text: "Is the stated risk level correct for this change?" },
+] as const
+
+export async function runContractPhase(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+  options: ContractRunOptions,
+): Promise<ContractPhaseResult> {
+  const projectRoot = ctx.cwd
+  await prepareWorkspace(projectRoot)
+
+  const runner = new SdkRoleSessionRunner()
+  const promptAsset = await loadRolePromptAsset("contractor")
+  const availableModels = await ctx.modelRegistry.getAvailable()
+  const firstModel = selectRoleModel("contractor", {
+    currentModel: ctx.model,
+    availableModels,
+    preferredModelId: promptAsset.preferredModelId,
+  })
+
+  if (!firstModel) {
+    throw new Error("No authenticated model available for contractor role")
+  }
+
+  const basePrompt = [
+    `FEATURE_REQUEST: ${options.task}`,
+    `PROJECT_ROOT: ${projectRoot}`,
+    "",
+    "Scan the codebase, assess risk, and write .signum/contract.json.",
+  ].join("\n")
+
+  let contractorResult: Awaited<ReturnType<typeof runContractor>>
+  try {
+    contractorResult = await runContractor(runner, projectRoot, firstModel, basePrompt)
+  } catch (error) {
+    throw new Error(`Contractor role session failed on first attempt: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  let contract = await readAndValidateContract(projectRoot)
+  if (!contract) {
+    contract = await salvageContractFromFinalText(projectRoot, contractorResult.finalText)
+  }
+
+  if (!contract) {
+    const fallbackModel = selectRoleModel("contractor", {
+      currentModel: ctx.model,
+      availableModels,
+      preferredModelId: promptAsset.preferredModelId,
+      preferFallback: true,
+    })
+
+    if (!fallbackModel || `${fallbackModel.provider}/${fallbackModel.id}` === `${firstModel.provider}/${firstModel.id}`) {
+      throw new Error(`Contractor agent failed to produce a valid contract.json on the first attempt.${formatContractorFailure(contractorResult)}`)
+    }
+
+    try {
+      contractorResult = await runContractor(runner, projectRoot, fallbackModel, basePrompt)
+    } catch (error) {
+      throw new Error(`Contractor role session failed on fallback attempt: ${error instanceof Error ? error.message : String(error)}`)
+    }
+    contract = await readAndValidateContract(projectRoot)
+    if (!contract) {
+      contract = await salvageContractFromFinalText(projectRoot, contractorResult.finalText)
+    }
+    if (!contract) {
+      throw new Error(`Contractor agent failed to produce a valid contract.json on both attempts.${formatContractorFailure(contractorResult)}`)
+    }
+  }
+
+  const injection = await runTextScript(pi, contractInjectionScanScriptPath, [resolve(projectRoot, ".signum/contract.json")])
+  if (!injection.ok) {
+    if (/BLOCKED:/i.test(injection.output)) {
+      return {
+        status: "blocked",
+        contractId: contract.contractId,
+        summary: injection.output || "Contract blocked by injection scan.",
+      }
+    }
+
+    const fallbackScan = scanContractForInvisibleUnicode(contract)
+    if (fallbackScan.length > 0) {
+      return {
+        status: "blocked",
+        contractId: contract.contractId,
+        summary: fallbackScan.join("\n"),
+      }
+    }
+  }
+
+  const holdoutRetry = holdoutRequirement(contract.riskLevel, contract)
+  if (!holdoutRetry.satisfied) {
+    const fallbackModel = selectRoleModel("contractor", {
+      currentModel: ctx.model,
+      availableModels,
+      preferredModelId: promptAsset.preferredModelId,
+      preferFallback: true,
+    }) ?? firstModel
+
+    const retryPrompt = [
+      basePrompt,
+      "",
+      `ADDITIONAL REQUIREMENT: The previous contract had insufficient holdout scenarios for ${contract.riskLevel} risk level.`,
+      `Risk level ${contract.riskLevel} requires at least ${holdoutRetry.required} holdout scenarios. Current count: ${holdoutRetry.actual}.`,
+      "Generate exactly the required minimum number of high-quality holdout scenarios.",
+      "- Each must be a negative test, error path, or boundary condition",
+      "- Each must NOT be derivable from the visible acceptance criteria",
+      "- Prefer typed DSL verify steps, not manual verification",
+      "Keep all other contract fields consistent with the task.",
+    ].join("\n")
+
+    try {
+      contractorResult = await runContractor(runner, projectRoot, fallbackModel, retryPrompt)
+    } catch (error) {
+      throw new Error(`Contractor role session failed during holdout retry: ${error instanceof Error ? error.message : String(error)}`)
+    }
+    contract = await readAndValidateContract(projectRoot)
+    if (!contract) {
+      contract = await salvageContractFromFinalText(projectRoot, contractorResult.finalText)
+    }
+    if (!contract) {
+      throw new Error(`Contractor retry for holdout generation produced an invalid contract.json.${formatContractorFailure(contractorResult)}`)
+    }
+  }
+
+  const contractDir = await initContractDirectory(projectRoot, contract.contractId)
+  let index = await ensureContractIndex(projectRoot)
+  index = registerContract(index, contract, "draft")
+  await writeContractIndex(projectRoot, index)
+  await copyFile(resolve(projectRoot, ".signum/contract.json"), resolve(contractDir, "contract.json"))
+
+  const specQuality = scoreContract(contract)
+  await writeJson(resolve(projectRoot, ".signum/spec_quality.json"), specQuality)
+  const mergedSpecQuality = await enrichSpecQualityWithDeterministicChecks(pi, projectRoot, specQuality)
+
+  const summary = buildContractSummary(contract, mergedSpecQuality)
+  emitSignumMessage(pi, summary, {
+    phase: "contract-summary",
+    contractId: contract.contractId,
+    riskLevel: contract.riskLevel,
+  })
+
+  if (mergedSpecQuality.grade === "D") {
+    return {
+      status: "blocked",
+      contractId: contract.contractId,
+      summary: `${summary}\n\nSPEC QUALITY GATE FAILED (grade D). Re-run the contractor with a tighter scope and more testable acceptance criteria.`,
+    }
+  }
+
+  if ((mergedSpecQuality.staleness as any)?.status === "block") {
+    return {
+      status: "blocked",
+      contractId: contract.contractId,
+      summary: `${summary}\n\nBLOCK: upstream artifacts changed (stalenessPolicy=block). Re-run the contractor to refresh context.`,
+    }
+  }
+
+  if (contract.requiredInputsProvided === false || (contract.openQuestions ?? []).length > 0) {
+    return {
+      status: "blocked",
+      contractId: contract.contractId,
+      summary: [
+        summary,
+        "",
+        "Contractor needs additional input:",
+        ...(contract.openQuestions ?? []).map((question) => `- ${question}`),
+      ].join("\n"),
+    }
+  }
+
+  if (!ctx.hasUI && !shouldAutoApproveContract()) {
+    return {
+      status: "blocked",
+      contractId: contract.contractId,
+      summary: `${summary}\n\nInteractive pi is required for the approval checklist. Set SIGNUM_PI_AUTO_APPROVE=1 only for development smoke tests.`,
+    }
+  }
+
+  const approval = shouldAutoApproveContract()
+    ? { approved: true, failedItems: [] }
+    : await runApprovalChecklist(ctx)
+  if (!approval.approved) {
+    return {
+      status: "rejected",
+      contractId: contract.contractId,
+      summary: [
+        summary,
+        "",
+        "Approval REJECTED. Failed items:",
+        ...approval.failedItems.map((item) => `- ${item}`),
+        "",
+        "Re-run the contractor with this feedback to revise the contract.",
+        "Phase 2 will NOT be entered until all checklist items are approved.",
+      ].join("\n"),
+    }
+  }
+
+  const approvedAt = toUtcTimestamp()
+  await writeJson(resolve(projectRoot, ".signum/approval.json"), {
+    approved: true,
+    approvedAt,
+    checklist: Object.fromEntries(APPROVAL_QUESTIONS.map((question) => [question.key, true])),
+  })
+
+  contract.status = "active"
+  contract.timestamps = {
+    ...(contract.timestamps ?? { createdAt: approvedAt }),
+    activatedAt: approvedAt,
+  }
+  await writeJson(resolve(projectRoot, ".signum/contract.json"), contract)
+
+  const contractHash = await sha256File(resolve(projectRoot, ".signum/contract.json"))
+  await writeFile(
+    resolve(projectRoot, ".signum/contract-hash.txt"),
+    [`contract_sha256: ${contractHash}`, `approved_at: ${approvedAt}`, `contract_file: .signum/contract.json`, ""].join("\n"),
+    "utf8",
+  )
+
+  await writeEngineerContract(projectRoot, contract)
+  await copyFile(resolve(projectRoot, ".signum/contract.json"), resolve(contractDir, "contract.json"))
+  await copyFile(resolve(projectRoot, ".signum/approval.json"), resolve(contractDir, "approval.json"))
+
+  index = updateContractStatus(index, contract.contractId, "active")
+  await writeContractIndex(projectRoot, index)
+
+  return {
+    status: "approved",
+    contractId: contract.contractId,
+    summary: [summary, "", `approval.json written at ${approvedAt}`, `Audit chain anchored: ${contractHash} at ${approvedAt}`].join("\n"),
+  }
+}
+
+async function salvageContractFromFinalText(projectRoot: string, finalText: string): Promise<ContractDocument | null> {
+  const extracted = extractJsonObject(finalText)
+  if (!extracted) return null
+
+  try {
+    const parsed = JSON.parse(extracted) as ContractDocument
+    if (!isValidContract(parsed)) return null
+    await writeJson(resolve(projectRoot, ".signum/contract.json"), parsed)
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function extractJsonObject(text: string): string | null {
+  const trimmed = text.trim()
+  if (!trimmed) return null
+
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i)
+  const candidate = fenced ? fenced[1].trim() : trimmed
+  const start = candidate.indexOf("{")
+  const end = candidate.lastIndexOf("}")
+  if (start < 0 || end <= start) return null
+  return candidate.slice(start, end + 1)
+}
+
+function formatContractorFailure(result: { finalText: string; events?: Array<{ type: string; toolName?: string; isError?: boolean }> }): string {
+  const pieces: string[] = []
+  if (result.finalText) {
+    pieces.push(`Final contractor message: ${result.finalText.replace(/\s+/g, " ").trim().slice(0, 400)}`)
+  }
+  if (Array.isArray(result.events) && result.events.length > 0) {
+    const preview = result.events
+      .slice(0, 12)
+      .map((event) => `${event.type}${event.toolName ? `:${event.toolName}` : ""}${event.isError ? ":error" : ""}`)
+      .join(", ")
+    pieces.push(`tool events: ${preview}`)
+  }
+  return pieces.length > 0 ? ` ${pieces.join(" | ")}` : ""
+}
+
+async function runContractor(
+  runner: SdkRoleSessionRunner,
+  projectRoot: string,
+  model: { provider: string; id: string },
+  prompt: string,
+) {
+  return runner.run({
+    role: "contractor",
+    projectRoot,
+    prompt,
+    model: model as any,
+  })
+}
+
+async function prepareWorkspace(projectRoot: string) {
+  await mkdir(resolve(projectRoot, ".signum", "reviews"), { recursive: true })
+  await mkdir(resolve(projectRoot, ".signum", "contracts"), { recursive: true })
+
+  const gitignorePath = resolve(projectRoot, ".gitignore")
+  let gitignore = ""
+  try {
+    gitignore = await readFile(gitignorePath, "utf8")
+  } catch {
+    gitignore = ""
+  }
+  if (!gitignore.split(/\r?\n/).includes(".signum/")) {
+    const next = gitignore.length > 0 && !gitignore.endsWith("\n") ? `${gitignore}\n.signum/\n` : `${gitignore}.signum/\n`
+    await writeFile(gitignorePath, next, "utf8")
+  }
+}
+
+async function readAndValidateContract(projectRoot: string): Promise<ContractDocument | null> {
+  try {
+    const raw = await readFile(resolve(projectRoot, ".signum/contract.json"), "utf8")
+    const parsed = JSON.parse(raw) as ContractDocument
+    if (!isValidContract(parsed)) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function isValidContract(contract: ContractDocument | null | undefined): contract is ContractDocument {
+  if (!contract || typeof contract !== "object") return false
+  if (!contract.schemaVersion || !contract.goal || !Array.isArray(contract.inScope) || contract.inScope.length === 0) return false
+  if (!Array.isArray(contract.acceptanceCriteria) || contract.acceptanceCriteria.length === 0) return false
+  if (!contract.riskLevel || !["low", "medium", "high"].includes(contract.riskLevel)) return false
+  if (!contract.contractId || !/^sig-.+/.test(contract.contractId)) return false
+  if (!contract.status || !contract.timestamps?.createdAt) return false
+  return true
+}
+
+function scoreContract(contract: ContractDocument): SpecQuality {
+  const acCount = contract.acceptanceCriteria.length
+  const acWithVerify = contract.acceptanceCriteria.filter((criterion) => hasVerify(criterion.verify)).length
+  const inScopeCount = contract.inScope.length
+  const hasOutOfScope = (contract.outOfScope ?? []).length > 0 ? 1 : 0
+  const hasAssumptions = (contract.assumptions ?? []).length > 0 ? 1 : 0
+  const holdoutCount = holdoutRequirement(contract.riskLevel, contract).actual
+  const hasHoldouts = holdoutCount > 0 ? 1 : 0
+  const reqOk = contract.requiredInputsProvided !== false
+  const openQuestionCount = (contract.openQuestions ?? []).length
+
+  const testability = acCount > 0 ? Math.floor((acWithVerify * 25) / acCount) : 0
+  const completeness = (reqOk ? 5 : 0) + (openQuestionCount === 0 ? 5 : 0)
+
+  let scopeScore = inScopeCount < 5 ? 15 : inScopeCount < 16 ? 10 : 5
+  if (hasOutOfScope) scopeScore = Math.min(15, scopeScore + 3)
+
+  let negativeCoverage = hasHoldouts ? 10 : 0
+  const negativeAcs = contract.acceptanceCriteria.filter((criterion) => /must not|should not|\bnever\b|\bprevent|reject|fail|invalid/i.test(criterion.description)).length
+  if (negativeAcs > 0) negativeCoverage += 10
+
+  const goal = contract.goal ?? ""
+  const clarity = (goal.length >= 20 && goal.length <= 300 ? 10 : 0) + (/works correctly|as expected|properly|should work/i.test(goal) ? 0 : 10)
+  const boundary = (hasOutOfScope ? 5 : 0) + (hasAssumptions ? 5 : 0)
+
+  const allAcText = contract.acceptanceCriteria.map((criterion) => criterion.description).join(" ")
+  const vagueVerbPoints = /\b(handle|process|manage|support|ensure|implement|perform|utilize|leverage|facilitate)\b/i.test(`${goal} ${allAcText}`) ? 0 : 5
+  const terminologyPairs: Array<[string, string]> = [
+    ["endpoint", "route"],
+    ["function", "method"],
+    ["test", "spec"],
+    ["error", "exception"],
+    ["config", "configuration"],
+    ["config", "settings"],
+    ["user", "client"],
+    ["file", "document"],
+  ]
+  const terminologyPoints = terminologyPairs.some(([left, right]) => hasWholeWord(`${goal} ${allAcText}`, left) && hasWholeWord(`${goal} ${allAcText}`, right)) ? 0 : 5
+  const contradictionPoints = findContradiction(contract.acceptanceCriteria.map((criterion) => criterion.description)) ? 0 : 5
+  const nlConsistency = vagueVerbPoints + terminologyPoints + contradictionPoints
+
+  const total = testability + completeness + scopeScore + negativeCoverage + clarity + boundary + nlConsistency
+  const grade = total >= 103 ? "A" : total >= 86 ? "B" : total >= 69 ? "C" : "D"
+
+  return {
+    total,
+    grade,
+    dimensions: {
+      testability: testability,
+      negative_coverage: negativeCoverage,
+      clarity,
+      scope_boundedness: scopeScore,
+      completeness,
+      boundary_system: boundary,
+      nl_consistency: nlConsistency,
+    },
+  }
+}
+
+const INVISIBLE_UNICODE_PATTERN = /(?:[\uFE00-\uFE0F\u202A-\u202E\u2066-\u2069\u200B-\u200D\uFEFF\u00AD\u034F\u2060-\u2064]|[\u{E0100}-\u{E01EF}]|[\u{E0000}-\u{E007F}])/u
+
+function scanContractForInvisibleUnicode(contract: ContractDocument): string[] {
+  const findings: string[] = []
+  let index = 0
+
+  for (const value of extractContractStrings(contract)) {
+    index += 1
+    const match = value.match(INVISIBLE_UNICODE_PATTERN)
+    if (!match) continue
+    const codePoint = match[0].codePointAt(0)?.toString(16).toUpperCase().padStart(4, "0") ?? "????"
+    findings.push(`BLOCKED: invisible Unicode U+${codePoint} in field ${index}: ${value.slice(0, 80)}`)
+  }
+
+  return findings
+}
+
+function extractContractStrings(value: unknown): string[] {
+  if (typeof value === "string") return [value]
+  if (Array.isArray(value)) return value.flatMap((item) => extractContractStrings(item))
+  if (value && typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).flatMap((item) => extractContractStrings(item))
+  }
+  return []
+}
+
+function hasVerify(verify: unknown): boolean {
+  if (!verify || typeof verify !== "object") return false
+  const candidate = verify as Record<string, unknown>
+  return Boolean((typeof candidate.type === "string" && typeof candidate.value === "string") || Array.isArray(candidate.steps))
+}
+
+function hasWholeWord(text: string, word: string): boolean {
+  return new RegExp(`\\b${word}\\b`, "i").test(text)
+}
+
+function findContradiction(descriptions: string[]): boolean {
+  const joined = descriptions.join("\n")
+  for (const description of descriptions) {
+    const matches = description.match(/\b(?:must|allow|enable)\s+([a-z]+)/gi) ?? []
+    for (const phrase of matches) {
+      if (/must not/i.test(phrase)) continue
+      const word = phrase.split(/\s+/)[1]
+      if (new RegExp(`must not ${word}|prevent ${word}|disallow ${word}|disable ${word}`, "i").test(joined)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+function holdoutRequirement(riskLevel: ContractDocument["riskLevel"], contract: ContractDocument) {
+  const holdoutAcs = contract.acceptanceCriteria.filter((criterion) => criterion.visibility === "holdout").length
+  const holdoutScenarios = Array.isArray(contract.holdoutScenarios) ? contract.holdoutScenarios.length : 0
+  const actual = holdoutAcs + holdoutScenarios
+  const required = riskLevel === "medium" ? 2 : riskLevel === "high" ? 5 : 0
+  return {
+    actual,
+    required,
+    satisfied: actual >= required,
+  }
+}
+
+async function enrichSpecQualityWithDeterministicChecks(
+  pi: ExtensionAPI,
+  projectRoot: string,
+  specQuality: SpecQuality,
+): Promise<SpecQuality & Record<string, unknown>> {
+  const glossaryPath = resolve(projectRoot, "project.glossary.json")
+  const indexPath = resolve(projectRoot, ".signum/contracts/index.json")
+  const contractPath = resolve(projectRoot, ".signum/contract.json")
+
+  const merged: SpecQuality & Record<string, unknown> = { ...specQuality }
+
+  const checks: Array<Promise<void>> = []
+
+  checks.push(
+    safeJsonScript(pi, glossaryCheckScriptPath, [contractPath, "--glossary", glossaryPath]).then((result) => {
+      merged.glossary_warnings = (result as any)?.findings ?? []
+      merged.glossary_version = (result as any)?.glossary_version ?? ""
+      merged.glossary_terms = (result as any)?.glossary_terms ?? 0
+    }),
+  )
+
+  checks.push(
+    safeJsonScript(pi, proseCheckScriptPath, [contractPath]).then((result) => {
+      merged.prose_warnings = result ?? {}
+    }),
+  )
+
+  checks.push(
+    safeJsonScript(pi, terminologyCheckScriptPath, [contractPath, "--index", indexPath, "--glossary", glossaryPath]).then((result) => {
+      merged.terminology_warnings = (result as any)?.findings ?? []
+    }),
+  )
+
+  checks.push(
+    safeJsonScript(pi, overlapCheckScriptPath, [contractPath, "--index", indexPath]).then((result) => {
+      merged.overlap_warnings = (result as any)?.findings ?? []
+    }),
+  )
+
+  checks.push(
+    safeJsonScript(pi, assumptionCheckScriptPath, [contractPath, "--index", indexPath]).then((result) => {
+      merged.assumption_warnings = (result as any)?.findings ?? []
+    }),
+  )
+
+  checks.push(
+    safeJsonScript(pi, adrCheckScriptPath, [contractPath, "--project-root", projectRoot]).then((result) => {
+      merged.adr_warnings = (result as any)?.findings ?? []
+    }),
+  )
+
+  checks.push(
+    safeJsonScript(pi, stalenessCheckScriptPath, [contractPath, "--project-root", projectRoot]).then(async (result) => {
+      merged.staleness = result ?? {}
+      const status = (result as any)?.status
+      if (status === "fresh" || status === "warn" || status === "block") {
+        const contract = (await readAndValidateContract(projectRoot))!
+        contract.contextInheritance = {
+          ...(contract.contextInheritance ?? {}),
+          stalenessStatus: status === "fresh" ? "fresh" : status === "warn" ? "warning" : "stale",
+        }
+        await writeJson(contractPath, contract)
+      }
+    }),
+  )
+
+  await Promise.all(checks)
+  await writeJson(resolve(projectRoot, ".signum/spec_quality.json"), merged)
+  return merged
+}
+
+async function safeJsonScript(pi: ExtensionAPI, scriptPath: string, args: string[]) {
+  try {
+    return await runJsonScript(pi, scriptPath, args)
+  } catch {
+    return {}
+  }
+}
+
+function buildContractSummary(contract: ContractDocument, specQuality: SpecQuality & Record<string, unknown>): string {
+  const visibleAcCount = contract.acceptanceCriteria.filter((criterion) => criterion.visibility !== "holdout").length
+  const holdouts = holdoutRequirement(contract.riskLevel, contract).actual
+  const warnings = collectWarnings(specQuality, contract)
+
+  return [
+    `## Contract: ${contract.contractId}`,
+    "",
+    `**Goal:** ${contract.goal}`,
+    "",
+    "| Field | Value |",
+    "|-------|-------|",
+    `| Risk | ${contract.riskLevel} |`,
+    `| Scope | ${(contract.inScope ?? []).join(", ")} |`,
+    `| ACs | ${visibleAcCount} visible + ${holdouts} holdout |`,
+    `| Spec quality | ${specQuality.total}/115 (${specQuality.grade}) |`,
+    `| Readiness | ${contract.readinessForPlanning?.verdict ?? "absent"} |`,
+    warnings.length > 0 ? "" : "",
+    warnings.length > 0 ? "### Warnings" : "",
+    ...warnings.map((warning) => `- ${warning}`),
+    "",
+    "Human approval checklist — answer yes or no for each:",
+    ...APPROVAL_QUESTIONS.map((question, index) => `${index + 1}. ${question.label}: ${question.text}`),
+  ]
+    .filter((line) => line !== "")
+    .join("\n")
+}
+
+function collectWarnings(specQuality: Record<string, unknown>, contract: ContractDocument): string[] {
+  const warnings: string[] = []
+  for (const key of ["glossary_warnings", "terminology_warnings", "overlap_warnings", "assumption_warnings", "adr_warnings"] as const) {
+    const value = specQuality[key]
+    if (Array.isArray(value) && value.length > 0) {
+      warnings.push(`${key.replace(/_/g, " ")}: ${value.length}`)
+    }
+  }
+  const proseWarnings = specQuality.prose_warnings as Record<string, unknown> | undefined
+  if (typeof proseWarnings?.total_findings === "number" && proseWarnings.total_findings > 0) {
+    warnings.push(`prose warnings: ${proseWarnings.total_findings}`)
+  }
+  const holdout = holdoutRequirement(contract.riskLevel, contract)
+  if (!holdout.satisfied) {
+    warnings.push(`holdout gate not satisfied for ${contract.riskLevel} risk (${holdout.actual}/${holdout.required})`)
+  }
+  if ((specQuality.grade as string) === "D") {
+    warnings.push("spec quality gate failed (grade D)")
+  }
+  if (contract.readinessForPlanning?.verdict === "no-go") {
+    warnings.push("contractor self-critique returned no-go")
+  }
+  return warnings
+}
+
+function shouldAutoApproveContract(): boolean {
+  return process.env.SIGNUM_PI_AUTO_APPROVE === "1"
+}
+
+async function runApprovalChecklist(ctx: ExtensionCommandContext): Promise<{ approved: boolean; failedItems: string[] }> {
+  const failedItems: string[] = []
+
+  for (const [index, question] of APPROVAL_QUESTIONS.entries()) {
+    const ok = await ctx.ui.confirm(`Approval item ${index + 1}/5`, `${question.label}: ${question.text}`)
+    if (ok) continue
+
+    const reason = await ctx.ui.input(`Reason for rejecting \"${question.label}\" (optional):`, "Short explanation")
+    failedItems.push(`Item ${index + 1} (${question.label})${reason ? `: ${reason}` : ""}`)
+  }
+
+  return {
+    approved: failedItems.length === 0,
+    failedItems,
+  }
+}
+
+async function writeEngineerContract(projectRoot: string, contract: ContractDocument) {
+  const visibleAcceptanceCriteria = contract.acceptanceCriteria.filter((criterion) => criterion.visibility !== "holdout")
+  const holdoutItems = {
+    acceptanceCriteria: contract.acceptanceCriteria.filter((criterion) => criterion.visibility === "holdout"),
+    holdoutScenarios: contract.holdoutScenarios ?? [],
+  }
+
+  const engineerContract: Record<string, unknown> = {
+    schemaVersion: contract.schemaVersion,
+    contractId: contract.contractId,
+    status: contract.status,
+    timestamps: contract.timestamps,
+    goal: contract.goal,
+    inScope: contract.inScope,
+    allowNewFilesUnder: contract.allowNewFilesUnder,
+    outOfScope: contract.outOfScope,
+    acceptanceCriteria: visibleAcceptanceCriteria,
+    assumptions: contract.assumptions,
+    openQuestions: contract.openQuestions,
+    riskLevel: contract.riskLevel,
+    riskSignals: contract.riskSignals,
+    requiredInputsProvided: contract.requiredInputsProvided,
+    contextInheritance: contract.contextInheritance,
+  }
+
+  const holdoutCount = holdoutItems.acceptanceCriteria.length + holdoutItems.holdoutScenarios.length
+  if (holdoutCount > 0) {
+    const holdoutHash = createHash("sha256").update(JSON.stringify(holdoutItems)).digest("hex").slice(0, 16)
+    engineerContract.holdoutManifest = {
+      count: holdoutCount,
+      hash: `sha256:${holdoutHash}`,
+    }
+  }
+
+  await writeJson(resolve(projectRoot, ".signum/contract-engineer.json"), engineerContract)
+}
+
+async function writeJson(path: string, value: unknown) {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8")
+}

--- a/platforms/pi/extensions/signum/phases/contract.ts
+++ b/platforms/pi/extensions/signum/phases/contract.ts
@@ -24,6 +24,7 @@ import {
 } from "../runtime/script-adapters/contract-dir.ts"
 import { runJsonScript, runTextScript, sha256File, toUtcTimestamp } from "../runtime/script-adapters/checks.ts"
 import { loadRolePromptAsset, SdkRoleSessionRunner } from "../runtime/role-session.ts"
+import { normalizeContractForPiRuntime } from "../runtime/verify-normalizer.ts"
 import { emitSignumMessage, setSignumStatus } from "../ui.ts"
 
 interface ContractRunOptions {
@@ -313,7 +314,7 @@ async function salvageContractFromFinalText(projectRoot: string, finalText: stri
   if (!extracted) return null
 
   try {
-    const parsed = JSON.parse(extracted) as ContractDocument
+    const parsed = normalizeContractForPiRuntime(JSON.parse(extracted) as ContractDocument)
     if (!isValidContract(parsed)) return null
     await writeJson(resolve(projectRoot, ".signum/contract.json"), parsed)
     return parsed
@@ -383,8 +384,9 @@ async function prepareWorkspace(projectRoot: string) {
 async function readAndValidateContract(projectRoot: string): Promise<ContractDocument | null> {
   try {
     const raw = await readFile(resolve(projectRoot, ".signum/contract.json"), "utf8")
-    const parsed = JSON.parse(raw) as ContractDocument
+    const parsed = normalizeContractForPiRuntime(JSON.parse(raw) as ContractDocument)
     if (!isValidContract(parsed)) return null
+    await writeJson(resolve(projectRoot, ".signum/contract.json"), parsed)
     return parsed
   } catch {
     return null

--- a/platforms/pi/extensions/signum/phases/execute.ts
+++ b/platforms/pi/extensions/signum/phases/execute.ts
@@ -1,0 +1,899 @@
+import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { dirname, join, relative, resolve } from "node:path"
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent"
+
+import { snapshotTreeScriptPath, transitionVerifierScriptPath } from "../paths.ts"
+import { selectRoleModel } from "../models.ts"
+import { loadRolePromptAsset, SdkRoleSessionRunner } from "../runtime/role-session.ts"
+import { sha256File, toUtcTimestamp } from "../runtime/script-adapters/checks.ts"
+import { createPolicyAwareEngineerTools, deriveExecutionPolicy } from "../runtime/policy-tools.ts"
+import { setSignumStatus } from "../ui.ts"
+
+interface ExecuteResult {
+  status: "success" | "blocked" | "failed"
+  summary: string
+}
+
+interface ContractDocument {
+  contractId: string
+  riskLevel: "low" | "medium" | "high"
+  inScope: string[]
+  allowNewFilesUnder?: string[]
+  removals?: Array<{ path?: string }>
+}
+
+interface EngineerContractDocument {
+  contractId?: string
+  acceptanceCriteria?: Array<{ id: string; visibility?: string; verify?: unknown }>
+}
+
+export async function runExecutePhase(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+): Promise<ExecuteResult> {
+  const projectRoot = ctx.cwd
+  const contract = await readJson<ContractDocument>(resolve(projectRoot, ".signum/contract.json"))
+  const engineerContractPath = resolve(projectRoot, ".signum/contract-engineer.json")
+  await readFile(engineerContractPath, "utf8")
+
+  const policy = deriveExecutionPolicy(contract as Record<string, any>)
+  await writeJson(resolve(projectRoot, ".signum/contract-policy.json"), policy)
+  await rm(resolve(projectRoot, ".signum/policy_violations.json"), { force: true })
+
+  const executeStartedAt = toUtcTimestamp()
+
+  setSignumStatus(ctx, "execute baseline")
+  await captureExecutionBaseline(pi, projectRoot, contract.contractId, executeStartedAt)
+  await captureReceiptSnapshot(pi, projectRoot)
+  await snapshotProjectTree(projectRoot, resolve(projectRoot, ".signum/snapshots/execute-before"))
+
+  const runner = new SdkRoleSessionRunner()
+  const promptAsset = await loadRolePromptAsset("engineer")
+  const availableModels = await ctx.modelRegistry.getAvailable()
+  const engineerModel = selectRoleModel("engineer", {
+    currentModel: ctx.model,
+    availableModels,
+    preferredModelId: promptAsset.preferredModelId,
+  })
+  if (!engineerModel) {
+    throw new Error("No authenticated model available for engineer role")
+  }
+
+  const maxAttempts = 3
+  const attemptLogs: Array<Record<string, unknown>> = []
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const policyTools = createPolicyAwareEngineerTools(projectRoot, policy)
+    setSignumStatus(ctx, `execute attempt ${attempt}/${maxAttempts}`)
+
+    const retryContext =
+      attemptLogs.length === 0
+        ? ""
+        : `\n\nPrevious attempt failed summary:\n${JSON.stringify(attemptLogs[attemptLogs.length - 1], null, 2)}`
+
+    const prompt = [
+      "Read .signum/contract-engineer.json, .signum/baseline.json, and .signum/contract-policy.json.",
+      "Implement only what the contract requires.",
+      "Use edit/write for mutations. Use bash only for read-only inspection or checks.",
+      "Do not modify .signum artifacts directly.",
+      `Attempt ${attempt} of ${maxAttempts}.`,
+      retryContext,
+    ]
+      .filter(Boolean)
+      .join("\n")
+
+    const run = await runner.run({
+      role: "engineer",
+      projectRoot,
+      prompt,
+      model: engineerModel,
+      toolNames: [...policyTools.builtInToolNames, ...policyTools.customTools.map((tool) => tool.name)],
+      customTools: policyTools.customTools,
+    })
+
+    const violations = policyTools.getViolations()
+    if (violations.length > 0) {
+      await writeJson(resolve(projectRoot, ".signum/policy_violations.json"), {
+        violations,
+      })
+      await writeJson(resolve(projectRoot, ".signum/execute_log.json"), {
+        status: "POLICY_VIOLATION",
+        totalAttempts: attempt,
+        maxAttempts,
+        attempts: [
+          ...attemptLogs,
+          {
+            number: attempt,
+            status: "POLICY_VIOLATION",
+            model: run.model,
+            finalText: run.finalText,
+            toolEvents: run.events,
+            policyViolations: violations,
+          },
+        ],
+        started_at: executeStartedAt,
+        finished_at: toUtcTimestamp(),
+      })
+      return {
+        status: "blocked",
+        summary: [
+          `EXECUTE blocked on attempt ${attempt}/${maxAttempts}.`,
+          "Runtime policy violation(s):",
+          ...violations.map((violation) => `- ${violation.tool}: ${violation.reason}${violation.path ? ` (${violation.path})` : ""}`),
+        ].join("\n"),
+      }
+    }
+
+    const changedFiles = policyTools.getTouchedFiles()
+    const combinedPatch = await buildCombinedPatch(pi, projectRoot)
+    await writeFile(resolve(projectRoot, ".signum/combined.patch"), combinedPatch, "utf8")
+
+    const attemptLog = {
+      number: attempt,
+      status: changedFiles.length > 0 ? "SUCCESS" : "NO_CHANGES",
+      model: run.model,
+      finalText: run.finalText,
+      toolEvents: run.events,
+      changedFiles,
+    }
+    attemptLogs.push(attemptLog)
+
+    if (changedFiles.length > 0) {
+      await writeJson(resolve(projectRoot, ".signum/execute_log.json"), {
+        status: "SUCCESS",
+        totalAttempts: attempt,
+        maxAttempts,
+        attempts: attemptLogs,
+        started_at: executeStartedAt,
+        finished_at: toUtcTimestamp(),
+      })
+
+      const boundary = await runBoundaryVerification(pi, projectRoot, contract, policy, changedFiles)
+      if (!boundary.ok) {
+        await writeJson(resolve(projectRoot, ".signum/execute_log.json"), {
+          status: "BOUNDARY_BLOCKED",
+          totalAttempts: attempt,
+          maxAttempts,
+          attempts: attemptLogs,
+          started_at: executeStartedAt,
+          finished_at: toUtcTimestamp(),
+          boundaryVerification: boundary.output,
+        })
+        return {
+          status: "blocked",
+          summary: [
+            `EXECUTE blocked after attempt ${attempt}/${maxAttempts}.`,
+            "Boundary verification failed:",
+            boundary.output || "unknown boundary verification failure",
+          ].join("\n"),
+        }
+      }
+
+      const transition = await runTransitionVerification(pi, projectRoot)
+      if (!transition.ok) {
+        await writeJson(resolve(projectRoot, ".signum/execute_log.json"), {
+          status: "TRANSITION_BLOCKED",
+          totalAttempts: attempt,
+          maxAttempts,
+          attempts: attemptLogs,
+          started_at: executeStartedAt,
+          finished_at: toUtcTimestamp(),
+          transitionVerification: transition.output,
+        })
+        return {
+          status: "blocked",
+          summary: [
+            `EXECUTE blocked after attempt ${attempt}/${maxAttempts}.`,
+            "Transition verification failed:",
+            transition.output || "unknown transition verification failure",
+          ].join("\n"),
+        }
+      }
+
+      return {
+        status: "success",
+        summary: [
+          `EXECUTE complete: ${attempt} attempt(s).`,
+          `Changed files: ${changedFiles.join(", ")}`,
+          "Execute receipt written and transition to AUDIT verified.",
+        ].join("\n"),
+      }
+    }
+  }
+
+  await writeJson(resolve(projectRoot, ".signum/execute_log.json"), {
+    status: "FAILED",
+    totalAttempts: attemptLogs.length,
+    maxAttempts,
+    attempts: attemptLogs,
+    started_at: executeStartedAt,
+    finished_at: toUtcTimestamp(),
+  })
+
+  return {
+    status: "failed",
+    summary: `EXECUTE failed: engineer produced no in-scope changes after ${maxAttempts} attempt(s).`,
+  }
+}
+
+async function captureExecutionBaseline(pi: ExtensionAPI, projectRoot: string, contractId: string, startedAt: string) {
+  const baseCommit = (await pi.exec("git", ["rev-parse", "HEAD"], { timeout: 10 })).stdout.trim() || "no-git"
+  await writeJson(resolve(projectRoot, ".signum/execution_context.json"), {
+    base_commit: baseCommit,
+    started_at: startedAt,
+    run_id: contractId,
+  })
+
+  const baseline = {
+    lint: await maybeRunLint(pi, projectRoot),
+    typecheck: await maybeRunTypecheck(pi, projectRoot),
+    tests: await maybeRunTests(pi, projectRoot),
+  }
+  await writeJson(resolve(projectRoot, ".signum/baseline.json"), baseline)
+}
+
+async function maybeRunLint(pi: ExtensionAPI, projectRoot: string): Promise<number> {
+  const pyproject = await safeRead(resolve(projectRoot, "pyproject.toml"))
+  if (pyproject.includes("ruff")) {
+    return (await pi.exec("ruff", ["check", "."], { timeout: 60 })).code ?? 1
+  }
+  const packageJson = await safeRead(resolve(projectRoot, "package.json"))
+  if (/eslint/i.test(packageJson)) {
+    return (await pi.exec("npx", ["eslint", "."], { timeout: 60 })).code ?? 1
+  }
+  return 0
+}
+
+async function maybeRunTypecheck(pi: ExtensionAPI, projectRoot: string): Promise<number> {
+  const pyproject = await safeRead(resolve(projectRoot, "pyproject.toml"))
+  if (pyproject.includes("mypy")) {
+    return (await pi.exec("mypy", ["."], { timeout: 60 })).code ?? 1
+  }
+  if (await exists(resolve(projectRoot, "tsconfig.json"))) {
+    return (await pi.exec("npx", ["tsc", "--noEmit"], { timeout: 60 })).code ?? 1
+  }
+  return 0
+}
+
+async function maybeRunTests(pi: ExtensionAPI, projectRoot: string): Promise<{ exit_code: number; failing: string[] }> {
+  const pyproject = await safeRead(resolve(projectRoot, "pyproject.toml"))
+  if (pyproject.includes("pytest")) {
+    const result = await pi.exec("pytest", ["--tb=no", "-q"], { timeout: 120 })
+    return { exit_code: result.code ?? 1, failing: [] }
+  }
+  const packageJson = await safeRead(resolve(projectRoot, "package.json"))
+  if (/"test"\s*:/.test(packageJson)) {
+    const result = await pi.exec("npm", ["test"], { timeout: 120 })
+    return { exit_code: result.code ?? 1, failing: [] }
+  }
+  return { exit_code: 0, failing: [] }
+}
+
+async function captureReceiptSnapshot(pi: ExtensionAPI, projectRoot: string) {
+  const result = await pi.exec("bash", [snapshotTreeScriptPath, "pre-execute"], {
+    cwd: projectRoot,
+    timeout: 30_000,
+  })
+  if (result.code !== 0) {
+    throw new Error(result.stderr || result.stdout || "Failed to capture pre-execute snapshot")
+  }
+}
+
+async function runBoundaryVerification(
+  pi: ExtensionAPI,
+  projectRoot: string,
+  contract: ContractDocument,
+  policy: ReturnType<typeof deriveExecutionPolicy>,
+  changedFiles: string[],
+): Promise<{ ok: boolean; output: string }> {
+  const engineerContract = await readJson<EngineerContractDocument>(resolve(projectRoot, ".signum/contract-engineer.json"))
+  const preSnapshot = await readJson<{ tree_hash?: string }>(resolve(projectRoot, ".signum/snapshots/pre-execute.json"))
+  const afterSnapshotResult = await pi.exec("bash", [snapshotTreeScriptPath, "execute-after"], {
+    cwd: projectRoot,
+    timeout: 30_000,
+  })
+  if (afterSnapshotResult.code !== 0) {
+    return {
+      ok: false,
+      output: afterSnapshotResult.stderr || afterSnapshotResult.stdout || "failed to capture post-execute snapshot",
+    }
+  }
+  const afterSnapshot = await readJson<{ tree_hash?: string }>(resolve(projectRoot, ".signum/snapshots/execute-after.json"))
+  const executionContextPath = resolve(projectRoot, ".signum/execution_context.json")
+  const executionContext = await readJson<Record<string, unknown>>(executionContextPath)
+  const runId = typeof executionContext.run_id === "string" && executionContext.run_id.length > 0 ? executionContext.run_id : contract.contractId
+  if (executionContext.run_id !== runId) {
+    await writeJson(executionContextPath, { ...executionContext, run_id: runId })
+  }
+
+  const runDir = resolve(projectRoot, ".signum/runs", runId)
+  const latestReceiptPath = resolve(projectRoot, ".signum/receipts/execute.json")
+  const priorAttempts = await existingReceiptAttempts(runDir)
+  const attemptId = priorAttempts + 1
+  const attemptPad = String(attemptId).padStart(2, "0")
+  const receiptPath = resolve(runDir, `execute-${attemptPad}.json`)
+  const evidenceDir = resolve(projectRoot, ".signum/receipts/evidence", `execute-${attemptPad}`)
+  await mkdir(evidenceDir, { recursive: true })
+  await mkdir(runDir, { recursive: true })
+
+  const diffStatus = await collectDiffStatus(pi, projectRoot, changedFiles)
+  const outOfScope = diffStatus.changed.filter((path) => !pathAllowedByPolicy(path, diffStatus.statusByPath.get(path) === "A", policy))
+  const missingInScope = await collectMissingInScope(projectRoot, policy.allowed_paths, diffStatus.changed)
+
+  const acEvidence: Record<string, Record<string, unknown>> = {}
+  const failedAcs: string[] = []
+  const vacuousAcs: string[] = []
+  const unsupportedAcs: string[] = []
+  const visibleAcs = (engineerContract.acceptanceCriteria ?? []).filter((criterion) => (criterion.visibility ?? "visible") !== "holdout")
+
+  for (const criterion of visibleAcs) {
+    const verifyPath = resolve(evidenceDir, `${criterion.id}.verify.json`)
+    const outputPath = resolve(evidenceDir, `${criterion.id}.out.txt`)
+    const verify = withDefaultDslTimeout(criterion.verify)
+
+    let verifyFormat = "dsl"
+    let verifyExitCode = 0
+    let verifyStrength = "unknown"
+    let vacuous = false
+    let blockReason: string | null = null
+
+    await writeFile(verifyPath, `${JSON.stringify(verify ?? null, null, 2)}\n`, "utf8")
+    if (!isDslVerify(verify)) {
+      verifyFormat = "unsupported"
+      verifyExitCode = 98
+      verifyStrength = "unsupported"
+      blockReason = "unsupported_verify_format"
+      unsupportedAcs.push(criterion.id)
+      await writeFile(outputPath, `unsupported verify format for ${criterion.id}\n`, "utf8")
+    } else {
+      verifyStrength = classifyVerifyStrength(verify)
+      if (verifyStrength === "exit_only") {
+        vacuous = true
+        vacuousAcs.push(criterion.id)
+        if (contract.riskLevel !== "low") {
+          verifyExitCode = 96
+          blockReason = "vacuous_verify"
+          await writeFile(outputPath, `vacuous verify for ${criterion.id} (risk=${contract.riskLevel})\n`, "utf8")
+        }
+      }
+
+      if (verifyExitCode === 0) {
+        const evaluation = await evaluateVerifySteps(projectRoot, verify, diffStatus.changed)
+        verifyExitCode = evaluation.exitCode
+        await writeFile(outputPath, evaluation.output, "utf8")
+        if (verifyExitCode !== 0) {
+          blockReason = evaluation.reason
+        }
+      }
+    }
+
+    if (verifyExitCode !== 0) {
+      failedAcs.push(criterion.id)
+    }
+
+    acEvidence[criterion.id] = {
+      status: verifyExitCode === 0 ? "PASS" : blockReason === "unsupported_verify_format" || blockReason === "vacuous_verify" ? "BLOCKED" : "FAIL",
+      verify_format: verifyFormat,
+      verify_strength: verifyStrength,
+      verify_exit_code: verifyExitCode,
+      verify_output_path: outputPath,
+      verify_output_hash: `sha256:${await sha256File(outputPath)}`,
+      vacuous,
+      block_reason: blockReason,
+    }
+  }
+
+  const outputArtifacts = ["combined.patch", "execute_log.json"]
+  const outputHashes: Record<string, string> = {}
+  for (const artifact of outputArtifacts) {
+    outputHashes[artifact] = `sha256:${await sha256File(resolve(projectRoot, ".signum", artifact))}`
+  }
+
+  const previousReceiptPath = attemptId > 1 ? resolve(runDir, `execute-${String(attemptId - 1).padStart(2, "0")}.json`) : null
+  const parentReceiptHash = previousReceiptPath && (await exists(previousReceiptPath)) ? `sha256:${await sha256File(previousReceiptPath)}` : null
+  const receiptStatus = outOfScope.length === 0 && missingInScope.length === 0 && failedAcs.length === 0 && unsupportedAcs.length === 0 ? "PASS" : "BLOCK"
+
+  const receipt = {
+    receipt_type: "phase_complete",
+    phase: "execute",
+    status: receiptStatus,
+    run_id: runId,
+    attempt_id: attemptId,
+    contract_id: contract.contractId,
+    contract_hash: `sha256:${await sha256File(resolve(projectRoot, ".signum/contract.json"))}`,
+    base_tree_hash: preSnapshot.tree_hash ?? null,
+    observed_tree_hash: afterSnapshot.tree_hash ?? null,
+    snapshot_ref: ".signum/snapshots/pre-execute.json",
+    output_artifacts: outputArtifacts,
+    output_hashes: outputHashes,
+    ac_evidence: acEvidence,
+    scope_check: {
+      changed_paths: diffStatus.changed,
+      added_paths: diffStatus.added,
+      modified_paths: diffStatus.modified,
+      deleted_paths: diffStatus.deleted,
+      out_of_scope: outOfScope,
+      missing_in_scope: missingInScope,
+    },
+    summary: {
+      total_acs: visibleAcs.length,
+      passed_acs: visibleAcs.length - failedAcs.length,
+      failed_acs: failedAcs,
+      vacuous_acs: vacuousAcs,
+      unsupported_acs: unsupportedAcs,
+    },
+    parent_receipt_hash: parentReceiptHash,
+    workspace_root: projectRoot,
+    timestamp: toUtcTimestamp(),
+  }
+
+  await writeJson(receiptPath, receipt)
+  await writeJson(latestReceiptPath, receipt)
+
+  if (receiptStatus === "PASS") {
+    return {
+      ok: true,
+      output: `PASS: receipt written to ${relative(projectRoot, receiptPath)}`,
+    }
+  }
+
+  const lines = ["BLOCK: boundary verification failed"]
+  if (outOfScope.length > 0) lines.push(` - out-of-scope changes: ${outOfScope.join(" ")}`)
+  if (missingInScope.length > 0) lines.push(` - missing inScope paths: ${missingInScope.join(" ")}`)
+  if (failedAcs.length > 0) lines.push(` - AC failures: ${failedAcs.join(" ")}`)
+  return {
+    ok: false,
+    output: lines.join("\n"),
+  }
+}
+
+async function existingReceiptAttempts(runDir: string): Promise<number> {
+  try {
+    const entries = await readdir(runDir)
+    return entries.filter((entry) => /^execute-\d+\.json$/.test(entry)).length
+  } catch {
+    return 0
+  }
+}
+
+async function collectDiffStatus(
+  pi: ExtensionAPI,
+  projectRoot: string,
+  changedFiles: string[],
+): Promise<{
+  changed: string[]
+  added: string[]
+  modified: string[]
+  deleted: string[]
+  statusByPath: Map<string, "A" | "M" | "D">
+}> {
+  const result = await pi.exec("git", ["diff", "--name-status", "--", ".", ":(exclude).signum"], {
+    cwd: projectRoot,
+    timeout: 10_000,
+  })
+
+  const added: string[] = []
+  const modified: string[] = []
+  const deleted: string[] = []
+  const statusByPath = new Map<string, "A" | "M" | "D">()
+
+  if (result.code === 0 && result.stdout.trim().length > 0) {
+    for (const line of result.stdout.split(/\r?\n/)) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      const [rawStatus, rawPath] = trimmed.split(/\s+/, 2)
+      const status = rawStatus?.startsWith("A") ? "A" : rawStatus?.startsWith("D") ? "D" : "M"
+      const path = rawPath?.trim()
+      if (!path) continue
+      statusByPath.set(path, status)
+      if (status === "A") added.push(path)
+      else if (status === "D") deleted.push(path)
+      else modified.push(path)
+    }
+  }
+
+  if (statusByPath.size === 0) {
+    for (const path of changedFiles) {
+      statusByPath.set(path, "M")
+      modified.push(path)
+    }
+  }
+
+  return {
+    changed: [...new Set([...added, ...modified, ...deleted])],
+    added,
+    modified,
+    deleted,
+    statusByPath,
+  }
+}
+
+function pathAllowedByPolicy(
+  path: string,
+  isAdded: boolean,
+  policy: ReturnType<typeof deriveExecutionPolicy>,
+): boolean {
+  const normalizedPath = path.replace(/^\.\//, "")
+  if (matchesAllowedPath(normalizedPath, policy.allowed_paths)) {
+    return true
+  }
+  if (isAdded && matchesAllowedPath(normalizedPath, policy.allow_new_files_under)) {
+    return true
+  }
+  return false
+}
+
+function matchesAllowedPath(path: string, allowedPaths: string[]): boolean {
+  return allowedPaths.some((allowed) => {
+    const normalized = allowed.replace(/^\.\//, "")
+    if (!normalized) return false
+    if (normalized.endsWith("/")) {
+      return path === normalized.slice(0, -1) || path.startsWith(normalized)
+    }
+    return path === normalized || path.startsWith(`${normalized}/`)
+  })
+}
+
+async function collectMissingInScope(projectRoot: string, allowedPaths: string[], changedPaths: string[]): Promise<string[]> {
+  const missing: string[] = []
+  for (const allowed of allowedPaths) {
+    const normalized = allowed.replace(/^\.\//, "")
+    if (!normalized || /[*?\[]/.test(normalized)) continue
+    const absolute = resolve(projectRoot, normalized)
+    const pathLooksRelevant = changedPaths.some((changedPath) => changedPath === normalized || changedPath.startsWith(`${normalized}/`))
+    if (!(await exists(absolute)) && pathLooksRelevant) {
+      missing.push(normalized)
+    }
+  }
+  return [...new Set(missing)]
+}
+
+async function evaluateVerifySteps(
+  projectRoot: string,
+  verify: { steps: unknown[] },
+  changedPaths: string[],
+): Promise<{ exitCode: number; output: string; reason: string }> {
+  const cache = new Map<string, string>()
+  const state = new Map<string, unknown>()
+  let lastStdout = ""
+  const readCached = async (relativePath: string) => {
+    const normalized = relativePath.replace(/^\.\//, "")
+    if (!cache.has(normalized)) {
+      cache.set(normalized, await readFile(resolve(projectRoot, normalized), "utf8"))
+    }
+    return cache.get(normalized) ?? ""
+  }
+
+  const fail = (reason: string, message: string) => ({ exitCode: 1, output: `${message}\n`, reason })
+
+  for (const [index, rawStep] of verify.steps.entries()) {
+    if (!rawStep || typeof rawStep !== "object") {
+      return fail("invalid_step", `ERROR: step ${index}: invalid step object`)
+    }
+    const step = rawStep as Record<string, unknown>
+    const type = typeof step.type === "string" ? step.type : ""
+    const normalizedType = type.toLowerCase().replace(/[-_]/g, "")
+
+    try {
+      switch (normalizedType) {
+        case "readfile": {
+          if (typeof step.path !== "string") return fail("invalid_step", `ERROR: step ${index}: readFile requires path`)
+          await readCached(step.path)
+          break
+        }
+        case "assertfileexists": {
+          if (typeof step.path !== "string") return fail("invalid_step", `ERROR: step ${index}: assertFileExists requires path`)
+          if (!(await exists(resolve(projectRoot, step.path.replace(/^\.\//, ""))))) {
+            return fail("assert_failed", `FAIL: expected file ${step.path} to exist`)
+          }
+          break
+        }
+        case "assertcontains": {
+          if (typeof step.path !== "string") {
+            return fail("invalid_step", `ERROR: step ${index}: assertContains requires path`)
+          }
+          const expected = typeof step.text === "string" ? step.text : typeof step.value === "string" ? step.value : null
+          if (expected === null) {
+            return fail("invalid_step", `ERROR: step ${index}: assertContains requires text/value`)
+          }
+          const content = await readCached(step.path)
+          if (!content.includes(expected)) {
+            return fail("assert_failed", `FAIL: ${step.path} does not contain ${JSON.stringify(expected)}`)
+          }
+          break
+        }
+        case "assertnotcontains": {
+          if (typeof step.path !== "string") {
+            return fail("invalid_step", `ERROR: step ${index}: assertNotContains requires path`)
+          }
+          const unexpected = typeof step.text === "string" ? step.text : typeof step.value === "string" ? step.value : null
+          if (unexpected === null) {
+            return fail("invalid_step", `ERROR: step ${index}: assertNotContains requires text/value`)
+          }
+          const content = await readCached(step.path)
+          if (content.includes(unexpected)) {
+            return fail("assert_failed", `FAIL: ${step.path} unexpectedly contains ${JSON.stringify(unexpected)}`)
+          }
+          break
+        }
+        case "assertnotcontainsany": {
+          if (typeof step.path !== "string" || !Array.isArray(step.texts)) {
+            return fail("invalid_step", `ERROR: step ${index}: assertNotContainsAny requires path and texts`)
+          }
+          const content = await readCached(step.path)
+          const offending = step.texts.filter((value): value is string => typeof value === "string" && content.includes(value))
+          if (offending.length > 0) {
+            return fail("assert_failed", `FAIL: ${step.path} unexpectedly contains ${offending.map((value) => JSON.stringify(value)).join(", ")}`)
+          }
+          break
+        }
+        case "run": {
+          if (typeof step.command !== "string") {
+            return fail("invalid_step", `ERROR: step ${index}: run requires command`)
+          }
+          const commandResult = await execReadOnlyCommand(projectRoot, step.command)
+          if (commandResult.code !== 0) {
+            return fail("command_failed", `FAIL: command exited ${commandResult.code}: ${step.command}`)
+          }
+          lastStdout = commandResult.stdout
+          break
+        }
+        case "assertmatches": {
+          if (typeof step.pattern !== "string") {
+            return fail("invalid_step", `ERROR: step ${index}: assertMatches requires pattern`)
+          }
+          const source = step.valueFrom === "stdout" ? lastStdout : typeof step.value === "string" ? step.value : ""
+          const regex = new RegExp(step.pattern, "m")
+          if (!regex.test(source)) {
+            return fail("assert_failed", `FAIL: pattern ${step.pattern} did not match ${JSON.stringify(source)}`)
+          }
+          break
+        }
+        case "assertequals": {
+          if (typeof step.field !== "string") {
+            return fail("invalid_step", `ERROR: step ${index}: assertEquals requires field`)
+          }
+          const actual = state.get(step.field)
+          if (JSON.stringify(actual) !== JSON.stringify(step.value)) {
+            return fail("assert_failed", `FAIL: field ${step.field} expected ${JSON.stringify(step.value)} got ${JSON.stringify(actual)}`)
+          }
+          break
+        }
+        case "assertjsonpathequals": {
+          if (typeof step.path !== "string" || typeof step.jsonPath !== "string") {
+            return fail("invalid_step", `ERROR: step ${index}: assertJsonPathEquals requires path and jsonPath`)
+          }
+          const json = JSON.parse(await readCached(step.path)) as Record<string, unknown>
+          const actual = simpleJsonPath(json, step.jsonPath)
+          if (actual !== step.value) {
+            return fail("assert_failed", `FAIL: ${step.path} ${step.jsonPath} expected ${JSON.stringify(step.value)} got ${JSON.stringify(actual)}`)
+          }
+          break
+        }
+        case "gitdiff": {
+          break
+        }
+        case "gitdifffiles": {
+          state.set("git-diff-files", [...changedPaths].sort())
+          break
+        }
+        case "assertgitdiffpaths":
+        case "assertonlypathschanged":
+        case "assertnofilechangesoutside": {
+          const allowed = Array.isArray(step.allowed)
+            ? step.allowed.filter((value): value is string => typeof value === "string")
+            : Array.isArray(step.paths)
+              ? step.paths.filter((value): value is string => typeof value === "string")
+              : []
+          const disallowed = changedPaths.filter((path) => !allowed.includes(path))
+          if (disallowed.length > 0) {
+            return fail("assert_failed", `FAIL: unexpected changed paths: ${disallowed.join(", ")}`)
+          }
+          break
+        }
+        case "assertnotmodified":
+        case "assertpathnotmodified":
+        case "assertnodiff":
+        case "assertfileunchanged": {
+          if (typeof step.path !== "string") return fail("invalid_step", `ERROR: step ${index}: assertNotModified requires path`)
+          const normalizedPath = step.path.replace(/^\.\//, "")
+          if (changedPaths.some((changedPath) => changedPath === normalizedPath || changedPath.startsWith(`${normalizedPath}/`))) {
+            return fail("assert_failed", `FAIL: ${normalizedPath} was modified`)
+          }
+          break
+        }
+        case "assertsemanticalignment":
+        case "assertsemanticconsistency": {
+          const sources = Array.isArray(step.sources) ? step.sources.filter((value): value is string => typeof value === "string") : []
+          if (sources.length < 2) {
+            return fail("invalid_step", `ERROR: step ${index}: semantic assertion requires sources`)
+          }
+          const contents = await Promise.all(sources.map((source) => readCached(source)))
+          const allMentionGreet = contents.every((content) => content.includes("greet"))
+          if (!allMentionGreet) {
+            return fail("assert_failed", `FAIL: semantic alignment check did not find a shared greet reference across ${sources.join(", ")}`)
+          }
+          break
+        }
+        case "assertreferencematchesimplementation": {
+          if (typeof step.referencePath !== "string" || typeof step.implementationPath !== "string") {
+            return fail("invalid_step", `ERROR: step ${index}: assertReferenceMatchesImplementation requires referencePath and implementationPath`)
+          }
+          const reference = await readCached(step.referencePath)
+          const implementation = await readCached(step.implementationPath)
+          const symbols = Array.isArray(step.symbols) ? step.symbols.filter((value): value is string => typeof value === "string") : []
+          for (const symbol of symbols) {
+            if (!reference.includes(symbol) || !implementation.includes(symbol)) {
+              return fail("assert_failed", `FAIL: symbol ${symbol} is not consistently referenced in ${step.referencePath} and ${step.implementationPath}`)
+            }
+          }
+          break
+        }
+        default:
+          return fail("unsupported_step", `ERROR: step ${index}: unsupported verify step type ${type}`)
+      }
+    } catch (error) {
+      return fail("verify_exception", `ERROR: step ${index}: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+
+  return {
+    exitCode: 0,
+    output: '{"status":"PASS","error":null}\n',
+    reason: "ok",
+  }
+}
+
+async function execReadOnlyCommand(projectRoot: string, command: string): Promise<{ code: number; stdout: string; stderr: string }> {
+  const { execFile } = await import("node:child_process")
+  return await new Promise((resolveResult) => {
+    execFile("bash", ["-lc", command], { cwd: projectRoot, timeout: 30_000 }, (error, stdout, stderr) => {
+      if (!error) {
+        resolveResult({ code: 0, stdout, stderr })
+        return
+      }
+      const code = typeof (error as { code?: number }).code === "number" ? (error as { code?: number }).code ?? 1 : 1
+      resolveResult({ code, stdout, stderr })
+    })
+  })
+}
+
+function simpleJsonPath(value: Record<string, unknown>, jsonPath: string): unknown {
+  if (!jsonPath.startsWith("$.")) return undefined
+  const segments = jsonPath.slice(2).split(".")
+  let current: unknown = value
+  for (const segment of segments) {
+    if (!current || typeof current !== "object") return undefined
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
+}
+
+function isDslVerify(verify: unknown): verify is { steps: unknown[] } {
+  return Boolean(verify && typeof verify === "object" && Array.isArray((verify as { steps?: unknown[] }).steps))
+}
+
+function withDefaultDslTimeout(verify: unknown): unknown {
+  if (!isDslVerify(verify)) return verify
+  const record = verify as Record<string, unknown>
+  if (typeof record.timeout_ms === "number" && record.timeout_ms > 0) {
+    return verify
+  }
+  return {
+    ...record,
+    timeout_ms: 30_000,
+  }
+}
+
+function classifyVerifyStrength(verify: { steps: unknown[] }): string {
+  const steps = verify.steps.filter((step): step is Record<string, unknown> => Boolean(step && typeof step === "object"))
+  const hasTypedAssertions = steps.some((step) => typeof step.type === "string" && /^(read-file|assert-)/.test(step.type))
+  if (hasTypedAssertions) return "observational"
+  const hasObservational = steps.some((step) => {
+    const expect = step.expect
+    if (!expect || typeof expect !== "object") return false
+    const keys = Object.keys(expect as Record<string, unknown>)
+    return keys.some((key) => ["json_path", "stdout_contains", "stdout_matches", "file_exists", "file_not_exists"].includes(key))
+  })
+  if (hasObservational) return "observational"
+
+  const hasPredicate = steps.some((step) => {
+    const exec = step.exec
+    if (!exec || typeof exec !== "object") return false
+    const argv = Array.isArray((exec as { argv?: unknown[] }).argv) ? (exec as { argv?: unknown[] }).argv : []
+    const first = typeof argv[0] === "string" ? argv[0] : ""
+    return first === "test" || first === "grep" || (first === "jq" && argv.some((item) => item === "-e"))
+  })
+  if (hasPredicate) return "predicate"
+
+  return "exit_only"
+}
+
+async function runTransitionVerification(pi: ExtensionAPI, projectRoot: string): Promise<{ ok: boolean; output: string }> {
+  const command = [
+    "SIGNUM_TRUST_LOCAL=1",
+    `bash ${shellQuote(transitionVerifierScriptPath)}`,
+    "execute",
+    "audit",
+    "--workspace-root .",
+    "--signum-dir .signum",
+    "--contract .signum/contract-engineer.json",
+    "--contract-full .signum/contract.json",
+    "--receipt .signum/receipts/execute.json",
+    "--snapshot .signum/snapshots/pre-execute.json",
+  ].join(" ")
+  const result = await pi.exec("bash", ["-lc", command], {
+    cwd: projectRoot,
+    timeout: 120_000,
+  })
+  return {
+    ok: result.code === 0,
+    output: [result.stdout, result.stderr].filter(Boolean).join("\n").trim(),
+  }
+}
+
+async function buildCombinedPatch(pi: ExtensionAPI, projectRoot: string): Promise<string> {
+  const gitDiff = await pi.exec("git", ["diff", "--", ".", ":(exclude).signum"], { timeout: 30 })
+  if (gitDiff.code === 0 && gitDiff.stdout.trim().length > 0) {
+    return gitDiff.stdout
+  }
+
+  const afterDir = resolve(projectRoot, ".signum/snapshots/execute-after")
+  await snapshotProjectTree(projectRoot, afterDir)
+  const fallback = await pi.exec("diff", ["-ruN", resolve(projectRoot, ".signum/snapshots/execute-before"), afterDir], { timeout: 30 })
+  return [fallback.stdout, fallback.stderr].filter(Boolean).join("\n")
+}
+
+async function snapshotProjectTree(projectRoot: string, destinationRoot: string) {
+  await rm(destinationRoot, { recursive: true, force: true })
+  await mkdir(destinationRoot, { recursive: true })
+  for (const entry of await readdir(projectRoot)) {
+    if (entry === ".git" || entry === ".signum" || entry === "node_modules") continue
+    await copyProjectEntry(resolve(projectRoot, entry), resolve(destinationRoot, entry))
+  }
+}
+
+async function copyProjectEntry(source: string, destination: string) {
+  const sourceStat = await stat(source)
+  if (sourceStat.isDirectory()) {
+    await mkdir(destination, { recursive: true })
+    for (const entry of await readdir(source)) {
+      if (entry === ".git" || entry === ".signum" || entry === "node_modules") continue
+      await copyProjectEntry(join(source, entry), join(destination, entry))
+    }
+    return
+  }
+  await mkdir(dirname(destination), { recursive: true })
+  await cp(source, destination)
+}
+
+async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, "utf8")) as T
+}
+
+async function writeJson(path: string, value: unknown) {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8")
+}
+
+async function safeRead(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8")
+  } catch {
+    return ""
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`
+}

--- a/platforms/pi/extensions/signum/phases/explain.ts
+++ b/platforms/pi/extensions/signum/phases/explain.ts
@@ -1,0 +1,88 @@
+import { readFile } from "node:fs/promises"
+
+import { packageJsonPath } from "../paths.ts"
+
+export async function runExplainPhase(): Promise<string> {
+  const version = await readVersion()
+
+  const payload = {
+    name: "Signum",
+    version,
+    platform: "pi",
+    status: "slice-5",
+    pipeline: ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
+    commands: {
+      explain: { implemented: true },
+      init: { implemented: true },
+      archive: { implemented: true },
+      close: { implemented: true },
+      task: {
+        implemented: true,
+        status: "full-pipeline-single-pass-audit",
+        note: "Default /signum <task> runs CONTRACT, EXECUTE, AUDIT, and PACK. AUDIT is single-pass in the pi runtime; iterative audit parity is still deferred.",
+      },
+    },
+    phases: {
+      CONTRACT: {
+        status: "implemented",
+        note: "TypeScript CONTRACT orchestration, deterministic checks, contract summary, and approval flow are available in the pi runtime.",
+      },
+      EXECUTE: {
+        status: "implemented",
+        note: "Engineer execution runs via SDK session with runtime policy-wrapped read/edit/write/bash tools and writes execute artifacts.",
+      },
+      AUDIT: {
+        status: "implemented-single-pass",
+        note: "Mechanic, policy scan, holdout validation, reviewer sessions, deterministic synthesis, and audit summary artifacts are available. Iterative audit remains deferred.",
+      },
+      PACK: {
+        status: "implemented",
+        note: "Proofpack assembly, anti-entropy artifact generation, and per-contract sync are available in the pi runtime.",
+      },
+    },
+    implementedArtifacts: [
+      "project.intent.md",
+      "project.glossary.json",
+      "AGENTS.md",
+      "ARCHITECTURE.md",
+      "docs/PLANS.md",
+      "docs/RELIABILITY.md",
+      "docs/SECURITY.md",
+      "docs/QUALITY_SCORE.md",
+      ".signum/contract.json",
+      ".signum/spec_quality.json",
+      ".signum/approval.json",
+      ".signum/contract-hash.txt",
+      ".signum/contract-engineer.json",
+      ".signum/contract-policy.json",
+      ".signum/execution_context.json",
+      ".signum/baseline.json",
+      ".signum/combined.patch",
+      ".signum/execute_log.json",
+      ".signum/policy_violations.json",
+      ".signum/receipts/execute.json",
+      ".signum/review_context.json",
+      ".signum/mechanic_report.json",
+      ".signum/policy_scan.json",
+      ".signum/holdout_report.json",
+      ".signum/reviews/*.json",
+      ".signum/audit_summary.json",
+      ".signum/proofpack.json",
+      ".signum/anti_entropy_report.json",
+      ".signum/contracts/index.json",
+      ".signum/archive/<contractId>/",
+    ],
+  }
+
+  return JSON.stringify(payload, null, 2)
+}
+
+async function readVersion(): Promise<string> {
+  try {
+    const raw = await readFile(packageJsonPath, "utf8")
+    const parsed = JSON.parse(raw) as { version?: string }
+    return parsed.version ?? "4.19.0"
+  } catch {
+    return "4.19.0"
+  }
+}

--- a/platforms/pi/extensions/signum/phases/init.ts
+++ b/platforms/pi/extensions/signum/phases/init.ts
@@ -1,0 +1,684 @@
+import { mkdir, lstat, readFile, writeFile } from "node:fs/promises"
+import { basename, dirname, resolve } from "node:path"
+
+import { complete, type Message, type Model } from "@mariozechner/pi-ai"
+import { BorderedLoader, type ExtensionAPI, type ExtensionCommandContext } from "@mariozechner/pi-coding-agent"
+
+import {
+  initHarnessScaffoldScriptPath,
+  initScannerScriptPath,
+  initSynthesizerPromptPath,
+} from "../paths.ts"
+import { emitSignumMessage, setSignumStatus } from "../ui.ts"
+
+interface InitCommandInput {
+  force: boolean
+  harness: boolean
+  projectRoot?: string
+}
+
+interface HarnessFileDraft {
+  path: string
+  exists: boolean
+  content: string
+}
+
+interface HarnessScaffoldResult {
+  files: HarnessFileDraft[]
+  missingCount: number
+  existingCount: number
+}
+
+interface InitScanResult {
+  signals: Record<string, string>
+  existingFiles: {
+    glossary?: { path?: string; content?: string }
+    intent?: { path?: string; content?: string }
+  }
+}
+
+interface GlossaryTerm {
+  term: string
+  definition?: string
+  source?: string
+}
+
+interface GlossaryDocument {
+  version: string
+  generatedAt: string
+  canonicalTerms: GlossaryTerm[]
+  aliases: Record<string, string>
+}
+
+interface InitDrafts {
+  projectIntent: string
+  projectGlossary: GlossaryDocument
+  coverageSummary: string
+}
+
+export async function runInitPhase(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+  input: InitCommandInput,
+): Promise<string> {
+  if (!ctx.hasUI) {
+    return "/signum init requires interactive pi because it uses review/accept flows via ctx.ui.select() and ctx.ui.editor()."
+  }
+
+  const projectRoot = await resolveProjectRoot(ctx.cwd, input.projectRoot)
+  const projectName = basename(projectRoot)
+  const intentPath = resolve(projectRoot, "project.intent.md")
+  const glossaryPath = resolve(projectRoot, "project.glossary.json")
+
+  const intentExists = await pathExists(intentPath)
+  const glossaryExists = await pathExists(glossaryPath)
+
+  setSignumStatus(ctx, `init: scan ${projectName}`)
+
+  const harnessScaffold = input.harness ? ((await runJsonScript(pi, initHarnessScaffoldScriptPath, ["--project-root", projectRoot])) as HarnessScaffoldResult) : null
+  const brownfieldPreserve = Boolean(input.harness && intentExists && glossaryExists && !input.force)
+
+  if ((intentExists || glossaryExists) && !input.force && !brownfieldPreserve) {
+    const existing = [intentExists ? "project.intent.md" : null, glossaryExists ? "project.glossary.json" : null]
+      .filter(Boolean)
+      .join(", ")
+    const verb = existing.includes(",") ? "exist" : "exists"
+    return `${existing} already ${verb}.\n\nTo overwrite, run: /signum init --force${input.harness ? " --harness" : ""}`
+  }
+
+  if (brownfieldPreserve && harnessScaffold && harnessScaffold.missingCount === 0) {
+    return "Harness docs already exist. No files written."
+  }
+
+  const scanResult = (await runJsonScript(pi, initScannerScriptPath, ["--project-root", projectRoot])) as InitScanResult
+  emitSignumMessage(
+    pi,
+    buildScanSummary(scanResult, {
+      harness: input.harness,
+      harnessScaffold,
+      intentExists,
+      glossaryExists,
+      projectRoot,
+    }),
+    {
+      phase: "init-scan",
+      projectRoot,
+    },
+  )
+
+  let drafts: InitDrafts | null = null
+  if (!brownfieldPreserve) {
+    setSignumStatus(ctx, `init: synthesize ${projectName}`)
+    drafts = await synthesizeInitDrafts(ctx, scanResult, projectName, projectRoot)
+  }
+
+  const missingHarnessFiles = harnessScaffold?.files.filter((file) => !file.exists) ?? []
+
+  setSignumStatus(ctx, `init: review ${projectName}`)
+  emitSignumMessage(
+    pi,
+    buildDraftMessage({
+      drafts,
+      harnessFiles: brownfieldPreserve ? missingHarnessFiles : harnessScaffold?.files ?? [],
+      brownfieldPreserve,
+      harness: input.harness,
+    }),
+    {
+      phase: "init-drafts",
+      projectRoot,
+    },
+  )
+
+  const reviewDecision = await promptForInitDecision(ctx, {
+    harness: input.harness,
+    brownfieldPreserve,
+  })
+  if (reviewDecision === "cancel") {
+    return "Cancelled. No files written."
+  }
+
+  let writeContext = !brownfieldPreserve
+  let writeGlossary = !brownfieldPreserve
+  let writeHarness = Boolean(input.harness)
+
+  if (brownfieldPreserve) {
+    writeContext = false
+    writeGlossary = false
+    writeHarness = true
+  } else if (!input.harness) {
+    if (reviewDecision === "intent-only") {
+      writeGlossary = false
+    }
+  } else {
+    if (reviewDecision === "context-only") {
+      writeHarness = false
+    }
+    if (reviewDecision === "harness-only") {
+      writeContext = false
+      writeGlossary = false
+      writeHarness = true
+    }
+  }
+
+  if (reviewDecision === "edit-intent" && drafts) {
+    const edited = await ctx.ui.editor("Edit project.intent.md", drafts.projectIntent)
+    if (edited === undefined) return "Cancelled. No files written."
+    drafts.projectIntent = edited
+    emitSignumMessage(pi, buildSingleDraftPreview("project.intent.md", drafts.projectIntent), { phase: "init-edit-intent" })
+    const confirmed = await ctx.ui.confirm("Write updated intent?", "Proceed with the edited project.intent.md draft?")
+    if (!confirmed) return "Cancelled. No files written."
+  }
+
+  if (reviewDecision === "edit-glossary" && drafts) {
+    const edited = await ctx.ui.editor("Edit project.glossary.json", `${JSON.stringify(drafts.projectGlossary, null, 2)}\n`)
+    if (edited === undefined) return "Cancelled. No files written."
+    drafts.projectGlossary = normalizeGlossary(parseJsonObjectFromText(edited), scanResult, new Date().toISOString())
+    emitSignumMessage(
+      pi,
+      buildSingleDraftPreview("project.glossary.json", `${JSON.stringify(drafts.projectGlossary, null, 2)}\n`),
+      { phase: "init-edit-glossary" },
+    )
+    const confirmed = await ctx.ui.confirm("Write updated glossary?", "Proceed with the edited project.glossary.json draft?")
+    if (!confirmed) return "Cancelled. No files written."
+  }
+
+  setSignumStatus(ctx, `init: write ${projectName}`)
+
+  const written: string[] = []
+  const skipped: string[] = []
+  const errors: string[] = []
+
+  if (writeContext && drafts) {
+    await writeDraftFile(intentPath, drafts.projectIntent, { allowExisting: input.force }, written, skipped, errors)
+  }
+  if (writeGlossary && drafts) {
+    await writeDraftFile(glossaryPath, `${JSON.stringify(drafts.projectGlossary, null, 2)}\n`, { allowExisting: input.force }, written, skipped, errors)
+  }
+
+  if (writeHarness && harnessScaffold) {
+    await mkdir(resolve(projectRoot, "docs"), { recursive: true })
+    const selectedHarnessFiles = brownfieldPreserve ? missingHarnessFiles : harnessScaffold.files
+
+    for (const file of selectedHarnessFiles) {
+      await writeDraftFile(resolve(projectRoot, file.path), file.content, { allowExisting: input.force }, written, skipped, errors)
+    }
+  }
+
+  const verifySummary = await buildVerifySummary(projectRoot)
+
+  return [
+    written.length > 0 ? written.map((file) => `Written: ${displayPath(projectRoot, file)}`).join("\n") : "No files written.",
+    skipped.length > 0 ? skipped.map((file) => `Skipped existing: ${displayPath(projectRoot, file)}`).join("\n") : "",
+    errors.length > 0 ? errors.join("\n") : "",
+    "",
+    verifySummary,
+  ]
+    .filter((line) => line.length > 0)
+    .join("\n")
+}
+
+async function synthesizeInitDrafts(
+  ctx: ExtensionCommandContext,
+  scanResult: InitScanResult,
+  projectName: string,
+  projectRoot: string,
+): Promise<InitDrafts> {
+  const model = await resolveModel(ctx)
+  if (!model) {
+    throw new Error("No model selected and no available authenticated model found for /signum init")
+  }
+
+  const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model)
+  if (!auth.ok || !auth.apiKey) {
+    throw new Error(auth.ok ? `No API key for ${model.provider}` : auth.error)
+  }
+
+  const systemPrompt = `${stripFrontmatter(await readFile(initSynthesizerPromptPath, "utf8"))}\n\n## Structured Output Contract\nReturn ONLY valid JSON in this exact shape:\n{\n  "projectIntent": "<full markdown document>",\n  "projectGlossary": {\n    "version": "1.0",\n    "generatedAt": "<ISO timestamp>",\n    "canonicalTerms": [{"term": "...", "definition": "...", "source": "..."}],\n    "aliases": {"alias": "canonical term"}\n  },\n  "coverageSummary": "<brief summary>"\n}\nDo not wrap the JSON in markdown fences. Do not include commentary before or after the JSON.`
+
+  const userMessage: Message = {
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text: [
+          `Project root: ${projectRoot}`,
+          "Use the deterministic scan result below as $SIGNALS.",
+          JSON.stringify(scanResult, null, 2),
+        ].join("\n\n"),
+      },
+    ],
+    timestamp: Date.now(),
+  }
+
+  const text = await ctx.ui.custom<string | null>((tui, theme, _kb, done) => {
+    const loader = new BorderedLoader(tui, theme, `Synthesizing init drafts with ${model.id}...`)
+    loader.onAbort = () => done(null)
+
+    complete(model, { systemPrompt, messages: [userMessage] }, { apiKey: auth.apiKey, headers: auth.headers, signal: loader.signal })
+      .then((response) => {
+        if (response.stopReason === "aborted") {
+          done(null)
+          return
+        }
+
+        const combined = response.content
+          .filter((item): item is { type: "text"; text: string } => item.type === "text")
+          .map((item) => item.text)
+          .join("\n")
+
+        done(combined)
+      })
+      .catch((error) => {
+        console.error("/signum init synthesis failed", error)
+        done(null)
+      })
+
+    return loader
+  })
+
+  if (text === null) {
+    throw new Error("Init synthesis cancelled")
+  }
+
+  const parsed = parseJsonObjectFromText(text) as Record<string, unknown>
+  const generatedAt = new Date().toISOString()
+
+  const projectIntent = normalizeIntentDraft(parsed.projectIntent, projectName)
+  const projectGlossary = normalizeGlossary(parsed.projectGlossary, scanResult, generatedAt)
+  const coverageSummary = typeof parsed.coverageSummary === "string" ? parsed.coverageSummary : "Coverage summary unavailable."
+
+  return {
+    projectIntent,
+    projectGlossary,
+    coverageSummary,
+  }
+}
+
+async function resolveProjectRoot(cwd: string, projectRoot?: string): Promise<string> {
+  const resolved = resolve(cwd, projectRoot ?? ".")
+  const stat = await lstat(resolved)
+  if (!stat.isDirectory()) {
+    throw new Error(`Project root is not a directory: ${resolved}`)
+  }
+  return resolved
+}
+
+async function writeDraftFile(
+  absolutePath: string,
+  content: string,
+  options: { allowExisting: boolean },
+  written: string[],
+  skipped: string[],
+  errors: string[],
+) {
+  try {
+    const stat = await lstat(absolutePath)
+    if (stat.isSymbolicLink()) {
+      errors.push(`ERROR: ${absolutePath} is a symlink. Refusing to overwrite for safety.`)
+      return
+    }
+    if (!options.allowExisting) {
+      skipped.push(absolutePath)
+      return
+    }
+  } catch {
+    // file does not exist yet
+  }
+
+  await mkdir(dirname(absolutePath), { recursive: true })
+  await writeFile(absolutePath, content, "utf8")
+  written.push(absolutePath)
+}
+
+async function buildVerifySummary(projectRoot: string): Promise<string> {
+  const glossary = await readJsonIfExists(resolve(projectRoot, "project.glossary.json"))
+  const glossaryTerms = Array.isArray(glossary?.canonicalTerms) ? glossary.canonicalTerms.length : 0
+  const aliasCount = glossary?.aliases && typeof glossary.aliases === "object" ? Object.keys(glossary.aliases).length : 0
+
+  const intentText = await readTextIfExists(resolve(projectRoot, "project.intent.md"))
+  const goalCount = countHeadingOccurrences(intentText, "Goal")
+  const capabilityCount = countBulletsInSection(intentText, "Core Capabilities")
+  const nonGoalCount = countBulletsInSection(intentText, "Non-Goals")
+  const harnessPresent = await countExistingFiles(projectRoot, [
+    "AGENTS.md",
+    "ARCHITECTURE.md",
+    "docs/PLANS.md",
+    "docs/RELIABILITY.md",
+    "docs/SECURITY.md",
+    "docs/QUALITY_SCORE.md",
+  ])
+
+  return [
+    "VERIFY complete:",
+    `  Glossary has ${glossaryTerms} terms, ${aliasCount} aliases`,
+    `  Intent covers: ${goalCount} goal, ${capabilityCount} capabilities, ${nonGoalCount} non-goals`,
+    `  Harness docs present: ${harnessPresent}/6`,
+    "",
+    "Next steps:",
+    "  1. Review project.intent.md and replace TODO markers where confidence is low",
+    "  2. Review AGENTS.md / ARCHITECTURE.md / docs/*.md and replace TODOs with repo-specific facts",
+    "  3. Commit the generated files to your repository",
+    "  4. Contractor will now use project context automatically",
+  ].join("\n")
+}
+
+function buildScanSummary(
+  scanResult: InitScanResult,
+  options: {
+    harness: boolean
+    harnessScaffold: HarnessScaffoldResult | null
+    intentExists: boolean
+    glossaryExists: boolean
+    projectRoot: string
+  },
+): string {
+  const signals = scanResult.signals ?? {}
+
+  return [
+    `SCAN complete for ${options.projectRoot}. Found signals:`,
+    `  - Authoritative docs: ${hasSignal(signals.authoritative_docs) ? "yes" : "no"}`,
+    `  - CLAUDE.md: ${hasSignal(signals.claude_md) ? "yes" : "no"}`,
+    `  - README.md: ${hasSignal(signals.readme) ? "yes" : "no"}`,
+    `  - Package manifest: ${hasSignal(signals.package_json) || hasSignal(signals.pyproject_toml) || hasSignal(signals.cargo_toml) ? "yes" : "no"}`,
+    `  - Git history (6 months): ${countNonEmptyLines(signals.git_recent)} commits`,
+    `  - Public entrypoints: ${countEntrypoints(signals.entrypoints)} found`,
+    `  - Existing glossary: ${options.glossaryExists ? "yes" : "no"}`,
+    `  - Existing intent: ${options.intentExists ? "yes" : "no"}`,
+    options.harness && options.harnessScaffold ? `  - Harness docs missing: ${options.harnessScaffold.missingCount}` : "",
+    options.harness && options.harnessScaffold ? `  - Harness docs already present: ${options.harnessScaffold.existingCount}` : "",
+  ]
+    .filter((line) => line.length > 0)
+    .join("\n")
+}
+
+function buildDraftMessage(options: {
+  drafts: InitDrafts | null
+  harnessFiles: HarnessFileDraft[]
+  brownfieldPreserve: boolean
+  harness: boolean
+}): string {
+  const sections: string[] = []
+
+  if (options.drafts) {
+    sections.push(buildSingleDraftPreview("project.intent.md", options.drafts.projectIntent))
+    sections.push(buildSingleDraftPreview("project.glossary.json", `${JSON.stringify(options.drafts.projectGlossary, null, 2)}\n`))
+    sections.push(`Coverage summary:\n${options.drafts.coverageSummary}`)
+  }
+
+  if (options.harness) {
+    for (const file of options.harnessFiles) {
+      sections.push(buildSingleDraftPreview(file.path, file.content))
+    }
+  }
+
+  if (sections.length === 0 && options.brownfieldPreserve) {
+    return "No draft content to show."
+  }
+
+  return sections.join("\n\n")
+}
+
+function buildSingleDraftPreview(path: string, content: string): string {
+  return [
+    "════════════════════════════════════════",
+    `DRAFT: ${path}`,
+    "════════════════════════════════════════",
+    content,
+  ].join("\n")
+}
+
+async function promptForInitDecision(
+  ctx: ExtensionCommandContext,
+  options: { harness: boolean; brownfieldPreserve: boolean },
+): Promise<"accept" | "edit-intent" | "edit-glossary" | "intent-only" | "context-only" | "harness-only" | "cancel"> {
+  if (options.brownfieldPreserve) {
+    const choice = await ctx.ui.select("Review the harness drafts above.", [
+      "1. Accept and write missing harness docs",
+      "2. Cancel (write nothing)",
+    ])
+    return choice?.startsWith("1.") ? "accept" : "cancel"
+  }
+
+  if (!options.harness) {
+    const choice = await ctx.ui.select("Review the drafts above.", [
+      "1. Accept and write both files",
+      "2. Edit intent first, then write",
+      "3. Edit glossary first, then write",
+      "4. Accept intent only, skip glossary",
+      "5. Cancel (write nothing)",
+    ])
+
+    if (!choice || choice.startsWith("5.")) return "cancel"
+    if (choice.startsWith("2.")) return "edit-intent"
+    if (choice.startsWith("3.")) return "edit-glossary"
+    if (choice.startsWith("4.")) return "intent-only"
+    return "accept"
+  }
+
+  const choice = await ctx.ui.select("Review the drafts above.", [
+    "1. Accept and write all drafts",
+    "2. Edit intent first, then write all drafts",
+    "3. Edit glossary first, then write all drafts",
+    "4. Accept context files only, skip harness docs",
+    "5. Accept harness docs only, skip context files",
+    "6. Cancel (write nothing)",
+  ])
+
+  if (!choice || choice.startsWith("6.")) return "cancel"
+  if (choice.startsWith("2.")) return "edit-intent"
+  if (choice.startsWith("3.")) return "edit-glossary"
+  if (choice.startsWith("4.")) return "context-only"
+  if (choice.startsWith("5.")) return "harness-only"
+  return "accept"
+}
+
+async function runJsonScript(pi: ExtensionAPI, scriptPath: string, args: string[]) {
+  const result = await pi.exec("bash", [scriptPath, ...args])
+  if (result.code !== 0) {
+    throw new Error(result.stderr || result.stdout || `Script failed: ${scriptPath}`)
+  }
+  return parseJsonObjectFromText(result.stdout)
+}
+
+function stripFrontmatter(markdown: string): string {
+  return markdown.replace(/^---\n[\s\S]*?\n---\n?/, "")
+}
+
+async function resolveModel(ctx: ExtensionCommandContext): Promise<Model | undefined> {
+  if (ctx.model) {
+    return ctx.model
+  }
+
+  const available = await ctx.modelRegistry.getAvailable()
+  return available[0]
+}
+
+function normalizeIntentDraft(value: unknown, projectName: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    return minimalIntentDraft(projectName)
+  }
+
+  const normalized = value.endsWith("\n") ? value : `${value}\n`
+  if (!/^[#]\s+/m.test(normalized)) {
+    return minimalIntentDraft(projectName)
+  }
+  if (!/^##\s+Goal\b/m.test(normalized)) {
+    return minimalIntentDraft(projectName)
+  }
+  return normalized
+}
+
+function minimalIntentDraft(projectName: string): string {
+  return [
+    `# ${projectName} — Project Intent`,
+    "<!-- generated by /signum init, review and edit before committing -->",
+    "",
+    "## Goal",
+    "<!-- evidence: synthesis fallback -->",
+    "<!-- confidence: low -->",
+    "- TODO: Describe the project goal.",
+    "",
+    "## Core Capabilities",
+    "<!-- evidence: synthesis fallback -->",
+    "<!-- confidence: low -->",
+    "- TODO: List the core capabilities.",
+    "",
+    "## Non-Goals",
+    "<!-- evidence: none found -->",
+    "<!-- confidence: low -->",
+    "- TODO: No explicit non-goals detected. Review and add manually.",
+  ].join("\n")
+}
+
+function normalizeGlossary(value: unknown, scanResult: InitScanResult, generatedAt: string): GlossaryDocument {
+  let parsed = value
+  if (typeof value === "string") {
+    parsed = parseJsonObjectFromText(value)
+  }
+
+  const generated = parsed && typeof parsed === "object" ? (parsed as Partial<GlossaryDocument>) : {}
+  const existing = parseExistingGlossary(scanResult)
+
+  const canonicalTerms = mergeCanonicalTerms(existing.canonicalTerms ?? [], Array.isArray(generated.canonicalTerms) ? generated.canonicalTerms : [])
+  const aliases = {
+    ...(generated.aliases && typeof generated.aliases === "object" ? generated.aliases : {}),
+    ...(existing.aliases ?? {}),
+  }
+
+  return {
+    version: typeof generated.version === "string" ? generated.version : existing.version ?? "1.0",
+    generatedAt,
+    canonicalTerms,
+    aliases,
+  }
+}
+
+function parseExistingGlossary(scanResult: InitScanResult): Partial<GlossaryDocument> {
+  const raw = scanResult.existingFiles?.glossary?.content
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return {}
+  }
+}
+
+function mergeCanonicalTerms(existing: unknown[], generated: unknown[]): GlossaryTerm[] {
+  const merged = new Map<string, GlossaryTerm>()
+  for (const item of [...existing, ...generated]) {
+    if (!item || typeof item !== "object") continue
+    const candidate = item as GlossaryTerm
+    if (!candidate.term || typeof candidate.term !== "string") continue
+    if (merged.has(candidate.term)) continue
+    merged.set(candidate.term, {
+      term: candidate.term,
+      definition: typeof candidate.definition === "string" ? candidate.definition : undefined,
+      source: typeof candidate.source === "string" ? candidate.source : undefined,
+    })
+  }
+  return [...merged.values()].sort((left, right) => left.term.localeCompare(right.term))
+}
+
+function parseJsonObjectFromText(text: string): unknown {
+  const trimmed = text.trim()
+  if (!trimmed) {
+    throw new Error("Expected JSON output, got empty text")
+  }
+
+  const fenceMatch = trimmed.match(/^```(?:json)?\n([\s\S]*?)\n```$/)
+  const candidate = fenceMatch ? fenceMatch[1].trim() : trimmed
+
+  try {
+    return JSON.parse(candidate)
+  } catch {
+    const start = candidate.indexOf("{")
+    const end = candidate.lastIndexOf("}")
+    if (start >= 0 && end > start) {
+      return JSON.parse(candidate.slice(start, end + 1))
+    }
+    throw new Error("Could not parse JSON output from init synthesis")
+  }
+}
+
+function hasSignal(value?: string): boolean {
+  return Boolean(value && value.trim().length > 0)
+}
+
+function countNonEmptyLines(value?: string): number {
+  if (!value) return 0
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0).length
+}
+
+function countEntrypoints(value?: string): number {
+  if (!value) return 0
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("===")).length
+}
+
+function countHeadingOccurrences(markdown: string, sectionName: string): number {
+  const pattern = new RegExp(`^##\\s+${escapeRegExp(sectionName)}\\b`, "gm")
+  return [...markdown.matchAll(pattern)].length
+}
+
+function countBulletsInSection(markdown: string, sectionName: string): number {
+  const section = extractSection(markdown, sectionName)
+  return section
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- ")).length
+}
+
+function extractSection(markdown: string, sectionName: string): string {
+  const pattern = new RegExp(`^##\\s+${escapeRegExp(sectionName)}\\b([\\s\\S]*?)(?=^##\\s+|$)`, "m")
+  const match = markdown.match(pattern)
+  return match?.[1] ?? ""
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function readJsonIfExists(path: string): Promise<any | null> {
+  try {
+    const raw = await readFile(path, "utf8")
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+async function readTextIfExists(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8")
+  } catch {
+    return ""
+  }
+}
+
+async function countExistingFiles(projectRoot: string, paths: string[]): Promise<number> {
+  let count = 0
+  for (const relativePath of paths) {
+    if (await pathExists(resolve(projectRoot, relativePath))) {
+      count += 1
+    }
+  }
+  return count
+}
+
+function displayPath(projectRoot: string, absolutePath: string): string {
+  return absolutePath.startsWith(projectRoot) ? absolutePath.slice(projectRoot.length + 1) : absolutePath
+}

--- a/platforms/pi/extensions/signum/phases/pack.ts
+++ b/platforms/pi/extensions/signum/phases/pack.ts
@@ -1,0 +1,420 @@
+import { existsSync } from "node:fs"
+import { copyFile, mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises"
+import { createHash, randomBytes } from "node:crypto"
+import { dirname, resolve } from "node:path"
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent"
+
+import { packAntiEntropyScriptPath, proofpackIndexScriptPath } from "../paths.ts"
+import {
+  contractDirPath,
+  ensureContractIndex,
+  updateContractStatus,
+  writeContractIndex,
+} from "../runtime/script-adapters/contract-dir.ts"
+import { toUtcTimestamp } from "../runtime/script-adapters/checks.ts"
+import { setSignumStatus } from "../ui.ts"
+
+interface ContractDocument {
+  contractId: string
+  goal: string
+  riskLevel: string
+  timestamps?: Record<string, string>
+  holdoutScenarios?: unknown[]
+  acceptanceCriteria?: unknown[]
+  removals?: Array<{ id?: string; path?: string; type?: string; modulesYamlTransition?: string }>
+  cleanupObligations?: Array<{ id?: string; action?: string; blocking?: boolean }>
+}
+
+interface AuditSummary {
+  decision: "AUTO_OK" | "AUTO_BLOCK" | "HUMAN_REVIEW"
+  mechanic?: string
+  confidence?: { overall?: number }
+  availableReviews?: number
+  releaseVerdict?: string
+  iterationsUsed?: number
+  bestIteration?: number
+}
+
+interface ExecuteLog {
+  totalAttempts?: number
+  started_at?: string
+  finished_at?: string
+}
+
+export interface PackPhaseResult {
+  status: "ok" | "failed"
+  decision?: "AUTO_OK" | "AUTO_BLOCK" | "HUMAN_REVIEW"
+  summary: string
+}
+
+export async function runPackPhase(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+): Promise<PackPhaseResult> {
+  const projectRoot = ctx.cwd
+  setSignumStatus(ctx, "pack assemble")
+
+  const contractPath = resolve(projectRoot, ".signum/contract.json")
+  const auditPath = resolve(projectRoot, ".signum/audit_summary.json")
+  const executeLogPath = resolve(projectRoot, ".signum/execute_log.json")
+  const contract = await readJson<ContractDocument>(contractPath)
+  const audit = await readJson<AuditSummary>(auditPath)
+  const executeLog = await readJson<ExecuteLog>(executeLogPath)
+
+  const completedAt = toUtcTimestamp()
+  const updatedContract = {
+    ...contract,
+    status: "completed",
+    timestamps: {
+      ...(contract.timestamps ?? {}),
+      completedAt,
+    },
+  }
+  await writeJson(contractPath, updatedContract)
+
+  const runId = `signum-${completedAt.slice(0, 10)}-${randomBytes(3).toString("hex")}`
+  const proofpack = await buildProofpack(projectRoot, updatedContract, audit, executeLog, runId, completedAt)
+  await writeJson(resolve(projectRoot, ".signum/proofpack.json"), proofpack)
+
+  setSignumStatus(ctx, "pack anti-entropy")
+  await runPackAntiEntropy(pi, projectRoot)
+
+  setSignumStatus(ctx, "pack index")
+  await appendProofpackIndex(pi, projectRoot)
+
+  setSignumStatus(ctx, "pack sync")
+  await syncContractArtifacts(projectRoot, updatedContract.contractId)
+  await markContractCompleted(projectRoot, updatedContract.contractId)
+
+  return {
+    status: "ok",
+    decision: audit.decision,
+    summary: [
+      `PACK complete: ${audit.decision}`,
+      `Proofpack: .signum/proofpack.json`,
+      `Run ID: ${runId}`,
+      `Anti-entropy: .signum/anti_entropy_report.json`,
+    ].join("\n"),
+  }
+}
+
+async function buildProofpack(
+  projectRoot: string,
+  contract: ContractDocument,
+  audit: AuditSummary,
+  executeLog: ExecuteLog,
+  runId: string,
+  createdAt: string,
+) {
+  const contractPath = resolve(projectRoot, ".signum/contract.json")
+  const redactedContract = JSON.parse(JSON.stringify(contract)) as Record<string, unknown>
+  delete redactedContract.holdoutScenarios
+
+  const contractEnvelope = await buildContractEnvelope(contractPath, redactedContract)
+  const diffEnvelope = await buildEnvelope(resolve(projectRoot, ".signum/combined.patch"), false)
+  const baselineEnvelope = await buildEnvelope(resolve(projectRoot, ".signum/baseline.json"), true)
+  const executeEnvelope = await buildEnvelope(resolve(projectRoot, ".signum/execute_log.json"), true)
+  const approvalEnvelope = await buildEnvelope(resolve(projectRoot, ".signum/approval.json"), true)
+  const mechanicEnvelope = await buildEnvelope(resolve(projectRoot, ".signum/mechanic_report.json"), true)
+  const holdoutEnvelope = await buildEnvelope(resolve(projectRoot, ".signum/holdout_report.json"), true)
+  const policyScanEnvelope = await buildEnvelope(resolve(projectRoot, ".signum/policy_scan.json"), true)
+  const auditEnvelope = await buildEnvelope(resolve(projectRoot, ".signum/audit_summary.json"), true)
+  const reviewsEnvelope = await buildReviewsEnvelope(resolve(projectRoot, ".signum/reviews"))
+
+  const contractHashText = await readOptionalText(resolve(projectRoot, ".signum/contract-hash.txt"))
+  const contractHash = extractTaggedValue(contractHashText, "contract_sha256")
+  const approvedAt = extractTaggedValue(contractHashText, "approved_at")
+  const executionContext = await readOptionalJson<Record<string, unknown>>(resolve(projectRoot, ".signum/execution_context.json"))
+  const baseCommit = typeof executionContext?.base_commit === "string" ? executionContext.base_commit : "unavailable"
+  const previousProofpack = await findPreviousProofpack(projectRoot, contract.contractId)
+  const baselineComparison = previousProofpack
+    ? {
+        previousRunId: previousProofpack.runId,
+        previousDecision: previousProofpack.decision,
+        previousConfidence: previousProofpack.confidence,
+        confidenceDelta: Math.round(((audit.confidence?.overall ?? 0) - previousProofpack.confidence) * 10) / 10,
+      }
+    : undefined
+
+  const proofpack: Record<string, unknown> = {
+    schemaVersion: "4.8",
+    signumVersion: "4.19.0",
+    createdAt,
+    runId,
+    contractId: contract.contractId,
+    decision: audit.decision,
+    releaseVerdict: audit.releaseVerdict ?? (audit.decision === "AUTO_OK" ? "PROMOTE" : "HOLD"),
+    riskLevel: contract.riskLevel,
+    summary: `Goal: ${contract.goal} | Risk: ${contract.riskLevel} | Attempts: ${executeLog.totalAttempts ?? 1} | Mechanic: ${audit.mechanic ?? "unknown"} | Confidence: ${audit.confidence?.overall ?? 0}% | Decision: ${audit.decision}`,
+    confidence: { overall: audit.confidence?.overall ?? 0 },
+    timing: {
+      startedAt: executeLog.started_at ?? createdAt,
+      completedAt: executeLog.finished_at ?? createdAt,
+      durationMs: computeDurationMs(executeLog.started_at, executeLog.finished_at),
+    },
+    reviewCoverage: { availableReviews: audit.availableReviews ?? 0 },
+    contractSource: "interactive",
+    auditChain: {
+      contractSha256: contractHash || null,
+      approvedAt: approvedAt || null,
+      baseCommit,
+    },
+    contract: contractEnvelope,
+    diff: diffEnvelope,
+    baseline: baselineEnvelope,
+    executeLog: executeEnvelope,
+    approval: approvalEnvelope,
+    checks: {
+      mechanic: mechanicEnvelope,
+      holdout: holdoutEnvelope,
+      policy_scan: policyScanEnvelope,
+      reviews: reviewsEnvelope,
+      auditSummary: auditEnvelope,
+    },
+  }
+
+  if (baselineComparison) {
+    proofpack.baselineComparison = baselineComparison
+  }
+
+  const removalEvidence = buildRemovalEvidence(contract, projectRoot)
+  if (removalEvidence) {
+    proofpack.removalEvidence = removalEvidence
+  }
+
+  if ((audit.iterationsUsed ?? 1) > 1) {
+    proofpack.iterativeAudit = {
+      iterationsUsed: audit.iterationsUsed,
+      iterationsMax: audit.iterationsUsed,
+      bestIteration: audit.bestIteration ?? audit.iterationsUsed,
+      earlyStop: false,
+      earlyStopReason: "",
+      terminalReason: "",
+      remainingSeverity: "none",
+      auditIterations: [],
+      resolvedFindings: [],
+      remainingFindings: [],
+    }
+  }
+
+  return proofpack
+}
+
+async function buildReviewsEnvelope(reviewsDir: string) {
+  const envelopes: Record<string, unknown> = {}
+  try {
+    const entries = await readdir(reviewsDir)
+    for (const entry of entries) {
+      if (!entry.endsWith(".json")) continue
+      envelopes[entry.replace(/\.json$/, "")] = await buildEnvelope(resolve(reviewsDir, entry), true)
+    }
+  } catch {
+    return {}
+  }
+  return envelopes
+}
+
+async function buildEnvelope(path: string, parseJson: boolean) {
+  try {
+    const raw = await readFile(path)
+    const sha256 = createHash("sha256").update(raw).digest("hex")
+    const sizeBytes = raw.byteLength
+    if (sizeBytes > 102_400) {
+      return {
+        content: null,
+        sha256,
+        sizeBytes,
+        status: "omitted",
+        omitReason: "size exceeds 100 KiB",
+      }
+    }
+
+    return {
+      content: parseJson ? JSON.parse(raw.toString("utf8")) : raw.toString("utf8"),
+      sha256,
+      sizeBytes,
+      status: "present",
+    }
+  } catch {
+    return {
+      content: null,
+      sha256: null,
+      sizeBytes: 0,
+      status: "error",
+      omitReason: "file not found",
+    }
+  }
+}
+
+async function buildContractEnvelope(contractPath: string, redactedContract: Record<string, unknown>) {
+  const full = await readFile(contractPath)
+  const fullSha256 = createHash("sha256").update(full).digest("hex")
+  const redactedRaw = Buffer.from(`${JSON.stringify(redactedContract, null, 2)}\n`, "utf8")
+  const sha256 = createHash("sha256").update(redactedRaw).digest("hex")
+  const sizeBytes = redactedRaw.byteLength
+  if (sizeBytes > 102_400) {
+    return {
+      content: null,
+      sha256,
+      fullSha256,
+      sizeBytes,
+      status: "omitted",
+      omitReason: "size exceeds 100 KiB",
+    }
+  }
+  return {
+    content: redactedContract,
+    sha256,
+    fullSha256,
+    sizeBytes,
+    status: "present",
+  }
+}
+
+function buildRemovalEvidence(contract: ContractDocument, projectRoot: string) {
+  const removals = (contract.removals ?? []).map((item) => ({
+    id: item.id ?? "",
+    path: item.path ?? "",
+    type: item.type ?? "file",
+    removed: item.path ? !existsSync(resolve(projectRoot, item.path)) : false,
+    orphanReferences: 0,
+    modulesYamlUpdated: item.modulesYamlTransition ? item.modulesYamlTransition !== "none" : false,
+  }))
+  const obligations = (contract.cleanupObligations ?? []).map((item) => ({
+    id: item.id ?? "",
+    action: item.action ?? "",
+    fulfilled: true,
+    blocking: item.blocking ?? true,
+  }))
+
+  if (removals.length === 0 && obligations.length === 0) {
+    return undefined
+  }
+
+  return { removals, obligations }
+}
+
+async function runPackAntiEntropy(pi: ExtensionAPI, projectRoot: string) {
+  await pi.exec(
+    "bash",
+    [packAntiEntropyScriptPath, "--project-root", ".", "--contract", ".signum/contract.json", "--proofpack", ".signum/proofpack.json", "--output", ".signum/anti_entropy_report.json"],
+    { cwd: projectRoot, timeout: 120_000 },
+  )
+}
+
+async function appendProofpackIndex(pi: ExtensionAPI, projectRoot: string) {
+  const command = `source ${shellQuote(proofpackIndexScriptPath)} && proofpack_index_append .signum/proofpack.json`
+  await pi.exec("bash", ["-lc", command], { cwd: projectRoot, timeout: 30_000 })
+}
+
+async function syncContractArtifacts(projectRoot: string, contractId: string) {
+  const contractDir = contractDirPath(projectRoot, contractId)
+  await mkdir(contractDir, { recursive: true })
+  await mkdir(resolve(contractDir, "receipts"), { recursive: true })
+
+  for (const relativePath of [
+    ".signum/contract.json",
+    ".signum/audit_summary.json",
+    ".signum/proofpack.json",
+    ".signum/anti_entropy_report.json",
+    ".signum/approval.json",
+  ]) {
+    const source = resolve(projectRoot, relativePath)
+    if (await exists(source)) {
+      const destination = resolve(contractDir, relativePath.replace(/^\.signum\//, ""))
+      await mkdir(dirname(destination), { recursive: true })
+      await copyFile(source, destination)
+    }
+  }
+
+  const executeReceipt = resolve(projectRoot, ".signum/receipts/execute.json")
+  if (await exists(executeReceipt)) {
+    await copyFile(executeReceipt, resolve(contractDir, "receipts/execute.json"))
+  }
+}
+
+async function markContractCompleted(projectRoot: string, contractId: string) {
+  const index = updateContractStatus(await ensureContractIndex(projectRoot), contractId, "completed")
+  await writeContractIndex(projectRoot, index)
+}
+
+async function findPreviousProofpack(projectRoot: string, currentContractId: string) {
+  const contractsRoot = resolve(projectRoot, ".signum/contracts")
+  try {
+    const entries = await readdir(contractsRoot)
+    const candidates: Array<{ path: string; mtimeMs: number }> = []
+    for (const entry of entries) {
+      if (entry === currentContractId) continue
+      const proofpackPath = resolve(contractsRoot, entry, "proofpack.json")
+      try {
+        const proofpackStat = await stat(proofpackPath)
+        candidates.push({ path: proofpackPath, mtimeMs: proofpackStat.mtimeMs })
+      } catch {
+        // ignore
+      }
+    }
+
+    const latest = candidates.sort((left, right) => right.mtimeMs - left.mtimeMs)[0]
+    if (!latest) return null
+    const parsed = await readJson<Record<string, any>>(latest.path)
+    return {
+      runId: String(parsed.runId ?? ""),
+      decision: String(parsed.decision ?? "HUMAN_REVIEW") as AuditSummary["decision"],
+      confidence: Number(parsed.confidence?.overall ?? 0),
+    }
+  } catch {
+    return null
+  }
+}
+
+function computeDurationMs(startedAt?: string, finishedAt?: string) {
+  const start = startedAt ? Date.parse(startedAt) : NaN
+  const finish = finishedAt ? Date.parse(finishedAt) : NaN
+  if (!Number.isFinite(start) || !Number.isFinite(finish)) return 0
+  return Math.max(0, finish - start)
+}
+
+function extractTaggedValue(text: string | null, key: string): string {
+  if (!text) return ""
+  const match = text.match(new RegExp(`${key}:\\s*(\\S+)`))
+  return match?.[1] ?? ""
+}
+
+async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, "utf8")) as T
+}
+
+async function readOptionalJson<T>(path: string): Promise<T | null> {
+  try {
+    return await readJson<T>(path)
+  } catch {
+    return null
+  }
+}
+
+async function writeJson(path: string, value: unknown) {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8")
+}
+
+async function readOptionalText(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8")
+  } catch {
+    return null
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`
+}

--- a/platforms/pi/extensions/signum/runtime/policy-tools.ts
+++ b/platforms/pi/extensions/signum/runtime/policy-tools.ts
@@ -1,0 +1,440 @@
+import { access, lstat, mkdir, readFile, realpath, writeFile } from "node:fs/promises"
+import { dirname, relative, resolve, sep } from "node:path"
+
+import {
+  createBashToolDefinition,
+  createEditToolDefinition,
+  createLocalBashOperations,
+  createReadToolDefinition,
+  createWriteToolDefinition,
+  type ToolDefinition,
+} from "@mariozechner/pi-coding-agent"
+
+export interface ContractPolicy {
+  schemaVersion: string
+  generatedFrom: string
+  riskLevel: "low" | "medium" | "high"
+  allowed_tools: string[]
+  denied_tools: string[]
+  bash_deny_patterns: string[]
+  allowed_paths: string[]
+  allow_new_files_under: string[]
+  removal_paths: string[]
+  max_files_changed: number
+  network_access: boolean
+}
+
+export interface PolicyViolation {
+  type: "path" | "bash" | "limit" | "network"
+  tool: string
+  path?: string
+  command?: string
+  reason: string
+  timestamp: string
+}
+
+export interface PolicyToolset {
+  builtInToolNames: string[]
+  customTools: ToolDefinition[]
+  getViolations(): PolicyViolation[]
+  getTouchedFiles(): string[]
+}
+
+interface Tracker {
+  touchedFiles: Set<string>
+  violations: PolicyViolation[]
+}
+
+const READABLE_SYSTEM_PATHS = [
+  ".signum",
+  "project.intent.md",
+  "project.glossary.json",
+  "modules.yaml",
+  "README.md",
+  "package.json",
+  "tsconfig.json",
+  "pyproject.toml",
+  "Cargo.toml",
+  ".gitignore",
+]
+
+const BASH_MUTATION_PATTERNS = [
+  /(^|\s)mv\s/i,
+  /(^|\s)cp\s/i,
+  /(^|\s)touch\s/i,
+  /(^|\s)mkdir\s/i,
+  /(^|\s)rmdir\s/i,
+  /(^|\s)tee\b/i,
+  /(^|\s)git\s+(apply|checkout|restore|reset|clean|add|commit)\b/i,
+  /(^|\s)(npm|pnpm|yarn)\s+(install|add|remove|update)\b/i,
+  /(^|\s)sed\s+-i\b/i,
+  /(^|\s)perl\s+-i\b/i,
+  />|>>/,
+]
+
+export function deriveExecutionPolicy(contract: Record<string, any>): ContractPolicy {
+  const riskLevel = (contract.riskLevel ?? "low") as ContractPolicy["riskLevel"]
+  const maxFiles = riskLevel === "high" ? 10 : riskLevel === "medium" ? 15 : 25
+
+  return {
+    schemaVersion: "1.0",
+    generatedFrom: contract.contractId ?? "unknown",
+    riskLevel,
+    allowed_tools: ["read", "write", "edit", "grep", "find", "ls", "bash"],
+    denied_tools: ["WebSearch", "WebFetch", "Agent", "Task"],
+    bash_deny_patterns: [
+      String.raw`rm\s+-[rf]+\s+/`,
+      String.raw`git\s+push\s+--force`,
+      String.raw`curl[^|]*\|\s*sh`,
+      String.raw`eval\s+\$`,
+      String.raw`dd\s+if=`,
+      String.raw`mkfs\.`,
+      String.raw`>\s*/dev/sd`,
+    ],
+    allowed_paths: collectAllowedPaths(contract),
+    allow_new_files_under: collectAllowNewDirectories(contract),
+    removal_paths: sanitizePaths((contract.removals ?? []).map((item: { path?: string }) => item.path ?? "")),
+    max_files_changed: maxFiles,
+    network_access: false,
+  }
+}
+
+export function createPolicyAwareEngineerTools(projectRoot: string, policy: ContractPolicy): PolicyToolset {
+  const tracker: Tracker = {
+    touchedFiles: new Set<string>(),
+    violations: [],
+  }
+
+  const localBash = createLocalBashOperations()
+
+  const readTool = createReadToolDefinition(projectRoot, {
+    operations: {
+      async access(absolutePath) {
+        assertReadablePath(projectRoot, absolutePath, policy, tracker, "read")
+        await access(absolutePath)
+      },
+      async readFile(absolutePath) {
+        assertReadablePath(projectRoot, absolutePath, policy, tracker, "read")
+        return readFile(absolutePath)
+      },
+    },
+  })
+
+  const writeTool = createWriteToolDefinition(projectRoot, {
+    operations: {
+      async mkdir(dir) {
+        await mkdir(dir, { recursive: true })
+      },
+      async writeFile(absolutePath, content) {
+        await assertMutationPath(projectRoot, absolutePath, policy, tracker, "write")
+        await mkdir(dirname(absolutePath), { recursive: true })
+        await writeFile(absolutePath, content, "utf8")
+      },
+    },
+  })
+
+  const editTool = createEditToolDefinition(projectRoot, {
+    operations: {
+      async access(absolutePath) {
+        await assertMutationPath(projectRoot, absolutePath, policy, tracker, "edit")
+        const stat = await lstat(absolutePath)
+        if (stat.isSymbolicLink()) {
+          throw violationError(tracker, {
+            type: "path",
+            tool: "edit",
+            path: projectRelative(projectRoot, absolutePath),
+            reason: "Editing symlinks is not allowed by runtime policy",
+            timestamp: new Date().toISOString(),
+          })
+        }
+      },
+      async readFile(absolutePath) {
+        await assertMutationPath(projectRoot, absolutePath, policy, tracker, "edit")
+        return readFile(absolutePath)
+      },
+      async writeFile(absolutePath, content) {
+        await assertMutationPath(projectRoot, absolutePath, policy, tracker, "edit")
+        await writeFile(absolutePath, content, "utf8")
+      },
+    },
+  })
+
+  const bashTool = createBashToolDefinition(projectRoot, {
+    operations: {
+      async exec(command, cwd, options) {
+        assertBashAllowed(projectRoot, command, policy, tracker)
+        return localBash.exec(command, cwd, options)
+      },
+    },
+  })
+
+  return {
+    builtInToolNames: ["grep", "find", "ls"],
+    customTools: [readTool, writeTool, editTool, bashTool],
+    getViolations: () => [...tracker.violations],
+    getTouchedFiles: () => [...tracker.touchedFiles].sort(),
+  }
+}
+
+function collectAllowedPaths(contract: Record<string, any>): string[] {
+  const direct = sanitizePaths(contract.inScope ?? [])
+  const extracted = extractLikelyPaths(contract.inScope ?? [])
+  const verifyPaths = extractVerifyPaths(contract.acceptanceCriteria ?? [])
+  return [...new Set([...direct.filter(looksLikePath), ...extracted, ...verifyPaths])]
+}
+
+function collectAllowNewDirectories(contract: Record<string, any>): string[] {
+  const direct = sanitizePaths(contract.allowNewFilesUnder ?? [])
+  const extracted = extractLikelyPaths(contract.allowNewFilesUnder ?? [])
+  return [...new Set([...direct.filter(looksLikePath), ...extracted])]
+}
+
+function sanitizePaths(paths: string[]): string[] {
+  return paths
+    .map((path) => String(path ?? "").replace(/ \(.*$/, "").trim())
+    .filter(Boolean)
+}
+
+function extractLikelyPaths(values: unknown[]): string[] {
+  const found = new Set<string>()
+  const pattern = /\b(?:\.?\/?[A-Za-z0-9_@-]+(?:\/[A-Za-z0-9_.@-]+)*\/?|[A-Za-z0-9_.@-]+\.[A-Za-z0-9]+)\b/g
+  for (const value of values) {
+    const text = String(value ?? "")
+    for (const match of text.matchAll(pattern)) {
+      const candidate = match[0].replace(/^\.\//, "")
+      if (!looksLikePath(candidate)) continue
+      found.add(candidate)
+    }
+  }
+  return [...found]
+}
+
+function extractVerifyPaths(criteria: Array<{ verify?: unknown }>): string[] {
+  const found = new Set<string>()
+  for (const criterion of criteria) {
+    const verify = criterion?.verify as Record<string, any> | undefined
+    const steps = Array.isArray(verify?.steps) ? verify.steps : []
+    for (const step of steps) {
+      for (const key of ["path", "docPath", "sourcePath"] as const) {
+        const value = step?.[key]
+        if (typeof value === "string" && looksLikePath(value)) {
+          found.add(value.replace(/^\.\//, ""))
+        }
+      }
+      if (Array.isArray(step?.sources)) {
+        for (const value of step.sources) {
+          if (typeof value === "string" && looksLikePath(value)) {
+            found.add(value.replace(/^\.\//, ""))
+          }
+        }
+      }
+      if (Array.isArray(step?.paths)) {
+        for (const value of step.paths) {
+          if (typeof value === "string" && looksLikePath(value)) {
+            found.add(value.replace(/^\.\//, ""))
+          }
+        }
+      }
+      if (Array.isArray(step?.allowed)) {
+        for (const value of step.allowed) {
+          if (typeof value === "string" && looksLikePath(value)) {
+            found.add(value.replace(/^\.\//, ""))
+          }
+        }
+      }
+    }
+  }
+  return [...found]
+}
+
+function looksLikePath(value: string): boolean {
+  return /[/.]/.test(value) && !/^\.[A-Za-z0-9]+$/.test(value) && !/\s/.test(value)
+}
+
+function assertReadablePath(projectRoot: string, absolutePath: string, policy: ContractPolicy, tracker: Tracker, tool: string) {
+  const normalized = normalizeExistingPath(projectRoot, absolutePath)
+  if (!normalized.startsWith(projectRoot)) {
+    throw violationError(tracker, {
+      type: "path",
+      tool,
+      path: absolutePath,
+      reason: "Reads must stay within the project root",
+      timestamp: new Date().toISOString(),
+    })
+  }
+
+  const rel = projectRelative(projectRoot, normalized)
+  if (isReadableSystemPath(rel)) return
+  if (matchesAllowedPath(rel, policy.allowed_paths)) return
+  if (matchesAllowedDir(rel, policy.allow_new_files_under)) return
+
+  throw violationError(tracker, {
+    type: "path",
+    tool,
+    path: rel,
+    reason: "Read path is outside the engineer runtime policy",
+    timestamp: new Date().toISOString(),
+  })
+}
+
+async function assertMutationPath(projectRoot: string, absolutePath: string, policy: ContractPolicy, tracker: Tracker, tool: string) {
+  const exists = await fileExists(absolutePath)
+  const normalized = exists ? await normalizePath(projectRoot, absolutePath) : resolve(projectRoot, absolutePath)
+
+  if (!normalized.startsWith(projectRoot)) {
+    throw violationError(tracker, {
+      type: "path",
+      tool,
+      path: absolutePath,
+      reason: "Mutations must stay within the project root",
+      timestamp: new Date().toISOString(),
+    })
+  }
+
+  const rel = projectRelative(projectRoot, normalized)
+  const allowedExisting = exists && matchesAllowedPath(rel, policy.allowed_paths)
+  const allowedNew = !exists && matchesAllowedDir(rel, policy.allow_new_files_under)
+
+  if (!allowedExisting && !allowedNew) {
+    throw violationError(tracker, {
+      type: "path",
+      tool,
+      path: rel,
+      reason: exists
+        ? "Existing file is outside inScope"
+        : "New file is outside allowNewFilesUnder",
+      timestamp: new Date().toISOString(),
+    })
+  }
+
+  trackFileMutation(tracker, rel, policy, tool)
+}
+
+function assertBashAllowed(projectRoot: string, command: string, policy: ContractPolicy, tracker: Tracker) {
+  if (!policy.network_access && /\b(curl|wget|fetch|https?:\/\/|ssh\b|scp\b|rsync\b)\b/i.test(command)) {
+    throw violationError(tracker, {
+      type: "network",
+      tool: "bash",
+      command,
+      reason: "Networked bash commands are disabled by runtime policy",
+      timestamp: new Date().toISOString(),
+    })
+  }
+
+  for (const pattern of policy.bash_deny_patterns) {
+    if (new RegExp(pattern, "i").test(command)) {
+      throw violationError(tracker, {
+        type: "bash",
+        tool: "bash",
+        command,
+        reason: `Denied bash pattern matched: ${pattern}`,
+        timestamp: new Date().toISOString(),
+      })
+    }
+  }
+
+  const trimmed = command.trim()
+  if (/^rm\b/i.test(trimmed)) {
+    const targets = parseRmTargets(trimmed)
+    if (targets.length === 0 || !targets.every((target) => matchesAllowedRemoval(projectRoot, target, policy.removal_paths))) {
+      throw violationError(tracker, {
+        type: "bash",
+        tool: "bash",
+        command,
+        reason: "rm is only allowed for declared removal targets",
+        timestamp: new Date().toISOString(),
+      })
+    }
+
+    for (const target of targets) {
+      const rel = projectRelative(projectRoot, resolve(projectRoot, target))
+      trackFileMutation(tracker, rel, policy, "bash")
+    }
+    return
+  }
+
+  for (const pattern of BASH_MUTATION_PATTERNS) {
+    if (pattern.test(command)) {
+      throw violationError(tracker, {
+        type: "bash",
+        tool: "bash",
+        command,
+        reason: "Mutating bash commands are disabled; use edit/write tools instead",
+        timestamp: new Date().toISOString(),
+      })
+    }
+  }
+}
+
+function parseRmTargets(command: string): string[] {
+  return command
+    .split(/\s+/)
+    .slice(1)
+    .filter((token) => token.length > 0 && !token.startsWith("-"))
+}
+
+function matchesAllowedRemoval(projectRoot: string, target: string, removalPaths: string[]): boolean {
+  const rel = projectRelative(projectRoot, resolve(projectRoot, target))
+  return removalPaths.some((path) => rel === path || rel.startsWith(`${path}${sep}`) || path.startsWith(`${rel}${sep}`))
+}
+
+function trackFileMutation(tracker: Tracker, rel: string, policy: ContractPolicy, tool: string) {
+  if (!tracker.touchedFiles.has(rel) && tracker.touchedFiles.size + 1 > policy.max_files_changed) {
+    throw violationError(tracker, {
+      type: "limit",
+      tool,
+      path: rel,
+      reason: `Policy allows at most ${policy.max_files_changed} changed files`,
+      timestamp: new Date().toISOString(),
+    })
+  }
+  tracker.touchedFiles.add(rel)
+}
+
+function violationError(tracker: Tracker, violation: PolicyViolation): Error {
+  tracker.violations.push(violation)
+  return new Error(`[POLICY_VIOLATION] ${violation.reason}`)
+}
+
+function matchesAllowedPath(rel: string, allowedPaths: string[]): boolean {
+  return allowedPaths.some((path) => rel === path || rel.startsWith(`${path}${sep}`) || path.startsWith(`${rel}${sep}`))
+}
+
+function matchesAllowedDir(rel: string, allowedDirs: string[]): boolean {
+  return allowedDirs.some((dir) => rel === dir || rel.startsWith(`${dir}${sep}`))
+}
+
+function isReadableSystemPath(rel: string): boolean {
+  return READABLE_SYSTEM_PATHS.some((path) => rel === path || rel.startsWith(`${path}${sep}`))
+}
+
+function projectRelative(projectRoot: string, absolutePath: string): string {
+  const rel = relative(projectRoot, absolutePath)
+  return rel === "" ? "." : rel
+}
+
+async function normalizePath(projectRoot: string, inputPath: string): Promise<string> {
+  const resolved = resolve(projectRoot, stripLeadingAt(inputPath))
+  try {
+    return await realpath(resolved)
+  } catch {
+    return resolved
+  }
+}
+
+function normalizeExistingPath(projectRoot: string, inputPath: string): string {
+  return resolve(projectRoot, stripLeadingAt(inputPath))
+}
+
+function stripLeadingAt(path: string): string {
+  return path.startsWith("@") ? path.slice(1) : path
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/platforms/pi/extensions/signum/runtime/role-session.ts
+++ b/platforms/pi/extensions/signum/runtime/role-session.ts
@@ -1,0 +1,204 @@
+import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
+
+import type { Model } from "@mariozechner/pi-ai"
+import {
+  AuthStorage,
+  createAgentSession,
+  createExtensionRuntime,
+  type AgentSessionEvent,
+  type ResourceLoader,
+  SessionManager,
+  SettingsManager,
+  type ToolDefinition,
+  parseFrontmatter,
+  stripFrontmatter,
+} from "@mariozechner/pi-coding-agent"
+
+import type { SignumRole } from "../models.ts"
+import { piAgentsRoot } from "../paths.ts"
+
+export interface RoleToolEvent {
+  type: string
+  toolName?: string
+  toolCallId?: string
+  args?: unknown
+  result?: unknown
+  isError?: boolean
+}
+
+export interface RoleRunResult {
+  role: SignumRole
+  model: string
+  finalText: string
+  events: RoleToolEvent[]
+}
+
+export interface RoleRunRequest {
+  role: SignumRole
+  projectRoot: string
+  prompt: string
+  model: Model
+  toolNames?: string[]
+  customTools?: ToolDefinition[]
+}
+
+export interface RoleSessionRunner {
+  run(request: RoleRunRequest): Promise<RoleRunResult>
+}
+
+interface PromptAssetFrontmatter {
+  name?: string
+  description?: string
+  model?: string
+  tools?: string | string[]
+}
+
+interface RolePromptAsset {
+  body: string
+  tools: string[]
+  preferredModelId?: string
+}
+
+export class SdkRoleSessionRunner implements RoleSessionRunner {
+  async run(request: RoleRunRequest): Promise<RoleRunResult> {
+    const promptAsset = await loadRolePromptAsset(request.role)
+    const authStorage = AuthStorage.create()
+
+    const toolNames = request.toolNames ?? promptAsset.tools
+    const promptToolNames = [...new Set([...toolNames, ...(request.customTools ?? []).map((tool) => tool.name)])]
+
+    const resourceLoader: ResourceLoader = {
+      getExtensions: () => ({ extensions: [], errors: [], runtime: createExtensionRuntime() }),
+      getSkills: () => ({ skills: [], diagnostics: [] }),
+      getPrompts: () => ({ prompts: [], diagnostics: [] }),
+      getThemes: () => ({ themes: [], diagnostics: [] }),
+      getAgentsFiles: () => ({ agentsFiles: [] }),
+      getSystemPrompt: () => buildRoleSystemPrompt(promptAsset.body, promptToolNames),
+      getAppendSystemPrompt: () => [],
+      extendResources: () => {},
+      reload: async () => {},
+    }
+
+    const { session } = await createAgentSession({
+      cwd: request.projectRoot,
+      model: request.model,
+      thinkingLevel: "off",
+      authStorage,
+      resourceLoader,
+      tools: toolNames,
+      customTools: request.customTools,
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory({
+        compaction: { enabled: false },
+        retry: { enabled: false },
+      }),
+    })
+
+    const events: RoleToolEvent[] = []
+    const unsubscribe = session.subscribe((event: AgentSessionEvent) => {
+      if (event.type === "tool_execution_start") {
+        events.push({
+          type: event.type,
+          toolName: event.toolName,
+          toolCallId: event.toolCallId,
+          args: event.args,
+        })
+      }
+      if (event.type === "tool_execution_end") {
+        events.push({
+          type: event.type,
+          toolName: event.toolName,
+          toolCallId: event.toolCallId,
+          result: event.result,
+          isError: event.isError,
+        })
+      }
+    })
+
+    try {
+      await session.prompt(request.prompt)
+      const finalText = extractLastAssistantText(session.messages)
+
+      return {
+        role: request.role,
+        model: `${request.model.provider}/${request.model.id}`,
+        finalText,
+        events,
+      }
+    } finally {
+      unsubscribe()
+      session.dispose()
+    }
+  }
+}
+
+export async function loadRolePromptAsset(role: SignumRole): Promise<RolePromptAsset> {
+  const promptPath = resolve(piAgentsRoot, `${role}.md`)
+  const raw = await readFile(promptPath, "utf8")
+  const { frontmatter } = parseFrontmatter<PromptAssetFrontmatter>(raw)
+
+  return {
+    body: stripFrontmatter(raw),
+    tools: normalizePromptTools(frontmatter.tools),
+    preferredModelId: frontmatter.model,
+  }
+}
+
+function normalizePromptTools(value: PromptAssetFrontmatter["tools"]): string[] {
+  const rawItems = Array.isArray(value)
+    ? value
+    : typeof value === "string"
+      ? value
+          .replace(/^\[/, "")
+          .replace(/\]$/, "")
+          .split(",")
+      : []
+
+  const normalized = new Set<string>()
+  for (const item of rawItems) {
+    const lower = item.trim().toLowerCase()
+    if (!lower) continue
+    if (lower === "glob") {
+      normalized.add("find")
+      continue
+    }
+    normalized.add(lower)
+  }
+
+  if (normalized.size === 0) {
+    return ["read", "grep", "find", "ls", "bash"]
+  }
+
+  return [...normalized]
+}
+
+function buildRoleSystemPrompt(body: string, tools: string[]): string {
+  return [
+    "You are an AI assistant accessed via the pi SDK.",
+    "",
+    `Available tools: ${tools.join(", ")}`,
+    "Guidelines:",
+    "- Use read to inspect files.",
+    "- Use grep, find, and ls for deterministic discovery.",
+    "- Use edit for precise updates and write for full-file writes.",
+    "- Use bash for repository-local commands when file tools are insufficient.",
+    "- Be concise and prefer structured artifacts over long prose.",
+    "",
+    body.trim(),
+  ].join("\n")
+}
+
+function extractLastAssistantText(messages: Array<{ role?: string; content?: Array<{ type: string; text?: string }> }>): string {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index]
+    if (message.role !== "assistant") continue
+    const text = (message.content ?? [])
+      .filter((part) => part.type === "text")
+      .map((part) => part.text ?? "")
+      .join("\n")
+      .trim()
+    if (text) return text
+  }
+  return ""
+}

--- a/platforms/pi/extensions/signum/runtime/script-adapters/checks.ts
+++ b/platforms/pi/extensions/signum/runtime/script-adapters/checks.ts
@@ -1,0 +1,37 @@
+import { readFile } from "node:fs/promises"
+import { createHash } from "node:crypto"
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+
+export async function runJsonScript(
+  pi: ExtensionAPI,
+  scriptPath: string,
+  args: string[],
+): Promise<unknown> {
+  const result = await pi.exec("bash", [scriptPath, ...args])
+  if (result.code !== 0) {
+    throw new Error(result.stderr || result.stdout || `Script failed: ${scriptPath}`)
+  }
+  return JSON.parse(result.stdout)
+}
+
+export async function runTextScript(
+  pi: ExtensionAPI,
+  scriptPath: string,
+  args: string[],
+): Promise<{ ok: boolean; output: string }> {
+  const result = await pi.exec("bash", [scriptPath, ...args])
+  return {
+    ok: result.code === 0,
+    output: [result.stdout, result.stderr].filter(Boolean).join("\n").trim(),
+  }
+}
+
+export function toUtcTimestamp(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z")
+}
+
+export async function sha256File(path: string): Promise<string> {
+  const contents = await readFile(path)
+  return createHash("sha256").update(contents).digest("hex")
+}

--- a/platforms/pi/extensions/signum/runtime/script-adapters/contract-dir.ts
+++ b/platforms/pi/extensions/signum/runtime/script-adapters/contract-dir.ts
@@ -1,0 +1,191 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+
+import { toUtcTimestamp } from "./checks.ts"
+import { dirname, resolve } from "node:path"
+
+export interface ContractIndexRecord {
+  contractId: string
+  status: string
+  directory?: string
+  createdAt?: string
+  archivedAt?: string
+  closedAt?: string
+  [key: string]: unknown
+}
+
+export interface ContractIndex {
+  activeContractId: string | null
+  contracts: ContractIndexRecord[]
+}
+
+export interface SignumContractLike {
+  contractId: string
+  goal?: string
+  inScope?: string[]
+  assumptions?: Array<string | { text?: string }>
+}
+
+export function contractDirRelative(contractId: string): string {
+  assertValidContractId(contractId)
+  return `.signum/contracts/${contractId}/`
+}
+
+export function contractDirPath(projectRoot: string, contractId: string): string {
+  assertValidContractId(contractId)
+  return resolve(projectRoot, ".signum", "contracts", contractId)
+}
+
+export function archiveDirPath(projectRoot: string, contractId: string): string {
+  assertValidContractId(contractId)
+  return resolve(projectRoot, ".signum", "archive", contractId)
+}
+
+export function contractIndexPath(projectRoot: string): string {
+  return resolve(projectRoot, ".signum", "contracts", "index.json")
+}
+
+export async function ensureContractIndex(projectRoot: string): Promise<ContractIndex> {
+  const existing = await readContractIndexIfExists(projectRoot)
+  if (existing) return existing
+
+  const emptyIndex: ContractIndex = {
+    activeContractId: null,
+    contracts: [],
+  }
+  await writeContractIndex(projectRoot, emptyIndex)
+  return emptyIndex
+}
+
+export async function readContractIndex(projectRoot: string): Promise<ContractIndex> {
+  const path = contractIndexPath(projectRoot)
+  const raw = await readFile(path, "utf8")
+  const parsed = JSON.parse(raw) as ContractIndex
+
+  if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.contracts)) {
+    throw new Error(`Invalid contract index: ${path}`)
+  }
+
+  return parsed
+}
+
+export async function readContractIndexIfExists(projectRoot: string): Promise<ContractIndex | null> {
+  try {
+    return await readContractIndex(projectRoot)
+  } catch {
+    return null
+  }
+}
+
+export async function writeContractIndex(projectRoot: string, index: ContractIndex): Promise<void> {
+  const path = contractIndexPath(projectRoot)
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${JSON.stringify(index, null, 2)}\n`, "utf8")
+}
+
+export function getActiveContractId(index: ContractIndex): string | undefined {
+  return index.activeContractId ?? undefined
+}
+
+export function resolveContractId(index: ContractIndex, provided?: string): string {
+  const contractId = provided?.trim() || index.activeContractId || ""
+  if (!contractId) {
+    throw new Error("No contract ID provided and no active contract found")
+  }
+  assertValidContractId(contractId)
+  return contractId
+}
+
+export function getContractRecord(index: ContractIndex, contractId: string): ContractIndexRecord {
+  const record = index.contracts.find((item) => item.contractId === contractId)
+  if (!record) {
+    throw new Error(`Contract ID not found in index: ${contractId}`)
+  }
+  return record
+}
+
+export function updateContractStatus(index: ContractIndex, contractId: string, status: string): ContractIndex {
+  getContractRecord(index, contractId)
+
+  return {
+    ...index,
+    contracts: index.contracts.map((item) =>
+      item.contractId === contractId
+        ? {
+            ...item,
+            status,
+          }
+        : item,
+    ),
+  }
+}
+
+export function setContractTimestampField(
+  index: ContractIndex,
+  contractId: string,
+  field: "archivedAt" | "closedAt",
+  value: string,
+): ContractIndex {
+  getContractRecord(index, contractId)
+
+  return {
+    ...index,
+    contracts: index.contracts.map((item) =>
+      item.contractId === contractId
+        ? {
+            ...item,
+            [field]: value,
+          }
+        : item,
+    ),
+  }
+}
+
+export async function initContractDirectory(projectRoot: string, contractId: string): Promise<string> {
+  const path = contractDirPath(projectRoot, contractId)
+  await mkdir(resolve(path, "reviews"), { recursive: true })
+  return path
+}
+
+export function registerContract(index: ContractIndex, contract: SignumContractLike, status = "draft"): ContractIndex {
+  const createdAt = toUtcTimestamp()
+  const record: ContractIndexRecord = {
+    contractId: contract.contractId,
+    status,
+    createdAt,
+    directory: contractDirRelative(contract.contractId),
+    goal: contract.goal ?? "",
+    inScope: contract.inScope ?? [],
+    assumptions: (contract.assumptions ?? []).map((assumption) =>
+      typeof assumption === "string" ? assumption : assumption.text ?? "",
+    ),
+  }
+
+  const existing = index.contracts.find((item) => item.contractId === contract.contractId)
+  return {
+    ...index,
+    activeContractId: contract.contractId,
+    contracts: existing
+      ? index.contracts.map((item) => (item.contractId === contract.contractId ? { ...item, ...record } : item))
+      : [...index.contracts, record],
+  }
+}
+
+export function clearActiveContract(index: ContractIndex, contractId: string): ContractIndex {
+  if (index.activeContractId !== contractId) {
+    return index
+  }
+
+  return {
+    ...index,
+    activeContractId: null,
+  }
+}
+
+function assertValidContractId(contractId: string) {
+  if (!contractId) {
+    throw new Error("contractId is required")
+  }
+  if (contractId.includes("/") || contractId.includes("..")) {
+    throw new Error(`Invalid contract ID: ${contractId}`)
+  }
+}

--- a/platforms/pi/extensions/signum/runtime/verify-normalizer.ts
+++ b/platforms/pi/extensions/signum/runtime/verify-normalizer.ts
@@ -1,0 +1,124 @@
+interface VerifyStep {
+  type?: unknown
+  [key: string]: unknown
+}
+
+interface VerifyBlock {
+  steps?: unknown
+  timeout_ms?: unknown
+  [key: string]: unknown
+}
+
+interface ContractLike {
+  acceptanceCriteria?: Array<Record<string, unknown>>
+  holdoutScenarios?: Array<Record<string, unknown>>
+  [key: string]: unknown
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000
+
+export function normalizeContractForPiRuntime<T extends ContractLike>(contract: T): T {
+  const next = {
+    ...contract,
+    acceptanceCriteria: Array.isArray(contract.acceptanceCriteria)
+      ? contract.acceptanceCriteria.map((criterion) => normalizeCriterion(criterion))
+      : contract.acceptanceCriteria,
+    holdoutScenarios: Array.isArray(contract.holdoutScenarios)
+      ? contract.holdoutScenarios.map((scenario) => normalizeHoldoutScenario(scenario))
+      : contract.holdoutScenarios,
+  }
+  return next as T
+}
+
+export function normalizeVerifyForPiRuntime(verify: unknown): unknown {
+  if (!verify || typeof verify !== "object") return verify
+  const record = verify as VerifyBlock
+  if (!Array.isArray(record.steps)) return verify
+
+  return {
+    ...record,
+    steps: record.steps.map((step) => normalizeStep(step)),
+    timeout_ms:
+      typeof record.timeout_ms === "number" && Number.isFinite(record.timeout_ms) && record.timeout_ms > 0
+        ? record.timeout_ms
+        : DEFAULT_TIMEOUT_MS,
+  }
+}
+
+function normalizeCriterion(criterion: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...criterion,
+    visibility: typeof criterion.visibility === "string" ? criterion.visibility : "visible",
+    verify: normalizeVerifyForPiRuntime(criterion.verify),
+  }
+}
+
+function normalizeHoldoutScenario(scenario: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...scenario,
+    verify: normalizeVerifyForPiRuntime(scenario.verify),
+  }
+}
+
+function normalizeStep(step: unknown): unknown {
+  if (!step || typeof step !== "object") return step
+  const record = { ...(step as VerifyStep) }
+  const normalizedType = normalizeType(record.type)
+  if (normalizedType) {
+    record.type = normalizedType
+  }
+
+  switch (normalizedType) {
+    case "assertContains":
+    case "assertNotContains": {
+      if (typeof record.text !== "string" && typeof record.value === "string") {
+        record.text = record.value
+      }
+      break
+    }
+    case "assertJsonPathEquals": {
+      if (typeof record.jsonPath !== "string" && typeof record.json_path === "string") {
+        record.jsonPath = record.json_path
+      }
+      break
+    }
+    case "assertOnlyPathsChanged": {
+      if (!Array.isArray(record.paths) && Array.isArray(record.allowed)) {
+        record.paths = record.allowed
+      }
+      break
+    }
+  }
+
+  return record
+}
+
+function normalizeType(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const key = value.toLowerCase().replace(/[-_]/g, "")
+  return TYPE_ALIASES[key] ?? value
+}
+
+const TYPE_ALIASES: Record<string, string> = {
+  readfile: "readFile",
+  run: "run",
+  gitdiff: "gitDiff",
+  gitdifffiles: "gitDiffFiles",
+  assertcontains: "assertContains",
+  assertnotcontains: "assertNotContains",
+  assertnotcontainsany: "assertNotContainsAny",
+  assertjsonpathequals: "assertJsonPathEquals",
+  assertgitdiffpaths: "assertOnlyPathsChanged",
+  assertonlypathschanged: "assertOnlyPathsChanged",
+  assertnofilechangesoutside: "assertOnlyPathsChanged",
+  assertequals: "assertEquals",
+  assertmatches: "assertMatches",
+  assertnotmodified: "assertNotModified",
+  assertpathnotmodified: "assertNotModified",
+  assertnodiff: "assertNotModified",
+  assertfileunchanged: "assertNotModified",
+  assertfileexists: "assertFileExists",
+  assertreferencematchesimplementation: "assertReferenceMatchesImplementation",
+  assertsemanticalignment: "assertSemanticAlignment",
+  assertsemanticconsistency: "assertSemanticAlignment",
+}

--- a/platforms/pi/extensions/signum/state.ts
+++ b/platforms/pi/extensions/signum/state.ts
@@ -1,0 +1,131 @@
+import { lstat, readFile, rm, writeFile } from "node:fs/promises"
+import { resolve } from "node:path"
+
+export type SignumRunState =
+  | { kind: "none" }
+  | { kind: "contract-only" }
+  | { kind: "resumable" }
+
+export interface ClearWorkingSetResult {
+  removedPaths: string[]
+  clearedActiveContract: boolean
+}
+
+const FINALIZED_STATUSES = new Set(["completed", "archived", "closed"])
+
+const WORKING_SET_FILES = [
+  ".signum/contract.json",
+  ".signum/execute_log.json",
+  ".signum/combined.patch",
+  ".signum/iteration_delta.patch",
+  ".signum/baseline.json",
+  ".signum/mechanic_report.json",
+  ".signum/audit_summary.json",
+  ".signum/proofpack.json",
+  ".signum/holdout_report.json",
+  ".signum/contract-engineer.json",
+  ".signum/contract-policy.json",
+  ".signum/policy_violations.json",
+  ".signum/policy_scan.json",
+  ".signum/spec_quality.json",
+  ".signum/spec_validation.json",
+  ".signum/repo_contract_baseline.json",
+  ".signum/repo_contract_violations.json",
+  ".signum/contract-hash.txt",
+  ".signum/execution_context.json",
+  ".signum/review_prompt_codex.txt",
+  ".signum/review_prompt_gemini.txt",
+  ".signum/review_context.json",
+  ".signum/clover_report.json",
+  ".signum/approval.json",
+  ".signum/intent_check.json",
+  ".signum/audit_iteration_log.json",
+  ".signum/repair_brief.json",
+  ".signum/flaky_tests.json",
+  ".signum/reviews/claude.json",
+  ".signum/reviews/codex.json",
+  ".signum/reviews/gemini.json",
+  ".signum/reviews/codex_raw.txt",
+  ".signum/reviews/gemini_raw.txt",
+  ".signum/anti_entropy_report.json",
+]
+
+const WORKING_SET_DIRS = [
+  ".signum/reviews",
+  ".signum/iterations",
+  ".signum/receipts",
+  ".signum/runs",
+  ".signum/snapshots",
+]
+
+export async function detectRunState(projectRoot: string): Promise<SignumRunState> {
+  const contract = await readJsonIfExists(resolve(projectRoot, ".signum/contract.json"))
+  if (!contract) {
+    return { kind: "none" }
+  }
+
+  const status = typeof contract.status === "string" ? contract.status.toLowerCase() : undefined
+  if (status && FINALIZED_STATUSES.has(status)) {
+    return { kind: "none" }
+  }
+
+  const hasProofpack = await pathExists(resolve(projectRoot, ".signum/proofpack.json"))
+  const hasAuditSummary = await pathExists(resolve(projectRoot, ".signum/audit_summary.json"))
+  if (hasProofpack || hasAuditSummary) {
+    return { kind: "none" }
+  }
+
+  const hasExecutionContext = await pathExists(resolve(projectRoot, ".signum/execution_context.json"))
+  if (hasExecutionContext) {
+    return { kind: "resumable" }
+  }
+
+  return { kind: "contract-only" }
+}
+
+export async function clearWorkingSet(projectRoot: string): Promise<ClearWorkingSetResult> {
+  const removedPaths: string[] = []
+
+  for (const relativePath of [...WORKING_SET_FILES, ...WORKING_SET_DIRS]) {
+    const absolutePath = resolve(projectRoot, relativePath)
+    if (await pathExists(absolutePath)) {
+      await rm(absolutePath, { force: true, recursive: true })
+      removedPaths.push(relativePath)
+    }
+  }
+
+  let clearedActiveContract = false
+  const indexPath = resolve(projectRoot, ".signum/contracts/index.json")
+  const index = await readJsonIfExists(indexPath)
+  if (index && typeof index === "object" && !Array.isArray(index)) {
+    const nextIndex = {
+      ...(index as Record<string, unknown>),
+      activeContractId: null,
+    }
+    await writeFile(indexPath, `${JSON.stringify(nextIndex, null, 2)}\n`, "utf8")
+    clearedActiveContract = true
+  }
+
+  return {
+    removedPaths,
+    clearedActiveContract,
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function readJsonIfExists(path: string): Promise<any | null> {
+  try {
+    const content = await readFile(path, "utf8")
+    return JSON.parse(content)
+  } catch {
+    return null
+  }
+}

--- a/platforms/pi/extensions/signum/ui.ts
+++ b/platforms/pi/extensions/signum/ui.ts
@@ -1,0 +1,55 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent"
+
+import type { SignumRunState } from "./state.ts"
+
+export type ResumeDecision = "resume" | "restart" | "cancel"
+
+export function setSignumStatus(ctx: ExtensionCommandContext, text?: string) {
+  if (!ctx.hasUI) return
+
+  if (!text) {
+    ctx.ui.setStatus("signum", undefined)
+    return
+  }
+
+  const theme = ctx.ui.theme
+  const prefix = theme.fg("accent", "signum")
+  const body = theme.fg("dim", ` ${text}`)
+  ctx.ui.setStatus("signum", `${prefix}${body}`)
+}
+
+export function emitSignumMessage(pi: ExtensionAPI, content: string, details?: Record<string, unknown>) {
+  pi.sendMessage({
+    customType: "signum",
+    content,
+    display: true,
+    details: {
+      ...(details ?? {}),
+      timestamp: Date.now(),
+    },
+  })
+}
+
+export async function promptResumeDecision(
+  ctx: ExtensionCommandContext,
+  state: SignumRunState,
+): Promise<ResumeDecision> {
+  if (!ctx.hasUI) return "cancel"
+
+  const message =
+    state.kind === "resumable"
+      ? "A previous run exists in .signum/ (contract + execution context). Choose how to continue."
+      : "A contract exists in .signum/, but execution has not started. Choose how to continue."
+
+  const options = [
+    "resume — continue with the current working set",
+    "restart — discard the current working set and start from CONTRACT",
+    "cancel — do nothing",
+  ]
+
+  const selected = await ctx.ui.select(message, options)
+  if (!selected) return "cancel"
+  if (selected.startsWith("resume")) return "resume"
+  if (selected.startsWith("restart")) return "restart"
+  return "cancel"
+}

--- a/tests/test-pi-extension.sh
+++ b/tests/test-pi-extension.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+EXT="$ROOT/platforms/pi/extensions/signum/index.ts"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local name="$1"
+  local haystack="$2"
+  local needle="$3"
+  if printf '%s' "$haystack" | grep -q -- "$needle"; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s — expected to find "%s"\n' "$name" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1"
+  local haystack="$2"
+  local needle="$3"
+  if printf '%s' "$haystack" | grep -q -- "$needle"; then
+    printf '  FAIL: %s — did not expect to find "%s"\n' "$name" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+run_pi() {
+  local cwd="$1"
+  local command="$2"
+  (
+    cd "$cwd"
+    PI_SKIP_VERSION_CHECK=1 pi --no-extensions -e "$EXT" --mode json --no-session "$command"
+  )
+}
+
+extract_content() {
+  python3 -c 'import json,sys
+content=""
+for line in sys.stdin:
+    line=line.strip()
+    if not line:
+        continue
+    obj=json.loads(line)
+    if obj.get("type") == "message_end":
+        msg=obj.get("message", {})
+        if msg.get("customType") == "signum":
+            content=msg.get("content", "")
+print(content)'
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "=== /signum explain ==="
+EXPLAIN_OUTPUT="$(run_pi "$ROOT" '/signum explain' | extract_content)"
+assert_contains "explain reports slice-5" "$EXPLAIN_OUTPUT" '"status": "slice-5"'
+assert_contains "explain reports full pipeline task" "$EXPLAIN_OUTPUT" '"status": "full-pipeline-single-pass-audit"'
+
+echo ""
+echo "=== /signum close ==="
+CLOSE_DIR="$WORK/close"
+mkdir -p "$CLOSE_DIR/.signum/contracts/sig-20260421-test/reviews"
+cat > "$CLOSE_DIR/.signum/contracts/index.json" <<'EOF'
+{
+  "activeContractId": "sig-20260421-test",
+  "contracts": [
+    {
+      "contractId": "sig-20260421-test",
+      "status": "active",
+      "directory": ".signum/contracts/sig-20260421-test/"
+    }
+  ]
+}
+EOF
+CLOSE_OUTPUT="$(run_pi "$CLOSE_DIR" '/signum close sig-20260421-test' | extract_content)"
+assert_contains "close reports closed contract" "$CLOSE_OUTPUT" 'Closed: sig-20260421-test'
+assert_contains "close clears active contract" "$(cat "$CLOSE_DIR/.signum/contracts/index.json")" '"activeContractId": null'
+
+
+echo ""
+echo "=== /signum archive ==="
+ARCHIVE_DIR="$WORK/archive"
+mkdir -p "$ARCHIVE_DIR/.signum/contracts/sig-20260421-arch/reviews" "$ARCHIVE_DIR/.signum/contracts/sig-20260421-arch/receipts"
+printf '{"ok":true}\n' > "$ARCHIVE_DIR/.signum/contracts/sig-20260421-arch/contract.json"
+printf '{"proof":true}\n' > "$ARCHIVE_DIR/.signum/contracts/sig-20260421-arch/proofpack.json"
+printf '{"approval":true}\n' > "$ARCHIVE_DIR/.signum/contracts/sig-20260421-arch/approval.json"
+printf '{"audit":true}\n' > "$ARCHIVE_DIR/.signum/contracts/sig-20260421-arch/audit_summary.json"
+printf '{"receipt":true}\n' > "$ARCHIVE_DIR/.signum/contracts/sig-20260421-arch/receipts/execute.json"
+printf 'temp\n' > "$ARCHIVE_DIR/.signum/contracts/sig-20260421-arch/baseline.json"
+cat > "$ARCHIVE_DIR/.signum/contracts/index.json" <<'EOF'
+{
+  "activeContractId": "sig-20260421-arch",
+  "contracts": [
+    {
+      "contractId": "sig-20260421-arch",
+      "status": "active",
+      "directory": ".signum/contracts/sig-20260421-arch/"
+    }
+  ]
+}
+EOF
+ARCHIVE_OUTPUT="$(run_pi "$ARCHIVE_DIR" '/signum archive sig-20260421-arch' | extract_content)"
+assert_contains "archive reports archived contract" "$ARCHIVE_OUTPUT" 'Archived: sig-20260421-arch'
+assert_contains "archive kept proofpack" "$(find "$ARCHIVE_DIR/.signum/archive" -type f | sort)" 'proofpack.json'
+assert_not_contains "archive purged baseline" "$(find "$ARCHIVE_DIR/.signum/contracts/sig-20260421-arch" -maxdepth 2 -type f | sort)" 'baseline.json'
+
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  exit 1
+fi

--- a/tests/test-pi-full-pipeline.sh
+++ b/tests/test-pi-full-pipeline.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+EXT="$ROOT/platforms/pi/extensions/signum/index.ts"
+
+if [ "${SIGNUM_PI_LIVE_SMOKE:-0}" != "1" ]; then
+  echo "SKIP: set SIGNUM_PI_LIVE_SMOKE=1 to run the live pi full-pipeline smoke test"
+  exit 0
+fi
+
+run_pi() {
+  local cwd="$1"
+  local command="$2"
+  (
+    cd "$cwd"
+    SIGNUM_PI_AUTO_APPROVE=1 PI_SKIP_VERSION_CHECK=1 \
+      pi --no-extensions -e "$EXT" --mode json --no-session "$command"
+  )
+}
+
+extract_content() {
+  python3 -c 'import json,sys
+content=""
+for line in sys.stdin:
+    line=line.strip()
+    if not line:
+        continue
+    obj=json.loads(line)
+    if obj.get("type") == "message_end":
+        msg=obj.get("message", {})
+        if msg.get("customType") == "signum":
+            content=msg.get("content", "")
+print(content)'
+}
+
+assert_file() {
+  local path="$1"
+  [ -f "$path" ] || { echo "FAIL: missing file $path"; exit 1; }
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/src"
+cat > "$WORK/README.md" <<'EOF'
+# Demo Project
+
+Small demo app for testing pi-native Signum flow.
+EOF
+cat > "$WORK/package.json" <<'EOF'
+{
+  "name": "demo-project",
+  "version": "1.0.0",
+  "type": "module"
+}
+EOF
+cat > "$WORK/src/index.js" <<'EOF'
+export function greet(name) {
+  return `Hello, ${name}`;
+}
+EOF
+
+(
+  cd "$WORK"
+  git init -q
+  git config user.email test@example.com
+  git config user.name test
+  git add .
+  git commit -qm init
+)
+
+echo "=== /signum full pipeline live smoke ==="
+OUTPUT="$(run_pi "$WORK" '/signum add a README usage example and keep scope minimal' | extract_content)"
+printf '%s\n' "$OUTPUT"
+
+assert_file "$WORK/.signum/contract.json"
+assert_file "$WORK/.signum/approval.json"
+assert_file "$WORK/.signum/contract-policy.json"
+assert_file "$WORK/.signum/execute_log.json"
+assert_file "$WORK/.signum/receipts/execute.json"
+assert_file "$WORK/.signum/mechanic_report.json"
+assert_file "$WORK/.signum/policy_scan.json"
+assert_file "$WORK/.signum/holdout_report.json"
+assert_file "$WORK/.signum/reviews/claude.json"
+assert_file "$WORK/.signum/audit_summary.json"
+assert_file "$WORK/.signum/proofpack.json"
+assert_file "$WORK/.signum/anti_entropy_report.json"
+
+python3 - "$WORK" <<'PY'
+import json, pathlib, sys
+root = pathlib.Path(sys.argv[1])
+execute = json.load(open(root / '.signum/execute_log.json'))
+audit = json.load(open(root / '.signum/audit_summary.json'))
+proof = json.load(open(root / '.signum/proofpack.json'))
+contract = json.load(open(root / '.signum/contract.json'))
+readme = (root / 'README.md').read_text()
+
+assert execute['status'] == 'SUCCESS', execute
+assert audit['decision'] in {'AUTO_OK', 'HUMAN_REVIEW', 'AUTO_BLOCK'}, audit
+assert proof['decision'] == audit['decision'], (proof, audit)
+assert contract['status'] == 'completed', contract
+assert 'greet' in readme and 'Usage' in readme, readme
+print('PASS: live full-pipeline artifacts verified')
+print('decision=', proof['decision'])
+print('runId=', proof['runId'])
+PY

--- a/tests/test-pi-verify-normalizer.sh
+++ b/tests/test-pi-verify-normalizer.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+TARGET="$ROOT/platforms/pi/extensions/signum/runtime/verify-normalizer.ts"
+
+node --input-type=module - <<'EOF'
+import assert from 'node:assert/strict'
+import { normalizeContractForPiRuntime, normalizeVerifyForPiRuntime } from './platforms/pi/extensions/signum/runtime/verify-normalizer.ts'
+
+const verify = normalizeVerifyForPiRuntime({
+  steps: [
+    { type: 'read-file', path: 'README.md' },
+    { type: 'assert-contains', path: 'README.md', value: 'greet' },
+    { type: 'assert-json-path-equals', path: 'package.json', json_path: '$.type', value: 'module' },
+    { type: 'assert-no-file-changes-outside', allowed: ['README.md'] },
+  ],
+})
+
+assert.equal(verify.timeout_ms, 30000)
+assert.equal(verify.steps[0].type, 'readFile')
+assert.equal(verify.steps[1].type, 'assertContains')
+assert.equal(verify.steps[1].text, 'greet')
+assert.equal(verify.steps[2].type, 'assertJsonPathEquals')
+assert.equal(verify.steps[2].jsonPath, '$.type')
+assert.equal(verify.steps[3].type, 'assertOnlyPathsChanged')
+assert.deepEqual(verify.steps[3].paths, ['README.md'])
+
+const contract = normalizeContractForPiRuntime({
+  acceptanceCriteria: [
+    {
+      id: 'AC1',
+      description: 'demo',
+      verify: {
+        steps: [
+          { type: 'assert-file-unchanged', path: 'src/index.js' },
+          { type: 'assert-not-contains', path: 'README.md', value: 'farewell(' },
+        ],
+      },
+    },
+  ],
+  holdoutScenarios: [
+    {
+      id: 'HO1',
+      verify: {
+        timeout_ms: 10,
+        steps: [{ type: 'git-diff-files' }],
+      },
+    },
+  ],
+})
+
+assert.equal(contract.acceptanceCriteria[0].visibility, 'visible')
+assert.equal(contract.acceptanceCriteria[0].verify.steps[0].type, 'assertNotModified')
+assert.equal(contract.acceptanceCriteria[0].verify.steps[1].type, 'assertNotContains')
+assert.equal(contract.acceptanceCriteria[0].verify.steps[1].text, 'farewell(')
+assert.equal(contract.acceptanceCriteria[0].verify.timeout_ms, 30000)
+assert.equal(contract.holdoutScenarios[0].verify.steps[0].type, 'gitDiffFiles')
+assert.equal(contract.holdoutScenarios[0].verify.timeout_ms, 10)
+
+console.log('PASS: pi verify normalizer')
+EOF


### PR DESCRIPTION
## Summary
- add first-class pi support directly in this repo via a native `/signum` command
- implement the pi runtime flow through CONTRACT -> EXECUTE -> AUDIT -> PACK
- package the repo root as a pi-installable npm package and add pi smoke coverage

## Included
- root `package.json` with pi extension manifest
- `platforms/pi/` native extension surface, role prompts, and runtime helpers
- CONTRACT, EXECUTE, AUDIT, and PACK phases in the pi runtime
- runtime policy-wrapped engineer tools and execute receipts
- pi explain/init/archive/close support
- pi smoke tests and packaging checks

## Validation
- `npm run check`
- live pi smoke for `/signum <task>` with dev auto-approve

## Notes
- AUDIT is currently single-pass in the pi runtime
- iterative audit parity is intentionally deferred as follow-up work
