### PR TITLE
feat: normalize pi verify dialect

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "check": "npm run pack:dry-run && npm run test:pi",
     "pack:dry-run": "npm pack --dry-run",
-    "test:pi": "bash tests/test-pi-extension.sh",
+    "test:pi": "bash tests/test-pi-extension.sh && bash tests/test-pi-verify-normalizer.sh",
     "test:pi:live": "bash tests/test-pi-full-pipeline.sh"
   },
   "files": [

--- a/platforms/pi/agents/contractor.md
+++ b/platforms/pi/agents/contractor.md
@@ -61,6 +61,23 @@ Also include when possible:
 - Every AC must have `visibility: "visible"`
 - Every AC must include `verify`
 - Prefer typed DSL `verify.steps` over legacy string commands
+- In pi contracts, keep verify steps within the supported portable dialect:
+  - `readFile`
+  - `run`
+  - `gitDiffFiles`
+  - `assertContains`
+  - `assertNotContains`
+  - `assertNotContainsAny`
+  - `assertJsonPathEquals`
+  - `assertEquals`
+  - `assertMatches`
+  - `assertOnlyPathsChanged`
+  - `assertNotModified`
+  - `assertFileExists`
+  - `assertReferenceMatchesImplementation`
+  - `assertSemanticAlignment`
+- Prefer exact file/path assertions over vague semantic-only checks when possible
+- Use `text` for string assertions instead of mixing `text` and `value` unless a scalar equality check is intended
 - Use negative AC language where appropriate (`must not`, `reject`, `prevent`, `fail`) so the contract can be tested robustly
 
 ## Holdout rules
@@ -71,7 +88,7 @@ Generate hidden holdout scenarios the engineer should not optimize for directly.
 - high risk: at least 5
 - Include negative or boundary scenarios
 - Put them in `holdoutScenarios`
-- Prefer typed DSL verification here too
+- Prefer the same portable typed DSL verification here too
 
 ## Risk rules
 

--- a/platforms/pi/extensions/signum/phases/contract.ts
+++ b/platforms/pi/extensions/signum/phases/contract.ts
@@ -24,6 +24,7 @@ import {
 } from "../runtime/script-adapters/contract-dir.ts"
 import { runJsonScript, runTextScript, sha256File, toUtcTimestamp } from "../runtime/script-adapters/checks.ts"
 import { loadRolePromptAsset, SdkRoleSessionRunner } from "../runtime/role-session.ts"
+import { normalizeContractForPiRuntime } from "../runtime/verify-normalizer.ts"
 import { emitSignumMessage, setSignumStatus } from "../ui.ts"
 
 interface ContractRunOptions {
@@ -313,7 +314,7 @@ async function salvageContractFromFinalText(projectRoot: string, finalText: stri
   if (!extracted) return null
 
   try {
-    const parsed = JSON.parse(extracted) as ContractDocument
+    const parsed = normalizeContractForPiRuntime(JSON.parse(extracted) as ContractDocument)
     if (!isValidContract(parsed)) return null
     await writeJson(resolve(projectRoot, ".signum/contract.json"), parsed)
     return parsed
@@ -383,8 +384,9 @@ async function prepareWorkspace(projectRoot: string) {
 async function readAndValidateContract(projectRoot: string): Promise<ContractDocument | null> {
   try {
     const raw = await readFile(resolve(projectRoot, ".signum/contract.json"), "utf8")
-    const parsed = JSON.parse(raw) as ContractDocument
+    const parsed = normalizeContractForPiRuntime(JSON.parse(raw) as ContractDocument)
     if (!isValidContract(parsed)) return null
+    await writeJson(resolve(projectRoot, ".signum/contract.json"), parsed)
     return parsed
   } catch {
     return null

--- a/platforms/pi/extensions/signum/runtime/verify-normalizer.ts
+++ b/platforms/pi/extensions/signum/runtime/verify-normalizer.ts
@@ -1,0 +1,124 @@
+interface VerifyStep {
+  type?: unknown
+  [key: string]: unknown
+}
+
+interface VerifyBlock {
+  steps?: unknown
+  timeout_ms?: unknown
+  [key: string]: unknown
+}
+
+interface ContractLike {
+  acceptanceCriteria?: Array<Record<string, unknown>>
+  holdoutScenarios?: Array<Record<string, unknown>>
+  [key: string]: unknown
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000
+
+export function normalizeContractForPiRuntime<T extends ContractLike>(contract: T): T {
+  const next = {
+    ...contract,
+    acceptanceCriteria: Array.isArray(contract.acceptanceCriteria)
+      ? contract.acceptanceCriteria.map((criterion) => normalizeCriterion(criterion))
+      : contract.acceptanceCriteria,
+    holdoutScenarios: Array.isArray(contract.holdoutScenarios)
+      ? contract.holdoutScenarios.map((scenario) => normalizeHoldoutScenario(scenario))
+      : contract.holdoutScenarios,
+  }
+  return next as T
+}
+
+export function normalizeVerifyForPiRuntime(verify: unknown): unknown {
+  if (!verify || typeof verify !== "object") return verify
+  const record = verify as VerifyBlock
+  if (!Array.isArray(record.steps)) return verify
+
+  return {
+    ...record,
+    steps: record.steps.map((step) => normalizeStep(step)),
+    timeout_ms:
+      typeof record.timeout_ms === "number" && Number.isFinite(record.timeout_ms) && record.timeout_ms > 0
+        ? record.timeout_ms
+        : DEFAULT_TIMEOUT_MS,
+  }
+}
+
+function normalizeCriterion(criterion: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...criterion,
+    visibility: typeof criterion.visibility === "string" ? criterion.visibility : "visible",
+    verify: normalizeVerifyForPiRuntime(criterion.verify),
+  }
+}
+
+function normalizeHoldoutScenario(scenario: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...scenario,
+    verify: normalizeVerifyForPiRuntime(scenario.verify),
+  }
+}
+
+function normalizeStep(step: unknown): unknown {
+  if (!step || typeof step !== "object") return step
+  const record = { ...(step as VerifyStep) }
+  const normalizedType = normalizeType(record.type)
+  if (normalizedType) {
+    record.type = normalizedType
+  }
+
+  switch (normalizedType) {
+    case "assertContains":
+    case "assertNotContains": {
+      if (typeof record.text !== "string" && typeof record.value === "string") {
+        record.text = record.value
+      }
+      break
+    }
+    case "assertJsonPathEquals": {
+      if (typeof record.jsonPath !== "string" && typeof record.json_path === "string") {
+        record.jsonPath = record.json_path
+      }
+      break
+    }
+    case "assertOnlyPathsChanged": {
+      if (!Array.isArray(record.paths) && Array.isArray(record.allowed)) {
+        record.paths = record.allowed
+      }
+      break
+    }
+  }
+
+  return record
+}
+
+function normalizeType(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const key = value.toLowerCase().replace(/[-_]/g, "")
+  return TYPE_ALIASES[key] ?? value
+}
+
+const TYPE_ALIASES: Record<string, string> = {
+  readfile: "readFile",
+  run: "run",
+  gitdiff: "gitDiff",
+  gitdifffiles: "gitDiffFiles",
+  assertcontains: "assertContains",
+  assertnotcontains: "assertNotContains",
+  assertnotcontainsany: "assertNotContainsAny",
+  assertjsonpathequals: "assertJsonPathEquals",
+  assertgitdiffpaths: "assertOnlyPathsChanged",
+  assertonlypathschanged: "assertOnlyPathsChanged",
+  assertnofilechangesoutside: "assertOnlyPathsChanged",
+  assertequals: "assertEquals",
+  assertmatches: "assertMatches",
+  assertnotmodified: "assertNotModified",
+  assertpathnotmodified: "assertNotModified",
+  assertnodiff: "assertNotModified",
+  assertfileunchanged: "assertNotModified",
+  assertfileexists: "assertFileExists",
+  assertreferencematchesimplementation: "assertReferenceMatchesImplementation",
+  assertsemanticalignment: "assertSemanticAlignment",
+  assertsemanticconsistency: "assertSemanticAlignment",
+}

--- a/tests/test-pi-verify-normalizer.sh
+++ b/tests/test-pi-verify-normalizer.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+TARGET="$ROOT/platforms/pi/extensions/signum/runtime/verify-normalizer.ts"
+
+node --input-type=module - <<'EOF'
+import assert from 'node:assert/strict'
+import { normalizeContractForPiRuntime, normalizeVerifyForPiRuntime } from './platforms/pi/extensions/signum/runtime/verify-normalizer.ts'
+
+const verify = normalizeVerifyForPiRuntime({
+  steps: [
+    { type: 'read-file', path: 'README.md' },
+    { type: 'assert-contains', path: 'README.md', value: 'greet' },
+    { type: 'assert-json-path-equals', path: 'package.json', json_path: '$.type', value: 'module' },
+    { type: 'assert-no-file-changes-outside', allowed: ['README.md'] },
+  ],
+})
+
+assert.equal(verify.timeout_ms, 30000)
+assert.equal(verify.steps[0].type, 'readFile')
+assert.equal(verify.steps[1].type, 'assertContains')
+assert.equal(verify.steps[1].text, 'greet')
+assert.equal(verify.steps[2].type, 'assertJsonPathEquals')
+assert.equal(verify.steps[2].jsonPath, '$.type')
+assert.equal(verify.steps[3].type, 'assertOnlyPathsChanged')
+assert.deepEqual(verify.steps[3].paths, ['README.md'])
+
+const contract = normalizeContractForPiRuntime({
+  acceptanceCriteria: [
+    {
+      id: 'AC1',
+      description: 'demo',
+      verify: {
+        steps: [
+          { type: 'assert-file-unchanged', path: 'src/index.js' },
+          { type: 'assert-not-contains', path: 'README.md', value: 'farewell(' },
+        ],
+      },
+    },
+  ],
+  holdoutScenarios: [
+    {
+      id: 'HO1',
+      verify: {
+        timeout_ms: 10,
+        steps: [{ type: 'git-diff-files' }],
+      },
+    },
+  ],
+})
+
+assert.equal(contract.acceptanceCriteria[0].visibility, 'visible')
+assert.equal(contract.acceptanceCriteria[0].verify.steps[0].type, 'assertNotModified')
+assert.equal(contract.acceptanceCriteria[0].verify.steps[1].type, 'assertNotContains')
+assert.equal(contract.acceptanceCriteria[0].verify.steps[1].text, 'farewell(')
+assert.equal(contract.acceptanceCriteria[0].verify.timeout_ms, 30000)
+assert.equal(contract.holdoutScenarios[0].verify.steps[0].type, 'gitDiffFiles')
+assert.equal(contract.holdoutScenarios[0].verify.timeout_ms, 10)
+
+console.log('PASS: pi verify normalizer')
+EOF


### PR DESCRIPTION
## Summary
- normalize pi contract verify blocks into a portable dialect before approval/execution
- reduce verify-shape drift from contractor output by canonicalizing common aliases and field names
- add deterministic coverage for the normalizer

## Included
- new `platforms/pi/extensions/signum/runtime/verify-normalizer.ts`
- contract-phase normalization before validation/persistence
- stricter pi contractor guidance for supported verify step shapes
- `tests/test-pi-verify-normalizer.sh`

## Validation
- `npm run check`

## Notes
- this PR is intentionally stacked on top of `feat/pi-native-slice5-mvp`
- goal is to reduce compatibility heuristics and make execute evidence more predictable
