### PR TITLE
[codex] Fix Signum init command surface

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,5 @@
   "license": "MIT",
   "name": "signum",
   "repository": "https://github.com/heurema/signum",
-  "version": "4.19.1"
+  "version": "4.19.2"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [4.19.2] - 2026-04-21
+
+### Fixed
+- Clarified the Claude Code init command surface so docs and prompts now use `/signum:init` as the canonical plugin invocation
+  - `README.md` and `docs/how-it-works.md` now document `/signum:init` instead of `/signum init`
+  - `commands/signum.md` and `platforms/claude-code/commands/signum.md` now redirect accidental `init ...` usage to `/signum:init`
+  - `commands/init.md` and `platforms/claude-code/commands/init.md` now note that `--harness` requires Signum `>= v4.18.0`
+- Made init bootstrap helper resolution work in downstream repos
+  - `commands/init.md` and `platforms/claude-code/commands/init.md` now resolve `init-scanner.sh` and `init-harness-scaffold.sh` from `CLAUDE_PLUGIN_ROOT/lib/` first, with repo-local `lib/` fallback
+  - `tests/test-init-command-surface.sh` covers canonical command usage, redirect guard, version note, and helper path resolution
+
 ## [4.19.1] - 2026-04-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ Storage model:
 For an existing repo, bootstrap project context first:
 
 ```bash
-/signum init --harness
+/signum:init --harness
 ```
+
+For Claude Code plugin usage, `/signum:init` is the canonical form. `--harness` requires Signum `>= v4.18.0`.
 
 This generates `project.intent.md`, `project.glossary.json`, and repo-level harness docs such as `AGENTS.md`, `ARCHITECTURE.md`, `docs/PLANS.md`, `docs/RELIABILITY.md`, `docs/SECURITY.md`, and `docs/QUALITY_SCORE.md`. In brownfield repos, existing context files are preserved unless you also pass `--force`.
 
@@ -77,7 +79,7 @@ This generates `project.intent.md`, `project.glossary.json`, and repo-level harn
 | Command | Description |
 |---------|-------------|
 | `/signum <task>` | Run the full CONTRACT → EXECUTE → AUDIT → PACK pipeline |
-| `/signum init [--force] [--harness] [--project-root <path>]` | Bootstrap `project.intent.md` / `project.glossary.json`; `--harness` also scaffolds repo-level harness docs |
+| `/signum:init [--force] [--harness] [--project-root <path>]` | Bootstrap `project.intent.md` / `project.glossary.json`; `--harness` also scaffolds repo-level harness docs |
 
 ## Maintenance checks
 
@@ -95,11 +97,11 @@ It is fixture-driven and snapshot-based by design. It does not call live provide
 
 **Holdout scenarios** — The Contractor generates hidden acceptance criteria the Engineer never sees. When implementation is complete, holdouts run against the result — blind testing for cases the agent couldn't optimize for. Verification uses a typed DSL with `http`, `exec` (whitelisted binaries only), and `expect` primitives — no shell execution, no `eval`. Minimum counts enforced by risk level: 0 for low, 2 for medium, 5 for high.
 
-**Project intent alignment** — If the target project has a `project.intent.md` at its root, the contractor reads it before generating contracts. Non-goals and glossary terms flow into contract scope and terminology. For medium/high-risk tasks, missing project intent triggers a blocking question. An LLM-based alignment check warns when the contract diverges from project goals. `/signum init` bootstraps this file from an existing codebase.
+**Project intent alignment** — If the target project has a `project.intent.md` at its root, the contractor reads it before generating contracts. Non-goals and glossary terms flow into contract scope and terminology. For medium/high-risk tasks, missing project intent triggers a blocking question. An LLM-based alignment check warns when the contract diverges from project goals. `/signum:init` bootstraps this file from an existing codebase.
 
 **Glossary enforcement** — A `project.glossary.json` at the project root defines canonical terms and forbidden synonyms. `glossary_check` scans contracts for alias usage, `terminology_consistency_check` detects synonym proliferation across active contracts. Both are WARN-only.
 
-**Harness bootstrap** — `/signum init --harness` adds deterministic repo-level scaffolding for `AGENTS.md`, `ARCHITECTURE.md`, `docs/PLANS.md`, `docs/RELIABILITY.md`, `docs/SECURITY.md`, and `docs/QUALITY_SCORE.md`. These files make repo conventions, architecture, planning, and review policy explicit without changing Signum runtime behavior.
+**Harness bootstrap** — `/signum:init --harness` adds deterministic repo-level scaffolding for `AGENTS.md`, `ARCHITECTURE.md`, `docs/PLANS.md`, `docs/RELIABILITY.md`, `docs/SECURITY.md`, and `docs/QUALITY_SCORE.md`. These files make repo conventions, architecture, planning, and review policy explicit without changing Signum runtime behavior.
 
 **Brownfield validation pattern** — When extending harness bootstrap or advisory anti-entropy behavior, prefer a downstream-style temporary repo test that preserves existing `project.intent.md` / `project.glossary.json`, materializes scaffold docs, and checks the resulting `.signum/anti_entropy_report.json`. `tests/test-brownfield-harness-flow.sh` is the reference pattern.
 

--- a/commands/init.md
+++ b/commands/init.md
@@ -31,14 +31,42 @@ Parse `$ARGUMENTS`:
 
 **Usage:**
 ```
-/signum init [--force] [--harness] [--project-root <path>]
+/signum:init [--force] [--harness] [--project-root <path>]
 ```
+
+For Claude Code plugin usage, `/signum:init` is the canonical form. `--harness` requires Signum `>= v4.18.0`.
 
 ---
 
 ## Step 1: SCAN (deterministic)
 
-### 1a. Check for existing files
+### 1a. Resolve Signum helper paths
+
+Run:
+```bash
+resolve_signum_helper() {
+  local helper="$1"
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/lib/${helper}" ]; then
+    printf '%s\n' "${CLAUDE_PLUGIN_ROOT}/lib/${helper}"
+    return 0
+  fi
+  if [ -f "lib/${helper}" ]; then
+    printf '%s\n' "lib/${helper}"
+    return 0
+  fi
+  echo "ERROR: Signum helper not found: ${helper}" >&2
+  return 1
+}
+
+INIT_SCANNER_PATH=$(resolve_signum_helper "init-scanner.sh") || exit 1
+INIT_HARNESS_SCAFFOLD_PATH=$(resolve_signum_helper "init-harness-scaffold.sh") || exit 1
+printf 'INIT_SCANNER_PATH=%s\n' "$INIT_SCANNER_PATH"
+printf 'INIT_HARNESS_SCAFFOLD_PATH=%s\n' "$INIT_HARNESS_SCAFFOLD_PATH"
+```
+
+Save the resolved helper paths as `INIT_SCANNER_PATH` and `INIT_HARNESS_SCAFFOLD_PATH`.
+
+### 1b. Check for existing files
 
 Run:
 ```bash
@@ -48,7 +76,7 @@ ls project.glossary.json 2>/dev/null && echo "GLOSSARY_EXISTS=true" || echo "GLO
 
 If `HARNESS_MODE=true`, also run:
 ```bash
-bash lib/init-harness-scaffold.sh --project-root "${PROJECT_ROOT:-.}" 2>/dev/null
+bash "$INIT_HARNESS_SCAFFOLD_PATH" --project-root "${PROJECT_ROOT:-.}" 2>/dev/null
 ```
 
 Save this JSON as HARNESS_SCAFFOLD. It contains the additional harness-doc drafts plus `.missingCount` / `.existingCount`.
@@ -67,14 +95,14 @@ If `HARNESS_MODE=false` AND (`project.intent.md` OR `project.glossary.json` alre
   ```
   project.intent.md already exists.
 
-  To overwrite, run: /signum init --force
-  To update (merge), run: /signum init --force
+  To overwrite, run: /signum:init --force
+  To update (merge), run: /signum:init --force
   ```
 
-### 1b. Run scanner
+### 1c. Run scanner
 
 ```bash
-bash lib/init-scanner.sh --project-root "${PROJECT_ROOT:-.}" 2>/dev/null
+bash "$INIT_SCANNER_PATH" --project-root "${PROJECT_ROOT:-.}" 2>/dev/null
 ```
 
 Save the output JSON as SCAN_SIGNALS. This contains all signals needed for synthesis.
@@ -98,7 +126,7 @@ SCAN complete. Found signals:
 
 ## Step 2: SYNTHESIZE (LLM)
 
-If `HARNESS_MODE=true`, harness docs come from `lib/init-harness-scaffold.sh` (deterministic; do NOT ask the synthesizer to invent them).
+If `HARNESS_MODE=true`, harness docs come from `INIT_HARNESS_SCAFFOLD_PATH` (deterministic; do NOT ask the synthesizer to invent them).
 
 If existing `project.intent.md` **and** `project.glossary.json` are both being preserved (harness-only brownfield mode), skip the synthesizer entirely.
 
@@ -302,7 +330,7 @@ Next steps:
 - If synthesis produces empty Goal: warn user, proceed with TODO placeholder
 - If jq/python3 unavailable: skip verification step, still write files
 - If project has no signals at all (no README, no manifest, no git): warn and emit minimal template with TODO markers throughout
-- If `lib/init-harness-scaffold.sh` fails in `--harness` mode: print error and stop (do not synthesize partial state)
+- If `INIT_HARNESS_SCAFFOLD_PATH` fails in `--harness` mode: print error and stop (do not synthesize partial state)
 
 ---
 

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -46,7 +46,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.19.1",
+  "version": "4.19.2",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -3095,7 +3095,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' .signum/audit_summary.js
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.19.1" \
+  --arg signumVersion "4.19.2" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -20,6 +20,25 @@ CONTRACT → EXECUTE → AUDIT → PACK
 
 The user's task: `$ARGUMENTS`
 
+## Init Command Redirect
+
+If the user's task is using Signum init command syntax instead of a feature request - for example:
+- exactly `init`
+- `init --force`
+- `init --harness`
+- `init --project-root <path>`
+
+do NOT run the CONTRACT → EXECUTE → AUDIT → PACK pipeline.
+
+Instead, tell the user:
+
+Use `/signum:init [--force] [--harness] [--project-root <path>]`.
+
+For Claude Code plugin usage, `/signum:init` is the canonical form.
+`--harness` requires Signum `>= v4.18.0`.
+
+Then stop.
+
 ## Explain Mode
 
 If the user's task is exactly `explain` (case-insensitive), do NOT run the pipeline. Instead, output this JSON and stop:

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -173,13 +173,15 @@ Signum also ships a maintainer-facing offline eval harness under `evals/`. It is
 - The scope is contract/audit/proofpack semantics for prompt/orchestration work.
 - No live provider calls, no LLM judge, no trajectory evaluation.
 
-## Project Context Bootstrap: /signum init
+## Project Context Bootstrap: /signum:init
 
-Before running the main pipeline on an unfamiliar project, use `/signum init` to generate project context files that the Contractor agent reads automatically. Use `--harness` when you also want repo-level harness docs scaffolded.
+Before running the main pipeline on an unfamiliar project, use `/signum:init` to generate project context files that the Contractor agent reads automatically. Use `--harness` when you also want repo-level harness docs scaffolded.
 
 ```
-/signum init [--force] [--harness] [--project-root <path>]
+/signum:init [--force] [--harness] [--project-root <path>]
 ```
+
+For Claude Code plugin usage, `/signum:init` is the canonical form. `--harness` requires Signum `>= v4.18.0`.
 
 ### Pipeline
 
@@ -187,7 +189,7 @@ Before running the main pipeline on an unfamiliar project, use `/signum init` to
 SCAN → SYNTHESIZE → PRESENT → VERIFY
 ```
 
-**SCAN** (deterministic, ~5s): `lib/init-scanner.sh` reads known-location files using Claude's native tools. Signal hierarchy (ranked, not averaged):
+**SCAN** (deterministic, ~5s): Signum resolves the plugin-owned `init-scanner.sh` helper first, then falls back to repo-local `lib/init-scanner.sh` when run inside the Signum source tree. The scanner reads known-location files using Claude's native tools. Signal hierarchy (ranked, not averaged):
 1. `docs/how-it-works.md`, `docs/architecture.md` — authoritative (Goal, Capabilities)
 2. `CLAUDE.md`, `AGENTS.md` — explicit conventions and exclusions (Non-Goals)
 3. `README.md` first 150 lines — fallback goal description
@@ -205,7 +207,7 @@ SCAN → SYNTHESIZE → PRESENT → VERIFY
 
 **VERIFY**: reports `Glossary has N terms, M aliases` and `Intent covers: N capabilities, N non-goals`.
 
-When `--harness` is enabled, Signum also runs `lib/init-harness-scaffold.sh` and scaffolds deterministic drafts for repo-level docs. In brownfield repos where both `project.intent.md` and `project.glossary.json` already exist, `--harness` preserves those files and only creates missing harness docs unless `--force` is also provided.
+When `--harness` is enabled, Signum also resolves the plugin-owned `init-harness-scaffold.sh` helper first, then falls back to repo-local `lib/init-harness-scaffold.sh` when run inside the Signum source tree. It scaffolds deterministic drafts for repo-level docs. In brownfield repos where both `project.intent.md` and `project.glossary.json` already exist, `--harness` preserves those files and only creates missing harness docs unless `--force` is also provided.
 
 ### Generated Files
 

--- a/platforms/claude-code/commands/init.md
+++ b/platforms/claude-code/commands/init.md
@@ -29,19 +29,47 @@ Parse `$ARGUMENTS`:
 - If `--harness` is present, set HARNESS_MODE=true (scaffold repo-level harness docs)
 - If `--project-root <path>` is present, use that path. Otherwise use current directory.
 - If both `--force` and `--actualize` are present: error "Cannot combine --force and --actualize. Use --actualize for section-by-section updates." and stop.
-- If both `--actualize` and `--harness` are present: error "Cannot combine --actualize and --harness in one run. Actualize intent first, then run /signum init --harness." and stop.
+- If both `--actualize` and `--harness` are present: error "Cannot combine --actualize and --harness in one run. Actualize intent first, then run /signum:init --harness." and stop.
 - Any other argument: print usage and stop.
 
 **Usage:**
 ```
-/signum init [--force] [--actualize] [--harness] [--project-root <path>]
+/signum:init [--force] [--actualize] [--harness] [--project-root <path>]
 ```
+
+For Claude Code plugin usage, `/signum:init` is the canonical form. `--harness` requires Signum `>= v4.18.0`.
 
 ---
 
 ## Step 1: SCAN (deterministic)
 
-### 1a. Check for existing files
+### 1a. Resolve Signum helper paths
+
+Run:
+```bash
+resolve_signum_helper() {
+  local helper="$1"
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/lib/${helper}" ]; then
+    printf '%s\n' "${CLAUDE_PLUGIN_ROOT}/lib/${helper}"
+    return 0
+  fi
+  if [ -f "lib/${helper}" ]; then
+    printf '%s\n' "lib/${helper}"
+    return 0
+  fi
+  echo "ERROR: Signum helper not found: ${helper}" >&2
+  return 1
+}
+
+INIT_SCANNER_PATH=$(resolve_signum_helper "init-scanner.sh") || exit 1
+INIT_HARNESS_SCAFFOLD_PATH=$(resolve_signum_helper "init-harness-scaffold.sh") || exit 1
+printf 'INIT_SCANNER_PATH=%s\n' "$INIT_SCANNER_PATH"
+printf 'INIT_HARNESS_SCAFFOLD_PATH=%s\n' "$INIT_HARNESS_SCAFFOLD_PATH"
+```
+
+Save the resolved helper paths as `INIT_SCANNER_PATH` and `INIT_HARNESS_SCAFFOLD_PATH`.
+
+### 1b. Check for existing files
 
 Run:
 ```bash
@@ -51,7 +79,7 @@ ls project.glossary.json 2>/dev/null && echo "GLOSSARY_EXISTS=true" || echo "GLO
 
 If `HARNESS_MODE=true`, also run:
 ```bash
-bash lib/init-harness-scaffold.sh --project-root "${PROJECT_ROOT:-.}" 2>/dev/null
+bash "$INIT_HARNESS_SCAFFOLD_PATH" --project-root "${PROJECT_ROOT:-.}" 2>/dev/null
 ```
 
 Save this JSON as HARNESS_SCAFFOLD. It contains the additional harness-doc drafts plus `.missingCount` / `.existingCount`.
@@ -59,7 +87,7 @@ Save this JSON as HARNESS_SCAFFOLD. It contains the additional harness-doc draft
 **If ACTUALIZE_MODE=true:**
 - If `project.intent.md` does NOT exist: print error and STOP:
   ```
-  actualize requires an existing project.intent.md. Run /signum init first.
+  actualize requires an existing project.intent.md. Run /signum:init first.
   ```
 - If `project.glossary.json` does NOT exist: print warning "Glossary will be created fresh." and continue.
 - Do NOT prompt about overwrite — actualize uses section-by-section confirmation.
@@ -77,17 +105,17 @@ Save this JSON as HARNESS_SCAFFOLD. It contains the additional harness-doc draft
   ```
   project.intent.md already exists.
 
-  To overwrite, run: /signum init --force
-  To update with diff review, run: /signum init --actualize
+  To overwrite, run: /signum:init --force
+  To update with diff review, run: /signum:init --actualize
   ```
 
 **If FORCE_MODE=true AND ACTUALIZE_MODE=false:**
 - Continue with full overwrite (existing behavior).
 
-### 1b. Run scanner
+### 1c. Run scanner
 
 ```bash
-bash lib/init-scanner.sh --project-root "${PROJECT_ROOT:-.}" 2>/dev/null
+bash "$INIT_SCANNER_PATH" --project-root "${PROJECT_ROOT:-.}" 2>/dev/null
 ```
 
 Save the output JSON as SCAN_SIGNALS. This contains all signals needed for synthesis.
@@ -111,7 +139,7 @@ SCAN complete. Found signals:
 
 ## Step 2: SYNTHESIZE (LLM)
 
-If `HARNESS_MODE=true`, harness docs come from `lib/init-harness-scaffold.sh` (deterministic; do NOT ask the synthesizer to invent them).
+If `HARNESS_MODE=true`, harness docs come from `INIT_HARNESS_SCAFFOLD_PATH` (deterministic; do NOT ask the synthesizer to invent them).
 
 If existing `project.intent.md` **and** `project.glossary.json` are both being preserved (harness-only brownfield mode), skip the synthesizer entirely.
 
@@ -423,7 +451,7 @@ Next steps:
 - If jq/python3 unavailable: skip verification step, still write files
 - If project has no signals at all (no README, no manifest, no git): warn and emit minimal template with TODO markers throughout
 - If actualize with no existing intent: error and stop (must run init first)
-- If `lib/init-harness-scaffold.sh` fails in `--harness` mode: print error and stop (do not synthesize partial state)
+- If `INIT_HARNESS_SCAFFOLD_PATH` fails in `--harness` mode: print error and stop (do not synthesize partial state)
 
 ---
 

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -47,7 +47,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.19.1",
+  "version": "4.19.2",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -3095,7 +3095,7 @@ fi
 # Final assembly
 jq -n \
   --arg schemaVersion "4.6" \
-  --arg signumVersion "4.19.1" \
+  --arg signumVersion "4.19.2" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -20,6 +20,26 @@ CONTRACT → EXECUTE → AUDIT → PACK
 
 The user's task: `$ARGUMENTS`
 
+## Init Command Redirect
+
+If the user's task is using Signum init command syntax instead of a feature request - for example:
+- exactly `init`
+- `init --force`
+- `init --actualize`
+- `init --harness`
+- `init --project-root <path>`
+
+do NOT run the CONTRACT → EXECUTE → AUDIT → PACK pipeline.
+
+Instead, tell the user:
+
+Use `/signum:init [--force] [--actualize] [--harness] [--project-root <path>]`.
+
+For Claude Code plugin usage, `/signum:init` is the canonical form.
+`--harness` requires Signum `>= v4.18.0`.
+
+Then stop.
+
 ## Explain Mode
 
 If the user's task is exactly `explain` (case-insensitive), do NOT run the pipeline. Instead, output this JSON and stop:

--- a/tests/test-init-command-surface.sh
+++ b/tests/test-init-command-surface.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# test-init-command-surface.sh -- command surface and helper resolution checks for init
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+ROOT_INIT="$REPO_ROOT/commands/init.md"
+OVERLAY_INIT="$REPO_ROOT/platforms/claude-code/commands/init.md"
+ROOT_SIGNUM="$REPO_ROOT/commands/signum.md"
+OVERLAY_SIGNUM="$REPO_ROOT/platforms/claude-code/commands/signum.md"
+README_FILE="$REPO_ROOT/README.md"
+HOW_IT_WORKS="$REPO_ROOT/docs/how-it-works.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local name="$1" file="$2" needle="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s — expected "%s" in %s\n' "$name" "$needle" "$file"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" file="$2" needle="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  FAIL: %s — found "%s" in %s\n' "$name" "$needle" "$file"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Public docs ==="
+assert_contains "README uses canonical init command" "$README_FILE" "/signum:init --harness"
+assert_contains "README documents version requirement" "$README_FILE" ">= v4.18.0"
+assert_not_contains "README no longer presents spaced init example" "$README_FILE" "/signum init --harness"
+assert_contains "How-it-works uses canonical init heading" "$HOW_IT_WORKS" "## Project Context Bootstrap: /signum:init"
+assert_contains "How-it-works uses canonical init usage" "$HOW_IT_WORKS" "/signum:init [--force] [--harness] [--project-root <path>]"
+assert_contains "How-it-works documents version requirement" "$HOW_IT_WORKS" ">= v4.18.0"
+
+echo ""
+echo "=== Init command prompts ==="
+assert_contains "Root init usage is canonical" "$ROOT_INIT" "/signum:init [--force] [--harness] [--project-root <path>]"
+assert_contains "Overlay init usage is canonical" "$OVERLAY_INIT" "/signum:init [--force] [--actualize] [--harness] [--project-root <path>]"
+assert_contains "Root init resolves plugin helper paths" "$ROOT_INIT" "resolve_signum_helper()"
+assert_contains "Overlay init resolves plugin helper paths" "$OVERLAY_INIT" "resolve_signum_helper()"
+assert_contains "Root init checks CLAUDE_PLUGIN_ROOT" "$ROOT_INIT" 'CLAUDE_PLUGIN_ROOT'
+assert_contains "Overlay init checks CLAUDE_PLUGIN_ROOT" "$OVERLAY_INIT" 'CLAUDE_PLUGIN_ROOT'
+assert_contains "Root init uses resolved scanner path" "$ROOT_INIT" 'bash "$INIT_SCANNER_PATH" --project-root'
+assert_contains "Overlay init uses resolved scanner path" "$OVERLAY_INIT" 'bash "$INIT_SCANNER_PATH" --project-root'
+assert_contains "Root init uses resolved harness scaffold path" "$ROOT_INIT" 'bash "$INIT_HARNESS_SCAFFOLD_PATH" --project-root'
+assert_contains "Overlay init uses resolved harness scaffold path" "$OVERLAY_INIT" 'bash "$INIT_HARNESS_SCAFFOLD_PATH" --project-root'
+assert_not_contains "Root init no longer hardcodes repo-local scanner path" "$ROOT_INIT" 'bash lib/init-scanner.sh'
+assert_not_contains "Overlay init no longer hardcodes repo-local scanner path" "$OVERLAY_INIT" 'bash lib/init-scanner.sh'
+assert_not_contains "Root init no longer hardcodes repo-local harness scaffold path" "$ROOT_INIT" 'bash lib/init-harness-scaffold.sh'
+assert_not_contains "Overlay init no longer hardcodes repo-local harness scaffold path" "$OVERLAY_INIT" 'bash lib/init-harness-scaffold.sh'
+
+echo ""
+echo "=== Root command guard ==="
+assert_contains "Root signum has init redirect section" "$ROOT_SIGNUM" "## Init Command Redirect"
+assert_contains "Overlay signum has init redirect section" "$OVERLAY_SIGNUM" "## Init Command Redirect"
+assert_contains "Root signum redirects to canonical init command" "$ROOT_SIGNUM" 'Use `/signum:init [--force] [--harness] [--project-root <path>]`.'
+assert_contains "Overlay signum redirects to canonical init command" "$OVERLAY_SIGNUM" 'Use `/signum:init [--force] [--actualize] [--harness] [--project-root <path>]`.'
+assert_contains "Root signum mentions version requirement" "$ROOT_SIGNUM" '>= v4.18.0'
+assert_contains "Overlay signum mentions version requirement" "$OVERLAY_SIGNUM" '>= v4.18.0'
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $passed"
+echo "Failed: $failed"
+echo ""
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+fi


### PR DESCRIPTION
## Summary
- canonicalize Claude Code init usage to `/signum:init`
- add a root `/signum` redirect guard for accidental `init ...` invocations
- resolve init helper scripts from `CLAUDE_PLUGIN_ROOT/lib/` first with repo-local fallback
- add regression coverage for init command surface, version note, and helper path resolution

## Issue
Fixes #26

## Test Plan
- `bash tests/test-init.sh`
- `bash tests/test-init-harness-scaffold.sh`
- `bash tests/test-init-command-surface.sh`
- `bash tests/test-doc-parity.sh`
