### PR TITLE
Use canonical contract artifact root and bump to 4.20.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,5 @@
   "license": "MIT",
   "name": "signum",
   "repository": "https://github.com/heurema/signum",
-  "version": "4.19.1"
+  "version": "4.20.0"
 }

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,7 +13,7 @@ review_cadence: quarterly
 - The product mixes two layers:
   - deterministic shell/JSON verification in `lib/`
   - LLM orchestration in `commands/` and `agents/`
-- The output artifact is `.signum/proofpack.json`, intended for CI gating and auditability.
+- The main output artifact is `proofpack.json` under the active contract artifact root (`.signum/contracts/<contractId>/proofpack.json`), intended for CI gating and auditability.
 
 ## Main Components
 
@@ -32,10 +32,10 @@ review_cadence: quarterly
 
 ### 1. Main product flow
 1. User runs `/signum <task>`.
-2. Contractor creates `.signum/contract.json`, applies spec-quality checks, and prepares execution policy.
+2. Contractor creates canonical `contract.json` under the active contract artifact root, applies spec-quality checks, and prepares execution policy.
 3. Engineer implements against the redacted contract.
 4. AUDIT runs deterministic checks + holdouts + multi-model review panel.
-5. PACK assembles `.signum/proofpack.json`.
+5. PACK assembles `proofpack.json` under the active contract artifact root.
 
 ### 2. Project-context bootstrap flow
 1. User runs `/signum init`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [4.20.0] - 2026-04-21
+
+### Changed
+- Canonical contract-dir artifact root is now consistently reflected across runtime helpers, docs, prompts, overlay surfaces, and CI/template flows
+  - `commands/signum.md` and `platforms/claude-code/commands/signum.md` now treat `.signum/contracts/<contractId>/` as the canonical active artifact root throughout CONTRACT, EXECUTE, AUDIT, PACK, archive/finalize flows, and registry-first resume handling
+  - `lib/contract-dir.sh`, `lib/signum-ci.sh`, `lib/snapshot-tree.sh`, `lib/contract-injection-scan.sh`, `lib/proofpack-index.sh`, verifier helpers, anti-entropy helpers, and their overlay twins now prefer canonical contract-dir resolution before legacy root fallback
+  - core docs, quickstarts, architecture notes, skill docs, plan/research docs, and agent prompts now describe root `.signum/` as registry/state plus compatibility surface rather than the primary live artifact location
+  - new regression coverage locks down canonical path behavior and the remaining intentional compatibility mentions
+
 ## [4.19.1] - 2026-04-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 ## [4.18.1] - 2026-04-10
 
 ### Fixed
-- Claude overlay PACK parity — `platforms/claude-code/commands/signum.md` now emits advisory `.signum/anti_entropy_report.json`, advertises it in explain mode, syncs it to per-contract directories, and shows its summary in final output so `signumVersion` 4.18.x matches actual overlay behavior
+- Claude overlay PACK parity — `platforms/claude-code/commands/signum.md` now emits advisory `anti_entropy_report.json` under the active contract artifact root, advertises it in explain mode, and shows its summary in final output so `signumVersion` 4.18.x matches actual overlay behavior
 
 ## [4.18.0] - 2026-04-10
 
@@ -37,13 +37,13 @@
   - Brownfield-safe behavior: if `project.intent.md` and `project.glossary.json` already exist, `--harness` preserves them and scaffolds only missing harness docs unless `--force` is also provided
 - Anti-entropy Stage 1 report-only flow
   - `lib/anti-entropy-report.sh` — aggregates follow-up findings from cleanup evidence, `modules.yaml`, doc parity reports, and metric-ratchet reports
-  - `lib/pack-anti-entropy.sh` — safe PACK wrapper that always writes `.signum/anti_entropy_report.json` and never changes pipeline decision
+  - `lib/pack-anti-entropy.sh` — safe PACK wrapper that writes `anti_entropy_report.json` next to the active contract artifacts and never changes pipeline decision
   - `tests/test-anti-entropy-report.sh` and `tests/test-pack-anti-entropy.sh` — coverage for report generation and fallback artifact behavior
 
 ### Changed
 - `commands/init.md` — documents `--harness` mode for root Signum init flow
 - `platforms/claude-code/commands/init.md` — documents `--harness` mode for Claude overlay init flow; disallows `--actualize` + `--harness` in the MVP
-- `commands/signum.md` — root PACK now emits advisory `.signum/anti_entropy_report.json` after proofpack assembly and archives/cleans it with the rest of the working set
+- `commands/signum.md` — root PACK now emits advisory `anti_entropy_report.json` under the active contract artifact root after proofpack assembly and archives/cleans it with the rest of the working set
 
 ### Documentation
 - `docs/reference.md` — canonical source policy now states root `commands/signum.md` is the source of truth and platform variants are overlays
@@ -94,7 +94,7 @@
 ### Added
 - **Receipt chain** — deterministic phase-boundary enforcement with append-only receipts (issue #7)
   - `lib/snapshot-tree.sh` — workspace tree snapshot before each engineer launch, captures sorted manifest + tree hash
-  - `lib/boundary-verifier.sh` — runs AC verifiers via DSL runner after engineer returns, checks scope integrity (both out-of-scope and missing inScope), hashes artifacts, classifies evidence strength (observational/predicate/exit_only), writes append-only receipt to `.signum/runs/<run_id>/`
+  - `lib/boundary-verifier.sh` — runs AC verifiers via DSL runner after engineer returns, checks scope integrity (both out-of-scope and missing inScope), hashes artifacts, classifies evidence strength (observational/predicate/exit_only), writes append-only receipts under the active contract artifact root in `runs/<run_id>/`
   - `lib/transition-verifier.sh` — blocks execute→audit transition unless receipt is present, PASS, contract hash matches, artifact hashes valid, append-only chain intact, and all ACs have non-vacuous evidence
   - Orchestrator steps: 2.0.5 (pre-execute snapshot), 2.4.6 (scope existence gate), 2.5 (boundary verification), 2.6 (transition verification)
   - Iterative repair: fresh snapshot per attempt, boundary+transition verify per repair iteration, `RECEIPT_CHAIN_OK` flag prevents silent failure swallowing
@@ -105,7 +105,7 @@
 ### Changed
 - **Policy scanner** — `TODO:`, `FIXME:`, `HACK:`, `XXX:` upgraded from MINOR to CRITICAL `incomplete_implementation`. Added `panic("not implemented")`, `raise NotImplementedError`, `throw new Error("TODO")` patterns. Non-code files (markdown, json, yaml, docs, examples, tests) excluded from incomplete_implementation rules.
 - **Contractor prompt** — `verify.type: "manual"` forbidden. All ACs must use typed DSL with `steps`. Non-vacuous evidence required (must assert observable state via `expect.*` or predicates like `test`, `grep`, `jq -e`).
-- **Engineer prompt** — receipt-chain paths (`.signum/receipts/`, `.signum/runs/`, `.signum/snapshots/`) declared verifier-owned, forbidden for engineer writes.
+- **Engineer prompt** — receipt-chain paths (`receipts/`, `runs/`, `snapshots/`) under the active contract artifact root are verifier-owned and forbidden for engineer writes.
 - **Archive mode** — preserves execute receipt before purging receipt chain intermediates.
 - **`allowNewFilesUnder` scope strictness** — only permits file additions, not modifications or deletions of existing files under those paths.
 
@@ -160,7 +160,7 @@
 - **Context retrieval** (Step 3.2.0) — pre-review step gathers git history (last commit per file), issue refs (ID + title), and project.intent.md. Injected into Claude reviewer only — Codex/Gemini remain adversarially isolated.
   - `{review_context}` variable in `lib/prompts/review-template.md`
 - **Parallel repair lanes** (Step 3.6.2) — 2 parallel Engineers in git worktrees with different strategies (minimal fix vs root-cause). Mechanic+holdout on both, full review on winner only. Runner-up reviewed if winner gets MAJOR+.
-  - Lane artifacts in `.signum/iterations/NN/lanes/A|B/`
+  - Lane artifacts in `iterations/NN/lanes/A|B/` under the active contract artifact root
   - `selected_lane.json` for audit trail
   - Trap-based worktree cleanup, fallback to single-lane on failure
 - **Typed diagnostics** — extracted mechanic logic into `lib/mechanic-parser.sh` with hybrid output format: summary per check always + per-file findings when runner supports structured output.
@@ -220,7 +220,7 @@
 - `SIGNUM_AUDIT_MAX_ITERATIONS` env var for configurable iteration cap
 - `SIGNUM_CI_RELAXED` env var — HUMAN_REVIEW maps to exit 0 in relaxed mode
 - Engineer repair mode: reads `repair_brief.json` to fix specific findings
-- Per-iteration artifact storage in `.signum/iterations/NN/`
+- Per-iteration artifact storage in `iterations/NN/` under the active contract artifact root
 - `audit_iteration_log.json` for cross-iteration tracking
 - Best-of-N with rollback: pipeline keeps best candidate, not last attempt
 - Early stop: halts if no improvement for 2 consecutive iterations

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -29,25 +29,26 @@ Signum runs 4 phases automatically:
 1. **CONTRACT** — Generates a verifiable spec from your request
 2. **EXECUTE** — Implements code against the spec (with repair loop)
 3. **AUDIT** — Reviews with up to 3 independent AI models
-4. **PACK** — Bundles proof artifacts into `proofpack.json` and writes advisory `anti_entropy_report.json`
+4. **PACK** — Bundles proof artifacts into `proofpack.json` and writes advisory `anti_entropy_report.json` under the active contract artifact root
 
 You approve the contract once. Everything else is autonomous.
 
 ## 3. Read the Proofpack
 
-After a run, check the result:
+After a run, check the result under the active contract artifact root that Signum prints at the end of the run:
 
 ```bash
-jq '.decision, .confidence.overall' .signum/proofpack.json
+ARTIFACT_ROOT=".signum/contracts/<contractId>"
+jq '.decision, .confidence.overall' "$ARTIFACT_ROOT/proofpack.json"
 ```
 
 Decisions:
 - **AUTO_OK** — All checks passed. Review the diff and commit.
-- **AUTO_BLOCK** — Issues found. Check `.signum/audit_summary.json`.
+- **AUTO_BLOCK** — Issues found. Check `audit_summary.json` under the active contract artifact root.
 - **HUMAN_REVIEW** — Inconclusive. Review flagged findings manually.
 
 Optional follow-up:
-- `jq '.status, .summary' .signum/anti_entropy_report.json` — advisory cleanup / anti-drift findings
+- `jq '.status, .summary' "$ARTIFACT_ROOT/anti_entropy_report.json"` — advisory cleanup / anti-drift findings
 
 ## 4. Understand the Phases
 
@@ -58,7 +59,7 @@ Optional follow-up:
 | AUDIT | Mechanic checks + up to 3 model reviews + holdout validation | 1-3 min |
 | PACK | Bundles all artifacts into signed proofpack | ~5s |
 
-Key artifacts in `.signum/`:
+Key artifacts under the active contract artifact root (`.signum/contracts/<contractId>/`):
 - `contract.json` — The verified spec
 - `combined.patch` — The code diff
 - `mechanic_report.json` — Lint/typecheck/test results vs baseline
@@ -188,13 +189,13 @@ EOF
 2. Create `project.intent.md` (or skip — Signum will ask)
 3. Run: `/signum "describe your first task"`
 4. Review the contract when prompted (5-item checklist)
-5. Check `.signum/proofpack.json` for the result
-6. Optionally check `.signum/anti_entropy_report.json` for follow-up hygiene work
+5. Check `proofpack.json` under the active contract artifact root for the result
+6. Optionally check `anti_entropy_report.json` there for follow-up hygiene work
 
 `.signum/` is auto-added to `.gitignore`. No cleanup needed.
 
 ## Next Steps
 
 - Run `/signum` on a real task in your project
-- Check `.signum/audit_summary.json` after a run to understand findings
+- Check `audit_summary.json` under the active contract artifact root after a run to understand findings
 - Add `repo-contract.json` for project-wide invariant enforcement

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ claude plugin install .
 Signum grades your spec, shows the contract for approval, implements with an automatic repair loop, audits from multiple angles, and produces `proofpack.json` plus an advisory `anti_entropy_report.json`.
 
 Storage model:
-- `.signum/` is the live working set for the current run
-- `.signum/contracts/<contractId>/` stores durable per-contract snapshots/history, including receipt-chain evidence
+- `.signum/` is now mainly a registry/state surface for the repo, plus compatibility views during the contract-dir migration
+- `.signum/contracts/<contractId>/` stores durable per-contract snapshots/history, including receipt-chain evidence, and is now the canonical root for the contract, pre-execute metadata, execute outputs, selected audit/pack file artifacts (`contract.json`, `spec_quality.json`, `spec_validation.json`, `clover_report.json`, `intent_check.json`, `approval.json`, `contract-hash.txt`, `contract-engineer.json`, `contract-policy.json`, `execution_context.json`, `baseline.json`, `combined.patch`, `execute_log.json`, `iteration_delta.patch`, `mechanic_report.json`, `holdout_report.json`, `policy_violations.json`, `policy_scan.json`, `audit_iteration_log.json`, `repair_brief.json`, `flaky_tests.json`, `audit_summary.json`, `proofpack.json`, `anti_entropy_report.json`), and active run directories (`reviews/`, `iterations/`, `receipts/`, `runs/`, `snapshots/`)
+- `.signum/contracts/index.json.activeContractId` selects the current resumable contract; resume checks should use the registry first, not root `.signum/contract.json`
 - the per-contract directory is not a second active workspace
 
 For an existing repo, bootstrap project context first:
@@ -101,7 +102,7 @@ It is fixture-driven and snapshot-based by design. It does not call live provide
 
 **Harness bootstrap** — `/signum init --harness` adds deterministic repo-level scaffolding for `AGENTS.md`, `ARCHITECTURE.md`, `docs/PLANS.md`, `docs/RELIABILITY.md`, `docs/SECURITY.md`, and `docs/QUALITY_SCORE.md`. These files make repo conventions, architecture, planning, and review policy explicit without changing Signum runtime behavior.
 
-**Brownfield validation pattern** — When extending harness bootstrap or advisory anti-entropy behavior, prefer a downstream-style temporary repo test that preserves existing `project.intent.md` / `project.glossary.json`, materializes scaffold docs, and checks the resulting `.signum/anti_entropy_report.json`. `tests/test-brownfield-harness-flow.sh` is the reference pattern.
+**Brownfield validation pattern** — When extending harness bootstrap or advisory anti-entropy behavior, prefer a downstream-style temporary repo test that preserves existing `project.intent.md` / `project.glossary.json`, materializes scaffold docs, and checks the resulting `anti_entropy_report.json` under the active contract artifact root. `tests/test-brownfield-harness-flow.sh` is the reference pattern.
 
 **Cross-contract coherence** — `overlap_check` detects inScope file overlap between active contracts. `assumption_check` flags contradictions in assumptions across related contracts. `adr_check` warns when relevant ADRs exist but aren't referenced. Contract lineage is tracked via `parentContractId`, `relatedContractIds`, and `interfacesTouched`.
 
@@ -139,7 +140,7 @@ It is fixture-driven and snapshot-based by design. It does not call live provide
 
 **Cleanup contracts** — Contract schema v3.8 adds first-class support for code removal. `removals` entries specify files/directories to delete with `preventReintroduction` flags. `cleanupObligations` use K8s Finalizer semantics — blocking obligations (e.g., "remove all imports of deleted module") must be fulfilled before `AUTO_OK`. The DSL supports `file_not_exists` assertions and `grep` for reference-checking verify blocks. Evidence of successful removals is captured in `proofpack.json`.
 
-**Advisory anti-entropy report** — PACK also writes `.signum/anti_entropy_report.json`: a non-blocking follow-up report that can surface unresolved cleanup evidence, overdue `modules.yaml` lifecycle drift, and optional imported metric regressions. It never changes the pipeline decision.
+**Advisory anti-entropy report** — PACK also writes `anti_entropy_report.json` under the active contract artifact root, with a root `.signum/anti_entropy_report.json` compatibility path during the migration. It is a non-blocking follow-up report that can surface unresolved cleanup evidence, overdue `modules.yaml` lifecycle drift, and optional imported metric regressions. It never changes the pipeline decision.
 
 ## Architecture
 
@@ -223,7 +224,7 @@ Without this file, signum uses each CLI's default model. See `forge doctor` to v
 
 ## Privacy
 
-All orchestration runs inside Claude Code. External providers (Codex CLI, Gemini CLI) receive the diff only — never the full codebase. Signum degrades gracefully if either is unavailable. No API keys required beyond standard CLI auth. No telemetry. Artifacts stored in `.signum/` (auto-added to `.gitignore`), including the advisory `anti_entropy_report.json`.
+All orchestration runs inside Claude Code. External providers (Codex CLI, Gemini CLI) receive the diff only — never the full codebase. Signum degrades gracefully if either is unavailable. No API keys required beyond standard CLI auth. No telemetry. Canonical run artifacts live under `.signum/contracts/<contractId>/` with `.signum/` compatibility paths during the migration, and `.signum/` remains auto-added to `.gitignore`.
 
 ## Why Signum
 

--- a/agents/contractor.md
+++ b/agents/contractor.md
@@ -174,7 +174,7 @@ You receive:
    - Validate: removal paths must exist (for files/dirs being removed), no overlap with `inScope` paths
    - If `modules.yaml` exists, add obligation to update module status in `modules.yaml`
 4. **Generate contract.json** with:
-   - `contractId`: unique identifier in format `sig-YYYYMMDD-<4char-hash>` where YYYYMMDD is the UTC date and the 4-char hash is the first 4 hex characters of the SHA-1 of the goal string. Example: `sig-20260313-a7f2`
+   - `contractId`: include a provisional unique identifier. Preferred format is `sig-YYYYMMDD-HHMM-<4char-token>`, for example `sig-20260313-1000-a7f2`. The runtime may normalize this to its canonical format before execution.
    - `status`: always set to `"draft"` when generating a new contract
    - `timestamps`: object with `createdAt` set to the current UTC datetime in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ), e.g. `"2026-03-13T10:00:00Z"`
    - `schemaVersion`: always `"3.8"` for new contracts
@@ -225,11 +225,15 @@ You receive:
    - All inScope paths must exist (or be new files to create)
    - All verify blocks must use valid DSL step types
    - At least 1 acceptance criterion
-7. **Write** contract to `.signum/contract.json`
+7. **Write** contract to the canonical artifact root provided by the orchestrator
 
 ## Output
 
-Write `.signum/contract.json` following the schema at `lib/schemas/contract.schema.json`.
+Write `contract.json` under the canonical active contract root provided by the orchestrator, following the schema at `lib/schemas/contract.schema.json`.
+
+If both paths are shown to you:
+- canonical path under `.signum/contracts/<contractId>/` is the source of truth
+- `.signum/contract.json` is only a compatibility view pointing at that canonical file
 
 If you have unresolvable questions (can't determine scope, ambiguous requirement, missing context), set `openQuestions` to a non-empty array and `requiredInputsProvided` to false. The orchestrator will HARD STOP and ask the user.
 
@@ -238,7 +242,7 @@ If you have unresolvable questions (can't determine scope, ambiguous requirement
 You have a limited number of turns. Prioritize writing the contract over exhaustive scanning.
 
 - **Discovery budget**: spend at most 1 structural sweep (Glob/tree) + 3 targeted file reads. Do NOT read every file in scope.
-- **Write deadline**: you MUST call Write for `.signum/contract.json` by turn 10. If uncertain about details, write a blocked contract with `openQuestions` and `requiredInputsProvided: false` rather than continuing to scan.
+- **Write deadline**: you MUST call Write for canonical `contract.json` by turn 10. If uncertain about details, write a blocked contract with `openQuestions` and `requiredInputsProvided: false` rather than continuing to scan.
 - **Never finish without Write**: if you reach your last turn without having written contract.json, immediately write the best contract you have, even if incomplete. An incomplete contract is recoverable; a missing contract is a pipeline failure.
 - **Low-risk shortcut**: for low-risk contracts (< 5 files, 1 language), skip step 3.6 (self-critique) entirely and write immediately after validation.
 

--- a/agents/engineer.md
+++ b/agents/engineer.md
@@ -17,7 +17,9 @@ You operate in one of two modes:
 
 ## Policy
 
-Before implementation, read `.signum/contract-policy.json` if it exists. It defines execution constraints:
+The active contract artifact root is `.signum/contracts/<contractId>/`. Root `.signum/` paths may exist as compatibility views during migration, but the canonical engineer inputs and outputs live under the contract directory.
+
+Before implementation, read `.signum/contracts/<contractId>/contract-policy.json` if it exists. It defines execution constraints:
 
 - **allowed_tools**: only use tools in this list (Read, Write, Edit, Glob, Grep, Bash)
 - **denied_tools**: never use these (WebSearch, WebFetch, Agent, Task)
@@ -25,21 +27,21 @@ Before implementation, read `.signum/contract-policy.json` if it exists. It defi
 - **max_files_changed**: never modify more files than this limit
 - **network_access: false**: no web requests, no external downloads
 
-If `.signum/contract-policy.json` is absent, apply conservative defaults: no web access, no destructive bash.
+If `.signum/contracts/<contractId>/contract-policy.json` is absent, apply conservative defaults: no web access, no destructive bash.
 
 ## Input
 
 You receive:
-- `.signum/contract-engineer.json` -- the implementation contract (holdout scenarios removed by orchestrator for blind validation)
-- `.signum/contract-policy.json` -- execution policy (what you may and may not do)
-- `.signum/baseline.json` -- pre-change check results (written by orchestrator)
+- `.signum/contracts/<contractId>/contract-engineer.json` -- the implementation contract (holdout scenarios removed by orchestrator for blind validation)
+- `.signum/contracts/<contractId>/contract-policy.json` -- execution policy (what you may and may not do)
+- `.signum/contracts/<contractId>/baseline.json` -- pre-change check results (written by orchestrator)
 - Project codebase at the project root
 
 ## Process
 
 ### Step 1: Understand the contract
 
-Read `.signum/contract-engineer.json`. Extract:
+Read `.signum/contracts/<contractId>/contract-engineer.json`. Extract:
 - `goal` -- what to build
 - `inScope` -- which files/directories to touch
 - `acceptanceCriteria` -- what success looks like (with verify commands)
@@ -48,7 +50,7 @@ Read `.signum/contract-engineer.json`. Extract:
 
 ### Step 2: Read baseline
 
-Read `.signum/baseline.json` (written by orchestrator). Note any pre-existing failures -- you are NOT responsible for fixing them, but you MUST NOT introduce new ones.
+Read `.signum/contracts/<contractId>/baseline.json` (written by orchestrator). Note any pre-existing failures -- you are NOT responsible for fixing them, but you MUST NOT introduce new ones.
 
 ### Step 2.5: Execute removals (v3.8)
 
@@ -136,11 +138,11 @@ Before marking ANY attempt as PASSED or declaring SUCCESS, apply this mandatory 
 ### Step 5: Save artifacts
 
 On success:
-- Generate `.signum/combined.patch` via `git diff`
-- Write `.signum/execute_log.json` with attempt details
+- Generate `.signum/contracts/<contractId>/combined.patch` via `git diff`
+- Write `.signum/contracts/<contractId>/execute_log.json` with attempt details
 
 On failure:
-- Write `.signum/execute_log.json` with all attempt errors
+- Write `.signum/contracts/<contractId>/execute_log.json` with all attempt errors
 - Do NOT generate combined.patch (pipeline will stop)
 
 ## Output Format for execute_log.json
@@ -198,9 +200,9 @@ When `.signum/repair_brief.json` exists, you are in **repair mode** — fixing s
 ### Repair input
 
 Read these files:
-- `.signum/contract-engineer.json` — original contract (for scope and AC context)
-- `.signum/baseline.json` — pre-change check state (do not introduce new regressions)
-- `.signum/repair_brief.json` — specific issues to fix
+- `.signum/contracts/<contractId>/contract-engineer.json` — original contract (for scope and AC context)
+- `.signum/contracts/<contractId>/baseline.json` — pre-change check state (do not introduce new regressions)
+- `.signum/contracts/<contractId>/repair_brief.json` — specific issues to fix
 
 ### Repair process
 
@@ -208,7 +210,7 @@ Read these files:
 2. If `mechanicFindings` is present and non-empty, treat each entry as an additional repair target alongside `reviewFindings`. Each mechanic finding identifies the exact file, line, and error code to fix.
 3. Fix ONLY the listed issues. Do not refactor, do not add features, do not touch unrelated code.
 4. After fixing, re-run the visible AC verify commands to confirm existing behavior is preserved.
-5. Generate `.signum/combined.patch` via `git diff` and write `.signum/execute_log.json`.
+5. Generate `.signum/contracts/<contractId>/combined.patch` via `git diff` and write `.signum/contracts/<contractId>/execute_log.json`.
 
 ### Repair constraints
 

--- a/agents/reviewer-claude.md
+++ b/agents/reviewer-claude.md
@@ -13,28 +13,30 @@ You are the Claude reviewer in Signum v4.18's multi-model audit panel.
 
 ## Input
 
+The active contract artifact root is `.signum/contracts/<contractId>/`. Root `.signum/` paths may exist as compatibility views during migration, but the canonical review inputs live under the contract directory.
+
 Read these files:
-- `.signum/contract.json` -- the contract specification
-- `.signum/combined.patch` -- the generated diff
-- `.signum/mechanic_report.json` -- deterministic check results
-- `.signum/iteration_delta.patch` -- iteration delta (what changed in this fix, only present in iterative passes 2+)
+- `.signum/contracts/<contractId>/contract.json` -- the contract specification
+- `.signum/contracts/<contractId>/combined.patch` -- the generated diff
+- `.signum/contracts/<contractId>/mechanic_report.json` -- deterministic check results
+- `.signum/contracts/<contractId>/iteration_delta.patch` -- iteration delta (what changed in this fix, only present in iterative passes 2+)
 
 ## Task
 
 Review the diff against the contract for bugs, security issues, logic errors, and contract compliance.
 
 Read these inputs directly (do NOT look for a review template file):
-- `{contract_json}` = contents of `.signum/contract.json`
-- `{diff}` = contents of `.signum/combined.patch`
-- `{mechanic_report}` = contents of `.signum/mechanic_report.json`
-- `{iteration_delta}` = contents of `.signum/iteration_delta.patch` if it exists, otherwise empty string
+- `{contract_json}` = contents of `.signum/contracts/<contractId>/contract.json`
+- `{diff}` = contents of `.signum/contracts/<contractId>/combined.patch`
+- `{mechanic_report}` = contents of `.signum/contracts/<contractId>/mechanic_report.json`
+- `{iteration_delta}` = contents of `.signum/contracts/<contractId>/iteration_delta.patch` if it exists, otherwise empty string
 - `{review_context}` = review context JSON passed inline by the orchestrator (git history, issue refs)
 
 When `iteration_delta.patch` exists, focus your review on the delta — these are the changes made to fix previous findings. Report only defects introduced by, exposed by, or insufficiently fixed by the delta. Cite delta lines as primary evidence. Use the full patch for context only.
 
 ## Output
 
-Write your review result to `.signum/reviews/claude.json` as a JSON object with this structure:
+Write your review result to `.signum/contracts/<contractId>/reviews/claude.json` as a JSON object with this structure:
 ```json
 {
   "verdict": "APPROVE | APPROVE_WITH_CONCERNS | CONDITIONAL | REJECT",

--- a/agents/synthesizer.md
+++ b/agents/synthesizer.md
@@ -14,17 +14,19 @@ You are the Synthesizer agent for Signum v4.18. You combine three independent co
 
 ## Input
 
+The active contract artifact root is `.signum/contracts/<contractId>/`. Root `.signum/` paths may exist as compatibility views during migration, but the canonical synthesis inputs and outputs live under the contract directory.
+
 Read these files:
-- `.signum/contract.json` -- contract (needed for `riskLevel` to apply risk-proportional rules)
-- `.signum/mechanic_report.json` -- deterministic check results (with baseline comparison)
-- `.signum/policy_scan.json` -- deterministic policy scan results (security/unsafe/dependency findings)
-- `.signum/reviews/claude.json` -- Claude opus review
-- `.signum/reviews/codex.json` -- Codex review (may be missing or have parseOk: false)
-- `.signum/reviews/gemini.json` -- Gemini review (may be missing or have parseOk: false)
-- `.signum/holdout_report.json` -- holdout scenario results (if exists)
-- `.signum/execute_log.json` -- execution attempt history
-- `.signum/audit_iteration_log.json` -- previous iteration results (if exists, for iterative AUDIT)
-- `.signum/receipts/execute.json` -- execute boundary receipt (required for AC evidence gating)
+- `.signum/contracts/<contractId>/contract.json` -- contract (needed for `riskLevel` to apply risk-proportional rules)
+- `.signum/contracts/<contractId>/mechanic_report.json` -- deterministic check results (with baseline comparison)
+- `.signum/contracts/<contractId>/policy_scan.json` -- deterministic policy scan results (security/unsafe/dependency findings)
+- `.signum/contracts/<contractId>/reviews/claude.json` -- Claude opus review
+- `.signum/contracts/<contractId>/reviews/codex.json` -- Codex review (may be missing or have parseOk: false)
+- `.signum/contracts/<contractId>/reviews/gemini.json` -- Gemini review (may be missing or have parseOk: false)
+- `.signum/contracts/<contractId>/holdout_report.json` -- holdout scenario results (if exists)
+- `.signum/contracts/<contractId>/execute_log.json` -- execution attempt history
+- `.signum/contracts/<contractId>/audit_iteration_log.json` -- previous iteration results (if exists, for iterative AUDIT)
+- `.signum/contracts/<contractId>/receipts/execute.json` -- execute boundary receipt (required for AC evidence gating)
 
 ## Synthesis Rules (DETERMINISTIC -- follow exactly)
 
@@ -37,9 +39,9 @@ Read these files:
    - Policy scan (`policy_scan.json`) has `summaryCounts.critical` > 0 (CRITICAL policy finding present)
    - Any blocking `cleanupObligation` verify failed (v3.8)
    - Any `removal` with `preventReintroduction: true` has its path still existing (v3.8)
-   - Execute receipt (`.signum/receipts/execute.json`) is missing
+   - Execute receipt (`.signum/contracts/<contractId>/receipts/execute.json`) is missing
    - Execute receipt `status` is not `PASS`
-   - Any visible AC from `.signum/contract-engineer.json` has no matching entry in execute receipt `.ac_evidence`
+   - Any visible AC from `.signum/contracts/<contractId>/contract-engineer.json` has no matching entry in execute receipt `.ac_evidence`
    - Any visible AC has `verify_exit_code != 0` in the receipt
    - Any visible AC has `verify_format != "dsl"` in the receipt (legacy string verify — not trustworthy)
    - Any visible AC is marked `vacuous: true` in the receipt on medium/high risk contracts
@@ -89,10 +91,10 @@ list each failed/errored holdout ID, description, and error message from the `re
 After determining the decision, compute confidence metrics:
 
 - `execution_health` = (ACs_passed / ACs_total) * 100 - (repair_attempts * 5)
-  Read from `.signum/execute_log.json`
+  Read from `.signum/contracts/<contractId>/execute_log.json`
 - `baseline_stability` = 100 if no regressions, else 100 * (checks_stable / checks_total)
-  Read from `.signum/mechanic_report.json`
-- `behavioral_evidence` = holdout pass rate (from `.signum/holdout_report.json`):
+  Read from `.signum/contracts/<contractId>/mechanic_report.json`
+- `behavioral_evidence` = holdout pass rate (from `.signum/contracts/<contractId>/holdout_report.json`):
   - If total holdouts > 0: (passed / total) * 100
   - If total holdouts == 0: 75 (neutral — no evidence, no penalty)
 - `review_alignment`:
@@ -154,7 +156,7 @@ When the contract has `removals` or `cleanupObligations` arrays, add these secti
 
 If any blocking obligation is unfulfilled, set decision to AUTO_BLOCK with reasoning.
 
-Write `.signum/audit_summary.json`:
+Write `.signum/contracts/<contractId>/audit_summary.json`:
 
 ```json
 {
@@ -187,7 +189,7 @@ Write `.signum/audit_summary.json`:
 
 ## Execute Receipt Coverage Gate
 
-For every visible acceptance criterion in `.signum/contract-engineer.json`, verify that `.signum/receipts/execute.json` `.ac_evidence` contains an entry with the same AC id.
+For every visible acceptance criterion in `.signum/contracts/<contractId>/contract-engineer.json`, verify that `.signum/contracts/<contractId>/receipts/execute.json` `.ac_evidence` contains an entry with the same AC id.
 
 - If any visible AC is missing evidence → AUTO_BLOCK
 - If any AC evidence has `verify_exit_code != 0` → AUTO_BLOCK

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -27,7 +27,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.19.1",
+  "version": "4.20.0",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -3545,7 +3545,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.19.1" \
+  --arg signumVersion "4.20.0" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -62,7 +62,9 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
     "medium": {"reviews": "Claude + externals", "holdouts": "≥2", "cost": "~$0.50", "duration": "3-5 min"},
     "high": {"reviews": "Full 3-model panel", "holdouts": "≥5", "cost": "~$1.00", "duration": "5-10 min"}
   },
-  "artifacts": [".signum/contract.json", ".signum/combined.patch", ".signum/proofpack.json", ".signum/audit_summary.json", ".signum/anti_entropy_report.json"]
+  "artifactRoot": ".signum/contracts/<contractId>/",
+  "compatibilityRoot": ".signum/",
+  "artifacts": ["contract.json", "combined.patch", "proofpack.json", "audit_summary.json", "anti_entropy_report.json"]
 }
 ```
 
@@ -72,7 +74,7 @@ Do not proceed to Setup or any phase.
 
 If the user's task starts with `archive` (case-insensitive), do NOT run the pipeline. Instead, archive a completed contract.
 
-If a contract ID is provided (e.g., `archive sig-20260314-a1b2`), extract it from the user input. Otherwise, the active contract will be used.
+If a contract ID is provided (e.g., `archive sig-20260314-1030-a1b2`), extract it from the user input. Otherwise, the active contract will be used.
 
 Before running the Bash tool, parse the contract ID from the user's arguments (everything after `archive `). Pass it as `CONTRACT_ID_FROM_ARGS` environment variable. Use the Bash tool:
 
@@ -86,6 +88,11 @@ if [ -z "$CONTRACT_ID" ]; then
   exit 1
 fi
 
+WAS_ACTIVE=false
+if [ "$(get_active_contract 2>/dev/null || true)" = "$CONTRACT_ID" ]; then
+  WAS_ACTIVE=true
+fi
+
 DIR=$(contract_dir "$CONTRACT_ID")
 if [ ! -d "$DIR" ]; then
   echo "ERROR: Contract directory not found: $DIR" >&2
@@ -97,19 +104,7 @@ ARCHIVE_DIR=".signum/archive/${CONTRACT_ID}/"
 mkdir -p "$ARCHIVE_DIR"
 
 # Copy durable artifacts from the per-contract snapshot/history
-cp "${DIR}contract.json" "$ARCHIVE_DIR" 2>/dev/null || true
-cp "${DIR}proofpack.json" "$ARCHIVE_DIR" 2>/dev/null || true
-cp "${DIR}approval.json" "$ARCHIVE_DIR" 2>/dev/null || true
-
-# Copy audit summary if present
-cp "${DIR}audit_summary.json" "$ARCHIVE_DIR" 2>/dev/null || true
-cp "${DIR}anti_entropy_report.json" "$ARCHIVE_DIR" 2>/dev/null || true
-cp "${DIR}execution_context.json" "$ARCHIVE_DIR" 2>/dev/null || true
-
-# Copy receipt-chain artifacts needed for replay/verification
-cp -R "${DIR}receipts" "$ARCHIVE_DIR" 2>/dev/null || true
-cp -R "${DIR}runs" "$ARCHIVE_DIR" 2>/dev/null || true
-cp -R "${DIR}snapshots" "$ARCHIVE_DIR" 2>/dev/null || true
+archive_contract_artifacts "$CONTRACT_ID" "$ARCHIVE_DIR"
 
 # Purge intermediate artifacts (reviews, baseline, holdout, execute_log, prompts)
 rm -rf "${DIR}reviews/" 2>/dev/null || true
@@ -120,8 +115,10 @@ rm -f "${DIR}baseline.json" "${DIR}execute_log.json" "${DIR}holdout_report.json"
       "${DIR}contract-engineer.json" "${DIR}contract-policy.json" \
       "${DIR}policy_violations.json" "${DIR}spec_quality.json" \
       "${DIR}spec_validation.json" "${DIR}clover_report.json" \
+      "${DIR}repo_contract_baseline.json" "${DIR}repo_contract_violations.json" \
       "${DIR}contract-hash.txt" "${DIR}execution_context.json" \
       "${DIR}review_prompt_codex.txt" "${DIR}review_prompt_gemini.txt" \
+      "${DIR}review_context.json" \
       "${DIR}intent_check.json" \
       "${DIR}audit_iteration_log.json" "${DIR}repair_brief.json" "${DIR}flaky_tests.json" \
       "${DIR}policy_scan.json" 2>/dev/null || true
@@ -137,8 +134,12 @@ jq --arg id "$CONTRACT_ID" --arg ts "$ARCHIVED_AT" \
   .signum/contracts/index.json > .signum/contracts/index.json.tmp \
   && mv .signum/contracts/index.json.tmp .signum/contracts/index.json
 
+if [ "$WAS_ACTIVE" = "true" ]; then
+  purge_root_working_set_views >/dev/null 2>&1 || true
+fi
+
 echo "Archived: $CONTRACT_ID → $ARCHIVE_DIR"
-echo "Kept: contract.json, proofpack.json, approval.json, audit_summary.json, anti_entropy_report.json, execution_context.json, receipts/, runs/, snapshots/"
+echo "Kept: contract.json, proofpack.json, approval.json, audit_summary.json, anti_entropy_report.json, execution_context.json, optional reconcile_report.json + retro.json, receipts/, runs/, snapshots/"
 echo "Purged: intermediates (reviews, baseline, patches, prompts)"
 ```
 
@@ -148,7 +149,7 @@ Do not proceed to Setup or any phase.
 
 If the user's task starts with `close` (case-insensitive), do NOT run the pipeline. Instead, mark a contract as closed (abandoned, no proofpack).
 
-If a contract ID is provided (e.g., `close sig-20260314-a1b2`), extract it from user input. Otherwise, the active contract will be used.
+If a contract ID is provided (e.g., `close sig-20260314-1030-a1b2`), extract it from user input. Otherwise, the active contract will be used.
 
 Before running the Bash tool, parse the contract ID from the user's arguments (everything after `close `). Pass it as `CONTRACT_ID_FROM_ARGS` environment variable. Use the Bash tool:
 
@@ -162,6 +163,12 @@ if [ -z "$CONTRACT_ID" ]; then
   exit 1
 fi
 
+# Record whether this contract was the active one before closing.
+WAS_ACTIVE=false
+if [ "$(get_active_contract 2>/dev/null || true)" = "$CONTRACT_ID" ]; then
+  WAS_ACTIVE=true
+fi
+
 # Update status
 update_contract_status "$CONTRACT_ID" "closed"
 
@@ -173,11 +180,9 @@ jq --arg id "$CONTRACT_ID" --arg ts "$CLOSED_AT" \
   .signum/contracts/index.json > .signum/contracts/index.json.tmp \
   && mv .signum/contracts/index.json.tmp .signum/contracts/index.json
 
-# Clear active contract if this was the active one
-ACTIVE=$(get_active_contract)
-if [ "$ACTIVE" = "$CONTRACT_ID" ]; then
-  jq '.activeContractId = null' .signum/contracts/index.json > .signum/contracts/index.json.tmp \
-    && mv .signum/contracts/index.json.tmp .signum/contracts/index.json
+# update_contract_status() already clears activeContractId for terminal statuses.
+if [ "$WAS_ACTIVE" = "true" ]; then
+  purge_root_working_set_views >/dev/null 2>&1 || true
   echo "Cleared active contract (was $CONTRACT_ID)"
 fi
 
@@ -350,25 +355,85 @@ If either is empty, do NOT pass `--model` — let the CLI use its built-in defau
 
 Use the `PROJECT_ROOT` determined during Project Resolution. Verify we are in the correct directory:
 
-Check for a resumable working set (not just file existence — an archived/finalized run should not trigger resume):
+Check for a resumable working set using `contracts/index.json` first. Root `.signum/contract.json` is only a legacy fallback during the migration:
 
 ```bash
-if [ -f .signum/contract.json ] && [ -f .signum/execution_context.json ]; then
-  echo "RESUMABLE"
-elif [ -f .signum/contract.json ]; then
-  echo "CONTRACT_ONLY"
-else
-  echo "NONE"
+source lib/contract-dir.sh
+
+RESUME_INFO=$(describe_active_contract_state)
+RESUME_STATE=$(printf '%s' "$RESUME_INFO" | jq -r '.state')
+RESUME_CONTRACT_ID=$(printf '%s' "$RESUME_INFO" | jq -r '.contractId // empty')
+RESUME_STATUS=$(printf '%s' "$RESUME_INFO" | jq -r '.status // empty')
+
+if [ "$RESUME_STATE" = "NONE" ] && [ -f .signum/contract.json ] && [ ! -L .signum/contract.json ]; then
+  if [ -f .signum/execution_context.json ] && [ ! -L .signum/execution_context.json ]; then
+    RESUME_STATE="LEGACY_RESUMABLE"
+  else
+    RESUME_STATE="LEGACY_CONTRACT_ONLY"
+  fi
 fi
+
+jq -n \
+  --arg state "$RESUME_STATE" \
+  --arg contractId "$RESUME_CONTRACT_ID" \
+  --arg status "$RESUME_STATUS" \
+  '{
+    state: $state,
+    contractId: (if $contractId == "" then null else $contractId end),
+    status: (if $status == "" then null else $status end)
+  }'
 ```
 
-- If `RESUMABLE`: a previous run is in progress. Ask the user: "A previous run exists in .signum/ (contract + execution context). Resume from Phase 2, or restart from Phase 1 (discards existing contract)?"
-- If `CONTRACT_ONLY`: a contract exists but no execution started. Ask: "A contract exists but execution hasn't started. Resume from Phase 2 (execute this contract), or restart from Phase 1 (new contract)?"
-- If `NONE`: proceed to Phase 1.
+- If `.state == "RESUMABLE"`: an active contract exists in `contracts/index.json`. Ask the user: "Active contract `<contractId>` is in progress. Resume from Phase 2, or restart from Phase 1 (discards the active working set)?"
+- If `.state == "CONTRACT_ONLY"`: an active contract exists but execution has not started. Ask: "Active contract `<contractId>` exists but execution has not started. Resume from Phase 2, or restart from Phase 1 (new contract)?"
+- If `.state == "LEGACY_RESUMABLE"` or `.state == "LEGACY_CONTRACT_ONLY"`: a legacy root-based working set exists outside the contract registry. Ask: "A legacy `.signum/` working set was found. Resume by migrating it into `.signum/contracts/`, or restart from Phase 1?"
+- If `.state == "NONE"`: proceed to Phase 1.
+
+If the user chooses to resume a legacy root-based working set, migrate it into the canonical active contract directory before continuing:
+
+```bash
+source lib/contract-dir.sh
+
+LEGACY_CONTRACT_ID=$(jq -r '.contractId // empty' .signum/contract.json 2>/dev/null || true)
+if [ -z "$LEGACY_CONTRACT_ID" ] || [ "$LEGACY_CONTRACT_ID" = "null" ]; then
+  LEGACY_CONTRACT_ID="$(new_contract_id)"
+  jq --arg id "$LEGACY_CONTRACT_ID" '.contractId = $id' .signum/contract.json > .signum/contract.json.tmp \
+    && mv .signum/contract.json.tmp .signum/contract.json
+fi
+
+init_contract_dir "$LEGACY_CONTRACT_ID"
+register_contract "$LEGACY_CONTRACT_ID" "draft"
+set_active_contract "$LEGACY_CONTRACT_ID"
+
+for rel in \
+  contract.json \
+  spec_quality.json spec_validation.json clover_report.json intent_check.json approval.json \
+  contract-hash.txt contract-engineer.json contract-policy.json execution_context.json \
+  baseline.json combined.patch execute_log.json iteration_delta.patch mechanic_report.json \
+  holdout_report.json policy_violations.json policy_scan.json audit_iteration_log.json \
+  repair_brief.json flaky_tests.json audit_summary.json proofpack.json anti_entropy_report.json; do
+  if [ -e ".signum/$rel" ] || [ -L ".signum/$rel" ]; then
+    promote_root_artifact_to_active "$rel"
+  else
+    link_active_artifact "$rel"
+  fi
+done
+
+for rel in reviews iterations receipts runs snapshots; do
+  if [ -e ".signum/$rel" ] || [ -L ".signum/$rel" ]; then
+    promote_root_artifact_to_active "$rel"
+  else
+    ensure_active_artifact_dir "$rel"
+  fi
+done
+
+describe_active_contract_state
+```
 
 Wait for the user's answer before continuing. If restart, delete the existing artifacts:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
 rm -f .signum/contract.json .signum/execute_log.json .signum/combined.patch .signum/iteration_delta.patch \
        .signum/baseline.json .signum/mechanic_report.json \
        .signum/audit_summary.json .signum/proofpack.json \
@@ -378,18 +443,14 @@ rm -f .signum/contract.json .signum/execute_log.json .signum/combined.patch .sig
        .signum/spec_quality.json .signum/spec_validation.json \
        .signum/repo_contract_baseline.json .signum/repo_contract_violations.json \
        .signum/contract-hash.txt .signum/execution_context.json \
-       .signum/reviews/claude.json .signum/reviews/codex.json .signum/reviews/gemini.json \
        .signum/review_prompt_codex.txt .signum/review_prompt_gemini.txt \
-       .signum/reviews/codex_raw.txt .signum/reviews/gemini_raw.txt \
        .signum/clover_report.json .signum/approval.json \
        .signum/intent_check.json \
        .signum/audit_iteration_log.json .signum/repair_brief.json .signum/flaky_tests.json
-rm -rf .signum/iterations/ .signum/receipts/ .signum/runs/ .signum/snapshots/
-# Clear activeContractId if set
-if [ -f .signum/contracts/index.json ]; then
-  jq '.activeContractId = null' .signum/contracts/index.json > .signum/contracts/index.json.tmp \
-    && mv .signum/contracts/index.json.tmp .signum/contracts/index.json 2>/dev/null || true
-fi
+for rel in reviews iterations receipts runs snapshots; do
+  remove_root_artifact_view "$rel" >/dev/null 2>&1 || true
+done
+clear_active_contract >/dev/null 2>&1 || true
 ```
 
 ---
@@ -400,13 +461,50 @@ fi
 
 ### Step 1.1: Launch Contractor
 
-Use the Agent tool to launch the "contractor" agent with this prompt:
+Use the Bash tool once to pre-allocate the canonical active contract root for this run. If `SIGNUM_CONTRACT_PATH` is set, treat that file as the authoritative pre-approved contract and import it into the canonical root instead of launching the contractor:
+
+```bash
+source lib/contract-dir.sh
+
+FILE_CONTRACT_ID=""
+if [ -n "${SIGNUM_CONTRACT_PATH:-}" ] && [ -f "$SIGNUM_CONTRACT_PATH" ]; then
+  FILE_CONTRACT_ID="$(jq -r '.contractId // empty' "$SIGNUM_CONTRACT_PATH" 2>/dev/null || true)"
+fi
+
+CONTRACT_ID="${FILE_CONTRACT_ID:-$(new_contract_id)}"
+init_contract_dir "$CONTRACT_ID"
+register_contract "$CONTRACT_ID" "draft"
+set_active_contract "$CONTRACT_ID"
+
+ARTIFACT_ROOT="$(active_artifact_root)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+link_active_artifact "contract.json"
+
+if [ -n "${SIGNUM_CONTRACT_PATH:-}" ]; then
+  test -f "$SIGNUM_CONTRACT_PATH" || { echo "ERROR: SIGNUM_CONTRACT_PATH not found: $SIGNUM_CONTRACT_PATH"; exit 1; }
+  cp "$SIGNUM_CONTRACT_PATH" "$CONTRACT_PATH"
+  echo "CONTRACT_SOURCE=file"
+else
+  echo "CONTRACT_SOURCE=interactive"
+fi
+
+echo "CONTRACT_ID=$CONTRACT_ID"
+echo "ARTIFACT_ROOT=$ARTIFACT_ROOT"
+echo "CONTRACT_PATH=$CONTRACT_PATH"
+```
+
+If `SIGNUM_CONTRACT_PATH` is set, skip contractor launch and continue to Step 1.2 using the imported canonical contract above.
+
+Otherwise use the Agent tool to launch the "contractor" agent with this prompt:
 
 ```
 FEATURE_REQUEST: <the user's task from $ARGUMENTS>
 PROJECT_ROOT: <output of pwd>
+CONTRACT_ID: <value emitted above>
+CANONICAL_ARTIFACT_ROOT: <value emitted above>
 
-Scan the codebase, assess risk, and write .signum/contract.json.
+Scan the codebase, assess risk, and write `contract.json` to the canonical artifact root above.
+The `.signum/contract.json` compatibility path points there, but the canonical file is the one under the contract directory.
 ```
 
 ### Step 1.2: Validate contract
@@ -414,10 +512,15 @@ Scan the codebase, assess risk, and write .signum/contract.json.
 Use the Bash tool to verify the contract was written and has required fields:
 
 ```bash
-test -f .signum/contract.json || { echo "ERROR: contract.json not found"; exit 1; }
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+test -f "$CONTRACT_PATH" || { echo "ERROR: contract.json not found"; exit 1; }
 jq -e '.schemaVersion and .goal and .inScope and .acceptanceCriteria and .riskLevel' \
-  .signum/contract.json > /dev/null && echo "VALID" || echo "INVALID"
+  "$CONTRACT_PATH" > /dev/null && echo "VALID" || echo "INVALID"
 ```
+
+If `SIGNUM_CONTRACT_PATH` is set and the imported contract is missing or INVALID, stop immediately and report: "Pre-approved contract file is missing or invalid. Fix the file passed through SIGNUM_CONTRACT_PATH."
 
 If the file is missing or INVALID:
 1. **Auto-retry with sonnet** — haiku sometimes fails to produce valid contract.json on complex tasks. Re-launch the contractor agent with `model: sonnet` and the same prompt. This is a one-time automatic retry, not a loop.
@@ -430,39 +533,74 @@ Scan contract.json for invisible Unicode that could carry prompt injection from 
 Use the Bash tool:
 
 ```bash
-bash lib/contract-injection-scan.sh .signum/contract.json
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+bash lib/contract-injection-scan.sh "$CONTRACT_PATH"
 ```
 
 If exit code is 1: **HARD STOP**. Contract contains invisible Unicode characters (possible injection attack). Display the BLOCKED output to the user. Do not proceed.
 
 If exit code is 0: clean, continue.
 
-### Step 1.2.5: Initialize per-contract durable directory
+### Step 1.2.5: Finalize canonical contract bootstrap
 
-After contractor creates `contract.json`, extract the `contractId` and set up a per-contract durable directory. This directory is **not** the live workspace for the current run. The live working set remains under `.signum/`; the per-contract directory is a mirrored snapshot/history surface for this contract.
+After contractor creates `contract.json` in the active contract root, persist the preallocated `contractId` into the file, refresh index metadata, and expose the remaining Phase 1 compatibility views. Contract-owned artifacts, selected downstream file artifacts, and active run directories stay canonical under that active contract root.
 
 Use the Bash tool:
 
 ```bash
-# Source the contract-dir module
 source lib/contract-dir.sh
 
-# Extract contractId from contract.json
-CONTRACT_ID=$(jq -r '.contractId' .signum/contract.json)
-if [ -z "$CONTRACT_ID" ] || [ "$CONTRACT_ID" = "null" ]; then
-  echo "ERROR: contractId not found in contract.json"
-  exit 1
-fi
+CONTRACT_ID="$(get_active_contract)"
+ARTIFACT_ROOT="$(active_artifact_root)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+
+[ -n "$CONTRACT_ID" ] || { echo "ERROR: active contractId missing"; exit 1; }
+test -f "$CONTRACT_PATH" || { echo "ERROR: canonical contract.json not found"; exit 1; }
+
+jq --arg id "$CONTRACT_ID" '.contractId = $id' "$CONTRACT_PATH" > "${CONTRACT_PATH}.tmp" \
+  && mv "${CONTRACT_PATH}.tmp" "$CONTRACT_PATH"
 echo "contractId: $CONTRACT_ID"
 
-# Create per-contract durable directory
-init_contract_dir "$CONTRACT_ID"
-
-# Mirror the initial contract snapshot
-sync_contract_artifacts "$CONTRACT_ID" "contract.json"
-
-# Register contract in index.json
 register_contract "$CONTRACT_ID" "draft"
+
+# Expose Phase 1 artifact ownership through compatibility views.
+link_active_artifact "contract.json"
+link_active_artifact "spec_quality.json"
+link_active_artifact "spec_validation.json"
+link_active_artifact "clover_report.json"
+link_active_artifact "intent_check.json"
+link_active_artifact "approval.json"
+link_active_artifact "contract-hash.txt"
+link_active_artifact "contract-engineer.json"
+link_active_artifact "contract-policy.json"
+link_active_artifact "execution_context.json"
+link_active_artifact "baseline.json"
+link_active_artifact "combined.patch"
+link_active_artifact "execute_log.json"
+link_active_artifact "iteration_delta.patch"
+link_active_artifact "mechanic_report.json"
+link_active_artifact "holdout_report.json"
+link_active_artifact "policy_violations.json"
+link_active_artifact "policy_scan.json"
+link_active_artifact "repo_contract_baseline.json"
+link_active_artifact "repo_contract_violations.json"
+link_active_artifact "audit_iteration_log.json"
+link_active_artifact "repair_brief.json"
+link_active_artifact "flaky_tests.json"
+link_active_artifact "audit_summary.json"
+link_active_artifact "proofpack.json"
+link_active_artifact "anti_entropy_report.json"
+link_active_artifact "review_context.json"
+link_active_artifact "review_prompt_codex.txt"
+link_active_artifact "review_prompt_gemini.txt"
+ensure_active_artifact_dir "reviews"
+ensure_active_artifact_dir "iterations"
+ensure_active_artifact_dir "receipts"
+ensure_active_artifact_dir "runs"
+ensure_active_artifact_dir "snapshots"
+echo "ARTIFACT_ROOT=$ARTIFACT_ROOT"
 ```
 
 ### Step 1.3: Check for open questions
@@ -470,16 +608,20 @@ register_contract "$CONTRACT_ID" "draft"
 Use the Bash tool:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+
 # Check 1: requiredInputsProvided (contractor cannot resolve ambiguity from codebase alone)
-REQ_OK=$(jq -r '.requiredInputsProvided // true' .signum/contract.json)
+REQ_OK=$(jq -r '.requiredInputsProvided // true' "$CONTRACT_PATH")
 if [ "$REQ_OK" = "false" ]; then
   echo "HARD STOP: requiredInputsProvided=false"
-  jq -r '"Contractor needs additional input:\n  - " + ((.openQuestions // []) | join("\n  - "))' .signum/contract.json
+  jq -r '"Contractor needs additional input:\n  - " + ((.openQuestions // []) | join("\n  - "))' "$CONTRACT_PATH"
 fi
 
 # Check 2: open questions (ambiguities requiring user clarification)
 jq -r 'if (.openQuestions | length) > 0 then "BLOCKED: " + (.openQuestions | join("\n  - ")) else "OK" end' \
-  .signum/contract.json
+  "$CONTRACT_PATH"
 ```
 
 If output contains `HARD STOP:` or starts with `BLOCKED:`, display the questions to the user and **STOP**. Do not proceed to Phase 2 until the user provides answers.
@@ -491,15 +633,20 @@ Do not proceed to Phase 2 until the user provides answers to every open question
 Use the Bash tool to score the contract on 7 dimensions. A score below 69 (grade D) means the contract is too vague for reliable autonomous execution.
 
 ```bash
-GOAL=$(jq -r '.goal' .signum/contract.json)
-AC_COUNT=$(jq '.acceptanceCriteria | length' .signum/contract.json)
-AC_WITH_VERIFY=$(jq '[.acceptanceCriteria[] | select((.verify.type and .verify.value) or .verify.steps)] | length' .signum/contract.json)
-INSCOPE_COUNT=$(jq '.inScope | length' .signum/contract.json)
-HAS_OUTOFSCOPE=$(jq 'if (.outOfScope | length) > 0 then 1 else 0 end' .signum/contract.json)
-HAS_ASSUMPTIONS=$(jq 'if (.assumptions | length) > 0 then 1 else 0 end' .signum/contract.json)
-HAS_HOLDOUTS=$(jq 'if ((.holdoutScenarios // []) | length) > 0 then 1 else 0 end' .signum/contract.json)
-REQ_OK=$(jq -r '.requiredInputsProvided // true' .signum/contract.json)
-OPEN_Q=$(jq '(.openQuestions | length)' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+
+GOAL=$(jq -r '.goal' "$CONTRACT_PATH")
+AC_COUNT=$(jq '.acceptanceCriteria | length' "$CONTRACT_PATH")
+AC_WITH_VERIFY=$(jq '[.acceptanceCriteria[] | select((.verify.type and .verify.value) or .verify.steps)] | length' "$CONTRACT_PATH")
+INSCOPE_COUNT=$(jq '.inScope | length' "$CONTRACT_PATH")
+HAS_OUTOFSCOPE=$(jq 'if (.outOfScope | length) > 0 then 1 else 0 end' "$CONTRACT_PATH")
+HAS_ASSUMPTIONS=$(jq 'if (.assumptions | length) > 0 then 1 else 0 end' "$CONTRACT_PATH")
+HAS_HOLDOUTS=$(jq 'if ((.holdoutScenarios // []) | length) > 0 then 1 else 0 end' "$CONTRACT_PATH")
+REQ_OK=$(jq -r '.requiredInputsProvided // true' "$CONTRACT_PATH")
+OPEN_Q=$(jq '(.openQuestions | length)' "$CONTRACT_PATH")
 
 # Testability (0-25): fraction of ACs with verify commands
 if [ "$AC_COUNT" -gt 0 ]; then
@@ -527,7 +674,7 @@ fi
 # Negative coverage (0-20): holdouts + negative-language ACs
 NEG_SCORE=0
 [ "$HAS_HOLDOUTS" -eq 1 ] && NEG_SCORE=$((NEG_SCORE + 10))
-NEG_ACS=$(jq '[.acceptanceCriteria[] | select(.description | test("must not|should not|\\bnever\\b|\\bprevent|reject|fail|invalid"; "i"))] | length' .signum/contract.json)
+NEG_ACS=$(jq '[.acceptanceCriteria[] | select(.description | test("must not|should not|\\bnever\\b|\\bprevent|reject|fail|invalid"; "i"))] | length' "$CONTRACT_PATH")
 [ "$NEG_ACS" -gt 0 ] && NEG_SCORE=$((NEG_SCORE + 10))
 
 # Clarity (0-20): goal length + absence of vague phrases
@@ -547,7 +694,7 @@ BOUNDARY=0
 # Sub-check 1: Vague verb detection (0-5)
 # Synonym map for terminology consistency (endpoint/route, function/method, test/spec,
 #   error/exception, config/configuration/settings, user/client, file/document)
-ALL_AC_TEXT=$(jq -r '[.acceptanceCriteria[].description] | join(" ")' .signum/contract.json)
+ALL_AC_TEXT=$(jq -r '[.acceptanceCriteria[].description] | join(" ")' "$CONTRACT_PATH")
 VAGUE_VERBS_PATTERN="handle|process|manage|support|ensure|implement|perform|utilize|leverage|facilitate"
 VAGUE_VERBS_FOUND=$(printf '%s' "$ALL_AC_TEXT $GOAL" | grep -ciE "\b($VAGUE_VERBS_PATTERN)\b" 2>/dev/null | tail -1 || echo 0)
 if [ "$VAGUE_VERBS_FOUND" -eq 0 ]; then VAGUE_VERB_PTS=5; else VAGUE_VERB_PTS=0; fi
@@ -578,7 +725,7 @@ if [ "$SYNONYM_INCONSISTENT" -eq 0 ]; then TERM_PTS=5; else TERM_PTS=0; fi
 
 # Sub-check 3: AC contradiction detection (0-5)
 # Check pairs of AC descriptions for negation contradictions (must X vs must not X, allow Y vs prevent Y)
-AC_TEXTS=$(jq -r '.acceptanceCriteria[].description' .signum/contract.json 2>/dev/null || echo "")
+AC_TEXTS=$(jq -r '.acceptanceCriteria[].description' "$CONTRACT_PATH" 2>/dev/null || echo "")
 CONTRADICTION_FOUND=0
 while IFS= read -r ac_line; do
   pos=$(echo "$ac_line" | grep -oi "must [a-z]*\|allow [a-z]*\|enable [a-z]*" 2>/dev/null | grep -vi "must not" | head -5)
@@ -638,7 +785,7 @@ jq -n --argjson total "$TOTAL" --arg grade "$GRADE" \
                    clarity: $clarity, scope_boundedness: $scope,
                    completeness: $completeness, boundary_system: $boundary,
                    nl_consistency: $nl_consistency } }' \
-  > .signum/spec_quality.json
+  > "$SPEC_QUALITY_PATH"
 ```
 
 #### Prose quality check (informational, non-blocking)
@@ -647,17 +794,21 @@ Use the Bash tool to run the prose quality gate on the contract. This check is *
 
 ```bash
 PROSE_REPORT=""
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
 if [ -f lib/prose-check.sh ]; then
-  PROSE_REPORT=$(lib/prose-check.sh .signum/contract.json 2>/dev/null || echo '{}')
+  PROSE_REPORT=$(lib/prose-check.sh "$CONTRACT_PATH" 2>/dev/null || echo '{}')
   PROSE_TOTAL=$(echo "$PROSE_REPORT" | jq '.total_findings // 0')
   PROSE_PASS=$(echo "$PROSE_REPORT" | jq -r '.pass // "true"')
   echo "Prose quality: $PROSE_TOTAL finding(s), pass=$PROSE_PASS"
 
   # Merge prose_warnings into spec_quality.json (non-blocking)
-  if [ -f .signum/spec_quality.json ]; then
+  if [ -f "$SPEC_QUALITY_PATH" ]; then
     jq --argjson prose "$PROSE_REPORT" '. + {prose_warnings: $prose}' \
-      .signum/spec_quality.json > .signum/spec_quality_tmp.json \
-      && mv .signum/spec_quality_tmp.json .signum/spec_quality.json
+      "$SPEC_QUALITY_PATH" > "${SPEC_QUALITY_PATH}.tmp" \
+      && mv "${SPEC_QUALITY_PATH}.tmp" "$SPEC_QUALITY_PATH"
   fi
 fi
 ```
@@ -667,12 +818,16 @@ fi
 Run the glossary_check: scan goal, inScope items, and AC descriptions for forbidden synonyms from `project.glossary.json` aliases. This check is **non-blocking** — it never fails the pipeline or reduces the numeric spec quality score. Warnings are written only to `glossary_warnings` in `spec_quality.json`.
 
 ```bash
-GLOSSARY_RESULT=$(lib/glossary-check.sh .signum/contract.json \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+GLOSSARY_RESULT=$(lib/glossary-check.sh "$CONTRACT_PATH" \
   --glossary "${PROJECT_ROOT:-$PWD}/project.glossary.json" 2>/dev/null || echo '{}')
 jq --argjson r "$GLOSSARY_RESULT" \
   '. + {glossary_warnings: ($r.findings // []), glossary_version: ($r.glossary_version // ""), glossary_terms: ($r.glossary_terms // 0)}' \
-  .signum/spec_quality.json > .signum/spec_quality_tmp.json \
-  && mv .signum/spec_quality_tmp.json .signum/spec_quality.json
+  "$SPEC_QUALITY_PATH" > "${SPEC_QUALITY_PATH}.tmp" \
+  && mv "${SPEC_QUALITY_PATH}.tmp" "$SPEC_QUALITY_PATH"
 ```
 
 #### Terminology consistency check (terminology_consistency_check — informational, non-blocking)
@@ -680,13 +835,17 @@ jq --argjson r "$GLOSSARY_RESULT" \
 Run the terminology_consistency_check: read `.signum/contracts/index.json`, extract goal text from active contracts, and emit WARN on synonym proliferation (same concept appearing under two different terms across contracts). This check is **non-blocking**.
 
 ```bash
-TERMINOLOGY_RESULT=$(lib/terminology-check.sh .signum/contract.json \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+TERMINOLOGY_RESULT=$(lib/terminology-check.sh "$CONTRACT_PATH" \
   --index .signum/contracts/index.json \
   --glossary "${PROJECT_ROOT:-$PWD}/project.glossary.json" 2>/dev/null || echo '{}')
 jq --argjson r "$TERMINOLOGY_RESULT" \
   '. + {terminology_warnings: ($r.findings // [])}' \
-  .signum/spec_quality.json > .signum/spec_quality_tmp.json \
-  && mv .signum/spec_quality_tmp.json .signum/spec_quality.json
+  "$SPEC_QUALITY_PATH" > "${SPEC_QUALITY_PATH}.tmp" \
+  && mv "${SPEC_QUALITY_PATH}.tmp" "$SPEC_QUALITY_PATH"
 ```
 
 #### Cross-contract overlap check (cross_contract_overlap_check — informational, non-blocking)
@@ -694,12 +853,16 @@ jq --argjson r "$TERMINOLOGY_RESULT" \
 Run the cross_contract_overlap_check: read `.signum/contracts/index.json`, compare inScope arrays of active contracts against the new contract's inScope, and emit overlap warnings. This check is **non-blocking** — it never fails the pipeline or reduces the numeric spec quality score. Warnings are written only to `overlap_warnings` in `spec_quality.json`.
 
 ```bash
-OVERLAP_RESULT=$(lib/overlap-check.sh .signum/contract.json \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+OVERLAP_RESULT=$(lib/overlap-check.sh "$CONTRACT_PATH" \
   --index .signum/contracts/index.json 2>/dev/null || echo '{}')
 jq --argjson r "$OVERLAP_RESULT" \
   '. + {overlap_warnings: ($r.findings // [])}' \
-  .signum/spec_quality.json > .signum/spec_quality_tmp.json \
-  && mv .signum/spec_quality_tmp.json .signum/spec_quality.json
+  "$SPEC_QUALITY_PATH" > "${SPEC_QUALITY_PATH}.tmp" \
+  && mv "${SPEC_QUALITY_PATH}.tmp" "$SPEC_QUALITY_PATH"
 ```
 
 #### Assumption contradiction check (assumption_contradiction_check — informational, non-blocking)
@@ -707,12 +870,16 @@ jq --argjson r "$OVERLAP_RESULT" \
 Run the assumption_contradiction_check: read assumptions from each related contract in index.json (parentContractId, relatedContractIds), compare assumption text pairs for direct contradiction keywords, and emit contradiction warnings. This check is **non-blocking** — it does not block the pipeline.
 
 ```bash
-ASSUMPTION_RESULT=$(lib/assumption-check.sh .signum/contract.json \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+ASSUMPTION_RESULT=$(lib/assumption-check.sh "$CONTRACT_PATH" \
   --index .signum/contracts/index.json 2>/dev/null || echo '{}')
 jq --argjson r "$ASSUMPTION_RESULT" \
   '. + {assumption_warnings: ($r.findings // [])}' \
-  .signum/spec_quality.json > .signum/spec_quality_tmp.json \
-  && mv .signum/spec_quality_tmp.json .signum/spec_quality.json
+  "$SPEC_QUALITY_PATH" > "${SPEC_QUALITY_PATH}.tmp" \
+  && mv "${SPEC_QUALITY_PATH}.tmp" "$SPEC_QUALITY_PATH"
 ```
 
 #### ADR relevance check (adr_relevance_check — informational, non-blocking)
@@ -720,12 +887,16 @@ jq --argjson r "$ASSUMPTION_RESULT" \
 Run the adr_relevance_check: scan `docs/adr/` and `docs/decisions/` for `*.md` files, match their filenames against inScope paths using glob-style prefix matching, and emit a WARN when relevant ADRs exist but the contract's `adrRefs` field is absent or empty. This check is **non-blocking** and degrades gracefully to a no-op when neither directory exists.
 
 ```bash
-ADR_RESULT=$(lib/adr-check.sh .signum/contract.json \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+ADR_RESULT=$(lib/adr-check.sh "$CONTRACT_PATH" \
   --project-root "${PROJECT_ROOT:-$PWD}" 2>/dev/null || echo '{}')
 jq --argjson r "$ADR_RESULT" \
   '. + {adr_warnings: ($r.findings // [])}' \
-  .signum/spec_quality.json > .signum/spec_quality_tmp.json \
-  && mv .signum/spec_quality_tmp.json .signum/spec_quality.json
+  "$SPEC_QUALITY_PATH" > "${SPEC_QUALITY_PATH}.tmp" \
+  && mv "${SPEC_QUALITY_PATH}.tmp" "$SPEC_QUALITY_PATH"
 ```
 
 #### Upstream staleness check (upstream_staleness_check — blocking when stalenessPolicy is "block")
@@ -733,19 +904,22 @@ jq --argjson r "$ADR_RESULT" \
 Run the upstream_staleness_check: recompute SHA-256 over all files listed in `contextInheritance.staleIfChanged`, compare to `contextInheritance.contextSnapshotHash`, and emit BLOCK or WARN when the hash differs. This check is **skipped** when `staleIfChanged` is absent or empty.
 
 ```bash
-STALENESS_RESULT=$(lib/staleness-check.sh .signum/contract.json \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+STALENESS_RESULT=$(lib/staleness-check.sh "$CONTRACT_PATH" \
   --project-root "${PROJECT_ROOT:-$PWD}" 2>/dev/null || echo '{"check":"staleness","status":"error"}')
 STALENESS_STATUS=$(echo "$STALENESS_RESULT" | jq -r '.status // "error"')
 # Apply stalenessStatus mutation to contract.json based on check result
 if [ "$STALENESS_STATUS" = "fresh" ]; then
-  jq '.contextInheritance.stalenessStatus = "fresh"' .signum/contract.json > .signum/contract.json.tmp \
-    && mv .signum/contract.json.tmp .signum/contract.json
+  jq '.contextInheritance.stalenessStatus = "fresh"' "$CONTRACT_PATH" > "${CONTRACT_PATH}.tmp" \
+    && mv "${CONTRACT_PATH}.tmp" "$CONTRACT_PATH"
 elif [ "$STALENESS_STATUS" = "warn" ]; then
-  jq '.contextInheritance.stalenessStatus = "warning"' .signum/contract.json > .signum/contract.json.tmp \
-    && mv .signum/contract.json.tmp .signum/contract.json
+  jq '.contextInheritance.stalenessStatus = "warning"' "$CONTRACT_PATH" > "${CONTRACT_PATH}.tmp" \
+    && mv "${CONTRACT_PATH}.tmp" "$CONTRACT_PATH"
 elif [ "$STALENESS_STATUS" = "block" ]; then
-  jq '.contextInheritance.stalenessStatus = "stale"' .signum/contract.json > .signum/contract.json.tmp \
-    && mv .signum/contract.json.tmp .signum/contract.json
+  jq '.contextInheritance.stalenessStatus = "stale"' "$CONTRACT_PATH" > "${CONTRACT_PATH}.tmp" \
+    && mv "${CONTRACT_PATH}.tmp" "$CONTRACT_PATH"
   echo "BLOCK: upstream artifacts changed (stalenessPolicy=block). Re-run Contractor agent to refresh."
   exit 1
 fi
@@ -758,8 +932,11 @@ fi
 Check if contract has a project intent reference:
 
 ```bash
-PROJECT_REF=$(jq -r '.contextInheritance.projectRef // "absent"' .signum/contract.json)
-RISK=$(jq -r '.riskLevel' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+PROJECT_REF=$(jq -r '.contextInheritance.projectRef // "absent"' "$CONTRACT_PATH")
+RISK=$(jq -r '.riskLevel' "$CONTRACT_PATH")
 if [ "$RISK" = "low" ] || [ "$PROJECT_REF" = "absent" ] || [ "$PROJECT_REF" = "null" ] || [ "$PROJECT_REF" = "not_found" ]; then
   echo "Intent alignment check: skipped (risk=$RISK, projectRef=$PROJECT_REF)"
 else
@@ -796,7 +973,7 @@ Output JSON only:
 Parse the subagent response as JSON. If parsing fails, write safe default:
 `{"aligned": null, "concerns": [], "glossary_violations": [], "parse_error": true}`
 
-Write result to `.signum/intent_check.json`.
+Write result to `intent_check.json` under the canonical artifact root.
 
 ### Step 1.3.7: Multi-model spec validation (optional, if providers available)
 
@@ -815,9 +992,13 @@ If both are UNAVAILABLE, skip to Step 1.4.
 If at least one is available: read the contract to build validation context:
 
 ```bash
-SPEC_CONTEXT=$(python3 -c "
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_CONTEXT=$(python3 - "$CONTRACT_PATH" <<'PY'
 import json
-c = json.load(open('.signum/contract.json'))
+import sys
+c = json.load(open(sys.argv[1]))
 acs = '\n'.join(f'  - [{a[\"id\"]}] {a[\"description\"]}' for a in c.get('acceptanceCriteria', []))
 inscope = ', '.join(c.get('inScope', []))
 print(f'''Goal: {c[\"goal\"]}
@@ -828,7 +1009,8 @@ Acceptance criteria:
 Assumptions: {', '.join(c.get('assumptions', ['none']))}
 Out of scope: {', '.join(c.get('outOfScope', ['not specified']))}
 ''')
-")
+PY
+)
 echo "$SPEC_CONTEXT"
 ```
 
@@ -897,9 +1079,12 @@ Save the task ID as GEMINI_SPEC_TASK_ID.
 
 Use the TaskOutput tool with `block: true` to wait for CODEX_SPEC_TASK_ID (if launched). Then use the TaskOutput tool with `block: true` to wait for GEMINI_SPEC_TASK_ID (if launched).
 
-Write collected findings to `.signum/spec_validation.json`:
+Write collected findings to `spec_validation.json` under the canonical artifact root:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+SPEC_VALIDATION_PATH="${ARTIFACT_ROOT}spec_validation.json"
 jq -n \
   --arg codex_out "$CODEX_SPEC_OUT" \
   --arg gemini_out "$GEMINI_SPEC_OUT" \
@@ -908,8 +1093,8 @@ jq -n \
   '{
     codex: { available: ($codex_avail == "yes"), findings: $codex_out },
     gemini: { available: ($gemini_avail == "yes"), findings: $gemini_out }
-  }' > .signum/spec_validation.json
-echo "Spec validation written to .signum/spec_validation.json"
+  }' > "$SPEC_VALIDATION_PATH"
+echo "Spec validation written to $SPEC_VALIDATION_PATH"
 ```
 
 ### Step 1.3.8: Clover reconstruction test
@@ -923,7 +1108,7 @@ You are given ONLY the acceptance criteria below. You have NOT seen the original
 Reconstruct what the goal/task likely was based solely on these ACs.
 
 Acceptance criteria:
-<ACs from .signum/contract.json — list each AC id + description, but do NOT include the goal>
+<ACs from contract.json under the canonical artifact root - list each AC id + description, but do NOT include the goal>
 
 Write your reconstructed goal as a single paragraph (2-3 sentences max).
 Then write a JSON object:
@@ -938,7 +1123,11 @@ Output ONLY the JSON object, no other text.
 After the agent returns, use the Bash tool to compare:
 
 ```bash
-ORIGINAL_GOAL=$(jq -r '.goal' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+CLOVER_REPORT_PATH="${ARTIFACT_ROOT}clover_report.json"
+ORIGINAL_GOAL=$(jq -r '.goal' "$CONTRACT_PATH")
 RECONSTRUCTED=$(echo '<agent output>' | jq -r '.reconstructed_goal // empty')
 CONFIDENCE=$(echo '<agent output>' | jq -r '.confidence // 0')
 GAPS=$(echo '<agent output>' | jq -r '.coverage_gaps | length')
@@ -952,11 +1141,11 @@ jq -n \
   --argjson gaps "$(echo '<agent output>' | jq '.coverage_gaps')" \
   '{original_goal: $original, reconstructed_goal: $reconstructed,
     confidence: $confidence, coverage_gaps: $gaps, gap_count: $gap_count,
-    pass: ($confidence >= 0.7 and $gap_count <= 2)}' > .signum/clover_report.json
+    pass: ($confidence >= 0.7 and $gap_count <= 2)}' > "$CLOVER_REPORT_PATH"
 
-if [ "$(jq '.pass' .signum/clover_report.json)" = "false" ]; then
+if [ "$(jq '.pass' "$CLOVER_REPORT_PATH")" = "false" ]; then
   echo "CLOVER WARNING: ACs may not fully capture the goal (confidence=$CONFIDENCE, gaps=$GAPS)"
-  jq -r '.coverage_gaps[]' .signum/clover_report.json | sed 's/^/  - /'
+  jq -r '.coverage_gaps[]' "$CLOVER_REPORT_PATH" | sed 's/^/  - /'
   echo "Consider adding ACs to cover the gaps above."
 else
   echo "Clover test: PASS (confidence=$CONFIDENCE)"
@@ -970,29 +1159,36 @@ Clover failure is informational — it does not block the pipeline. Display warn
 **Data collection:** Use a single Bash call to extract all values into shell variables:
 
 ```bash
-CONTRACT_ID=$(jq -r '.contractId' .signum/contract.json)
-GOAL=$(jq -r '.goal' .signum/contract.json)
-RISK=$(jq -r '.riskLevel' .signum/contract.json)
-INSCOPE=$(jq -r '.inScope | join(", ")' .signum/contract.json)
-AC_COUNT=$(jq '.acceptanceCriteria | length' .signum/contract.json)
-HOLDOUT_COUNT=$(jq '((.holdoutScenarios // []) | length) + ([.acceptanceCriteria[] | select(.visibility == "holdout")] | length)' .signum/contract.json)
-VISIBLE_AC=$((AC_COUNT - $(jq '[.acceptanceCriteria[] | select(.visibility == "holdout")] | length' .signum/contract.json)))
-SPEC_TOTAL=$(jq -r '.total // "?"' .signum/spec_quality.json 2>/dev/null || echo "?")
-SPEC_GRADE=$(jq -r '.grade // "?"' .signum/spec_quality.json 2>/dev/null || echo "?")
-CLOVER=$(jq -r 'if .pass then "PASS (" + (.confidence | tostring) + ")" else "WARN (" + (.confidence | tostring) + ")" end' .signum/clover_report.json 2>/dev/null || echo "skipped")
-INTENT=$(jq -r 'if .aligned then "aligned" elif .aligned == false then "MISALIGNED" else "skipped" end' .signum/intent_check.json 2>/dev/null || echo "skipped")
-RISK_SIGNALS=$(jq -r 'if .riskLevel == "high" then (.riskSignals // [] | join(", ")) else "" end' .signum/contract.json)
-READINESS=$(jq -r '.readinessForPlanning.verdict // "absent"' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+CLOVER_REPORT_PATH="${ARTIFACT_ROOT}clover_report.json"
+INTENT_CHECK_PATH="${ARTIFACT_ROOT}intent_check.json"
+
+CONTRACT_ID=$(jq -r '.contractId' "$CONTRACT_PATH")
+GOAL=$(jq -r '.goal' "$CONTRACT_PATH")
+RISK=$(jq -r '.riskLevel' "$CONTRACT_PATH")
+INSCOPE=$(jq -r '.inScope | join(", ")' "$CONTRACT_PATH")
+AC_COUNT=$(jq '.acceptanceCriteria | length' "$CONTRACT_PATH")
+HOLDOUT_COUNT=$(jq '((.holdoutScenarios // []) | length) + ([.acceptanceCriteria[] | select(.visibility == "holdout")] | length)' "$CONTRACT_PATH")
+VISIBLE_AC=$((AC_COUNT - $(jq '[.acceptanceCriteria[] | select(.visibility == "holdout")] | length' "$CONTRACT_PATH")))
+SPEC_TOTAL=$(jq -r '.total // "?"' "$SPEC_QUALITY_PATH" 2>/dev/null || echo "?")
+SPEC_GRADE=$(jq -r '.grade // "?"' "$SPEC_QUALITY_PATH" 2>/dev/null || echo "?")
+CLOVER=$(jq -r 'if .pass then "PASS (" + (.confidence | tostring) + ")" else "WARN (" + (.confidence | tostring) + ")" end' "$CLOVER_REPORT_PATH" 2>/dev/null || echo "skipped")
+INTENT=$(jq -r 'if .aligned then "aligned" elif .aligned == false then "MISALIGNED" else "skipped" end' "$INTENT_CHECK_PATH" 2>/dev/null || echo "skipped")
+RISK_SIGNALS=$(jq -r 'if .riskLevel == "high" then (.riskSignals // [] | join(", ")) else "" end' "$CONTRACT_PATH")
+READINESS=$(jq -r '.readinessForPlanning.verdict // "absent"' "$CONTRACT_PATH")
 
 # Warnings (collect into array for display)
 WARNINGS=""
-if [ -f .signum/clover_report.json ] && [ "$(jq '.pass' .signum/clover_report.json)" = "false" ]; then
+if [ -f "$CLOVER_REPORT_PATH" ] && [ "$(jq '.pass' "$CLOVER_REPORT_PATH")" = "false" ]; then
   WARNINGS="${WARNINGS}\n- Clover: ACs may not fully capture the goal"
-  WARNINGS="${WARNINGS}\n$(jq -r '.coverage_gaps[] | "  - " + .' .signum/clover_report.json)"
+  WARNINGS="${WARNINGS}\n$(jq -r '.coverage_gaps[] | "  - " + .' "$CLOVER_REPORT_PATH")"
 fi
-if [ -f .signum/intent_check.json ] && [ "$(jq '.concerns | length' .signum/intent_check.json)" -gt 0 ]; then
+if [ -f "$INTENT_CHECK_PATH" ] && [ "$(jq '.concerns | length' "$INTENT_CHECK_PATH")" -gt 0 ]; then
   WARNINGS="${WARNINGS}\n- Intent alignment concerns:"
-  WARNINGS="${WARNINGS}\n$(jq -r '.concerns[] | "  - " + .' .signum/intent_check.json)"
+  WARNINGS="${WARNINGS}\n$(jq -r '.concerns[] | "  - " + .' "$INTENT_CHECK_PATH")"
 fi
 if [ "$READINESS" = "no-go" ]; then
   WARNINGS="${WARNINGS}\n- Contractor self-critique returned no-go"
@@ -1068,9 +1264,12 @@ Phase 2 will NOT be entered until all checklist items are approved.
 
 **STOP. Do not proceed to Phase 2.**
 
-If ALL items are answered "yes", write `.signum/approval.json`:
+If ALL items are answered "yes", write `approval.json` under the canonical artifact root:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+APPROVAL_PATH="${ARTIFACT_ROOT}approval.json"
 APPROVAL_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 jq -n --arg ts "$APPROVAL_TS" \
   '{
@@ -1083,18 +1282,21 @@ jq -n --arg ts "$APPROVAL_TS" \
       assumptions_valid: true,
       risk_appropriate: true
     }
-  }' > .signum/approval.json
+  }' > "$APPROVAL_PATH"
 echo "approval.json written at $APPROVAL_TS"
 ```
 
 After writing approval.json, transition the contract status from `draft` to `active` and record the `activatedAt` timestamp:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
 ACTIVATED_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 jq --arg ts "$ACTIVATED_TS" \
   '.status = "active" | .timestamps.activatedAt = $ts' \
-  .signum/contract.json > .signum/contract-tmp.json && \
-  mv .signum/contract-tmp.json .signum/contract.json
+  "$CONTRACT_PATH" > "${CONTRACT_PATH}.tmp" && \
+  mv "${CONTRACT_PATH}.tmp" "$CONTRACT_PATH"
 echo "Contract status: draft → active at $ACTIVATED_TS"
 ```
 
@@ -1105,20 +1307,25 @@ After the user confirms, anchor the approved contract with a SHA-256 hash and ti
 Use the Bash tool:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+CONTRACT_HASH_PATH="${ARTIFACT_ROOT}contract-hash.txt"
+
 if command -v sha256sum >/dev/null 2>&1; then
-  CONTRACT_HASH=$(sha256sum .signum/contract.json | awk '{print $1}')
+  CONTRACT_HASH=$(sha256sum "$CONTRACT_PATH" | awk '{print $1}')
 elif command -v shasum >/dev/null 2>&1; then
-  CONTRACT_HASH=$(shasum -a 256 .signum/contract.json | awk '{print $1}')
+  CONTRACT_HASH=$(shasum -a 256 "$CONTRACT_PATH" | awk '{print $1}')
 else
   CONTRACT_HASH="unavailable"
 fi
 
 APPROVAL_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-cat > .signum/contract-hash.txt <<EOF
+cat > "$CONTRACT_HASH_PATH" <<EOF
 contract_sha256: $CONTRACT_HASH
 approved_at: $APPROVAL_TS
-contract_file: .signum/contract.json
+contract_file: $CONTRACT_PATH
 EOF
 
 echo "Audit chain anchored: $CONTRACT_HASH at $APPROVAL_TS"
@@ -1129,32 +1336,40 @@ echo "Audit chain anchored: $CONTRACT_HASH at $APPROVAL_TS"
 Use the Bash tool to create a contract stripped of holdout scenarios and holdout ACs (data-level isolation):
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+CONTRACT_ENGINEER_PATH="${ARTIFACT_ROOT}contract-engineer.json"
+
 # Create engineer contract: remove holdouts + holdoutScenarios
 jq '{
   schemaVersion, contractId, status, timestamps, goal, inScope, allowNewFilesUnder, outOfScope,
   acceptanceCriteria: [.acceptanceCriteria[] | select(.visibility != "holdout")],
   assumptions, openQuestions, riskLevel, riskSignals, requiredInputsProvided,
   contextInheritance
-} | with_entries(select(.value != null))' .signum/contract.json > .signum/contract-engineer.json
+} | with_entries(select(.value != null))' "$CONTRACT_PATH" > "$CONTRACT_ENGINEER_PATH"
 
 # Generate holdout manifest for committed spec
-HOLDOUT_COUNT=$(jq '[.acceptanceCriteria[] | select(.visibility == "holdout")] | length' .signum/contract.json)
+HOLDOUT_COUNT=$(jq '[.acceptanceCriteria[] | select(.visibility == "holdout")] | length' "$CONTRACT_PATH")
 if [ "$HOLDOUT_COUNT" -gt 0 ]; then
-  HOLDOUT_HASH=$(jq -c '[.acceptanceCriteria[] | select(.visibility == "holdout")]' .signum/contract.json | shasum -a 256 | cut -c1-16)
+  HOLDOUT_HASH=$(jq -c '[.acceptanceCriteria[] | select(.visibility == "holdout")]' "$CONTRACT_PATH" | shasum -a 256 | cut -c1-16)
   jq --argjson count "$HOLDOUT_COUNT" --arg hash "sha256:$HOLDOUT_HASH" \
-    '. + {holdoutManifest: {count: $count, hash: $hash}}' .signum/contract-engineer.json > .signum/contract-engineer-tmp.json
-  mv .signum/contract-engineer-tmp.json .signum/contract-engineer.json
+    '. + {holdoutManifest: {count: $count, hash: $hash}}' "$CONTRACT_ENGINEER_PATH" > "${CONTRACT_ENGINEER_PATH}.tmp"
+  mv "${CONTRACT_ENGINEER_PATH}.tmp" "$CONTRACT_ENGINEER_PATH"
 fi
 
-AC_VISIBLE=$(jq '[.acceptanceCriteria[] | select(.visibility != "holdout")] | length' .signum/contract.json)
+AC_VISIBLE=$(jq '[.acceptanceCriteria[] | select(.visibility != "holdout")] | length' "$CONTRACT_PATH")
 echo "contract-engineer.json written ($AC_VISIBLE visible ACs, $HOLDOUT_COUNT holdouts redacted)"
 ```
 
 After writing `contract-engineer.json`, validate holdout count against risk level:
 
 ```bash
-RISK=$(jq -r '.riskLevel' .signum/contract.json)
-HOLDOUT_COUNT=$(jq '([.acceptanceCriteria[] | select(.visibility == "holdout")] | length) + ((.holdoutScenarios // []) | length)' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+RISK=$(jq -r '.riskLevel' "$CONTRACT_PATH")
+HOLDOUT_COUNT=$(jq '([.acceptanceCriteria[] | select(.visibility == "holdout")] | length) + ((.holdoutScenarios // []) | length)' "$CONTRACT_PATH")
 
 # Minimum holdout requirements by risk level
 MIN_HOLDOUTS=0
@@ -1190,9 +1405,16 @@ Derive `contract-policy.json` from the contract. This file defines what the Engi
 Use the Bash tool:
 
 ```bash
-python3 -c "
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+CONTRACT_POLICY_PATH="${ARTIFACT_ROOT}contract-policy.json"
+python3 - "$CONTRACT_PATH" "$CONTRACT_POLICY_PATH" <<'PY'
 import json
-with open('.signum/contract.json') as f:
+import sys
+contract_path = sys.argv[1]
+policy_path = sys.argv[2]
+with open(contract_path) as f:
     c = json.load(f)
 risk = c.get('riskLevel', 'low')
 in_scope = c.get('inScope', [])
@@ -1216,10 +1438,10 @@ policy = {
     'max_files_changed': max_files,
     'network_access': False,
 }
-with open('.signum/contract-policy.json', 'w') as f:
+with open(policy_path, 'w') as f:
     json.dump(policy, f, indent=2)
 print(f'contract-policy.json written (risk={risk}, allowed_paths={len(in_scope)}, max_files={max_files})')
-"
+PY
 ```
 
 ---
@@ -1233,16 +1455,22 @@ print(f'contract-policy.json written (risk={risk}, allowed_paths={len(in_scope)}
 Use the Bash tool to record the current commit SHA (audit chain: this is where the Engineer starts from) and run project checks BEFORE the engineer touches anything:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+BASELINE_PATH="${ARTIFACT_ROOT}baseline.json"
+
 # Record base commit for audit chain
 BASE_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "no-git")
 EXECUTE_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-echo "{\"base_commit\":\"$BASE_COMMIT\",\"started_at\":\"$EXECUTE_START\"}" > .signum/execution_context.json
+echo "{\"base_commit\":\"$BASE_COMMIT\",\"started_at\":\"$EXECUTE_START\"}" > "$EXECUTION_CONTEXT_PATH"
 echo "Execution context: base_commit=$BASE_COMMIT"
 
 # Set run_id for receipt chain
-RUN_ID=$(jq -r '.contractId // "signum-run"' .signum/contract.json)
-jq --arg rid "$RUN_ID" '. + {run_id:$rid}' .signum/execution_context.json > .signum/execution_context.json.tmp \
-  && mv .signum/execution_context.json.tmp .signum/execution_context.json
+RUN_ID=$(jq -r '.contractId // "signum-run"' "$CONTRACT_PATH")
+jq --arg rid "$RUN_ID" '. + {run_id:$rid}' "$EXECUTION_CONTEXT_PATH" > "${EXECUTION_CONTEXT_PATH}.tmp" \
+  && mv "${EXECUTION_CONTEXT_PATH}.tmp" "$EXECUTION_CONTEXT_PATH"
 
 # Lint
 if [ -f "pyproject.toml" ] && grep -q "ruff" pyproject.toml 2>/dev/null; then
@@ -1284,17 +1512,25 @@ jq -n \
   --argjson type "$BL_TYPE_EXIT" \
   --argjson test "$BL_TEST_EXIT" \
   --argjson failing "$BL_TEST_FAILING" \
-  '{ lint: $lint, typecheck: $type, tests: { exit_code: $test, failing: $failing } }' > .signum/baseline.json
+  '{ lint: $lint, typecheck: $type, tests: { exit_code: $test, failing: $failing } }' > "$BASELINE_PATH"
 
 echo "Baseline captured: lint=$BL_LINT_EXIT type=$BL_TYPE_EXIT test=$BL_TEST_EXIT"
 ```
 
-If `repo-contract.json` exists in the project root, also capture invariant baseline:
+If `repo-contract.json` exists in the project root, also capture invariant baseline to `repo_contract_baseline.json` under the canonical artifact root:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REPO_CONTRACT_BASELINE_PATH="${ARTIFACT_ROOT}repo_contract_baseline.json"
+
 if [ -f "repo-contract.json" ]; then
-  python3 -c "
-import json, subprocess
+  python3 - "$REPO_CONTRACT_BASELINE_PATH" <<'PY'
+import json
+import subprocess
+import sys
+
+output_path = sys.argv[1]
 with open('repo-contract.json') as f:
     rc = json.load(f)
 results = {}
@@ -1307,20 +1543,24 @@ for inv in rc.get('invariants', []):
         'exit_code': r.returncode,
         'passed': r.returncode == 0,
     }
-with open('.signum/repo_contract_baseline.json', 'w') as f:
+with open(output_path, 'w') as f:
     json.dump(results, f, indent=2)
 total = len(results)
 passed = sum(1 for v in results.values() if v['passed'])
 print(f'Repo-contract baseline: {passed}/{total} invariants passing')
-"
+PY
 fi
 ```
 
 ### Step 2.0.5: Capture pre-execute snapshot (receipt chain)
 
-Use the Bash tool to capture a deterministic workspace snapshot before the engineer runs. This snapshot anchors the receipt chain — `base_tree_hash` in the execute receipt will reference this snapshot.
+Use the Bash tool to capture a deterministic workspace snapshot before the engineer runs. This snapshot anchors the receipt chain, and it is written under the canonical artifact root so `base_tree_hash` in the execute receipt references the active contract's snapshot.
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+SNAPSHOT_PATH="${ARTIFACT_ROOT}snapshots/execute-attempt-01.json"
+
 # Resolve snapshot-tree.sh from known trusted Signum install roots only.
 _SIGNUM_SNAPSHOT=""
 for _d in \
@@ -1334,7 +1574,7 @@ done
 if [ -z "$_SIGNUM_SNAPSHOT" ]; then
   echo "WARNING: snapshot-tree.sh not found — receipt chain will be incomplete"
 else
-  bash "$_SIGNUM_SNAPSHOT" execute-attempt-01
+  bash "$_SIGNUM_SNAPSHOT" execute-attempt-01 --workspace-root "$PWD" --signum-dir "$ARTIFACT_ROOT"
   echo "Pre-execute snapshot captured"
 fi
 ```
@@ -1344,10 +1584,10 @@ fi
 Use the Agent tool to launch the "engineer" agent with this prompt:
 
 ```
-Read .signum/contract-engineer.json and implement the required changes.
-Read .signum/baseline.json for pre-existing check state.
+The canonical artifact root for this execute phase is `.signum/contracts/<activeContractId>/`.
+Read `contract-engineer.json` and `baseline.json` from that canonical artifact root.
 Implement, run the repair loop (max 3 attempts), save artifacts.
-Write .signum/combined.patch and .signum/execute_log.json.
+Write `combined.patch` and `execute_log.json` to that same canonical artifact root.
 ```
 
 ### Step 2.2: Check result
@@ -1355,15 +1595,18 @@ Write .signum/combined.patch and .signum/execute_log.json.
 Use the Bash tool:
 
 ```bash
-test -f .signum/execute_log.json || { echo "ERROR: execute_log.json not found"; exit 1; }
-STATUS=$(jq -r '.status' .signum/execute_log.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+test -f "$EXECUTE_LOG_PATH" || { echo "ERROR: execute_log.json not found"; exit 1; }
+STATUS=$(jq -r '.status' "$EXECUTE_LOG_PATH")
 if [ "$STATUS" != "SUCCESS" ]; then
   echo "ERROR: Execute status is '$STATUS' (expected SUCCESS)"
   jq -r '"Attempt failures:",
          (.attempts[] | "  Attempt " + (.number | tostring) + ": " +
            (.checks | to_entries[] | select(.value.passed == false) |
              "  " + .key + " failed: " + (.value.error // "no error message")))' \
-    .signum/execute_log.json 2>/dev/null || jq . .signum/execute_log.json
+    "$EXECUTE_LOG_PATH" 2>/dev/null || jq . "$EXECUTE_LOG_PATH"
   exit 1
 fi
 ```
@@ -1373,7 +1616,10 @@ If exit code is non-zero, report: "Engineer agent failed after all attempts. Fix
 Verify the patch exists:
 
 ```bash
-test -f .signum/combined.patch && wc -l .signum/combined.patch || echo "WARNING: combined.patch missing"
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+test -f "$COMBINED_PATCH_PATH" && wc -l "$COMBINED_PATCH_PATH" || echo "WARNING: combined.patch missing"
 ```
 
 ### Step 2.3: Display execution summary
@@ -1381,10 +1627,13 @@ test -f .signum/combined.patch && wc -l .signum/combined.patch || echo "WARNING:
 Use the Bash tool:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
 jq -r '"Attempts used: " + (.totalAttempts | tostring) + "/" + (.maxAttempts | tostring),
        "Acceptance criteria passed: " +
          ([.attempts[-1].checks | to_entries[] | select(.value.passed == true)] | length | tostring)' \
-  .signum/execute_log.json
+  "$EXECUTE_LOG_PATH"
 ```
 
 ### Step 2.4: Scope gate
@@ -1392,13 +1641,17 @@ jq -r '"Attempts used: " + (.totalAttempts | tostring) + "/" + (.maxAttempts | t
 Use the Bash tool to verify no out-of-scope files were modified:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+
 # Get changed files from patch
 CHANGED=$(git diff --name-only)
 # Strip parenthetical annotations from inScope paths (e.g., "src/main.rs (entry point)" -> "src/main.rs")
-IN_SCOPE=$(jq -r '.inScope[]' .signum/contract.json | sed 's/ (.*$//')
-ALLOW_NEW=$(jq -r '.allowNewFilesUnder // [] | .[]' .signum/contract.json | sed 's/ (.*$//')
+IN_SCOPE=$(jq -r '.inScope[]' "$CONTRACT_PATH" | sed 's/ (.*$//')
+ALLOW_NEW=$(jq -r '.allowNewFilesUnder // [] | .[]' "$CONTRACT_PATH" | sed 's/ (.*$//')
 # v3.8: removal targets are also allowed scope
-REMOVAL_PATHS=$(jq -r '(.removals // [])[] | .path' .signum/contract.json 2>/dev/null || true)
+REMOVAL_PATHS=$(jq -r '(.removals // [])[] | .path' "$CONTRACT_PATH" 2>/dev/null || true)
 
 VIOLATIONS=""
 while IFS= read -r file; do
@@ -1429,12 +1682,17 @@ If scope violation, **STOP**. Do not proceed to Phase 3.
 Use the Bash tool to verify the Engineer's changes comply with `contract-policy.json`:
 
 ```bash
-if [ ! -f ".signum/contract-policy.json" ]; then
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_POLICY_PATH="${ARTIFACT_ROOT}contract-policy.json"
+POLICY_VIOLATIONS_PATH="${ARTIFACT_ROOT}policy_violations.json"
+
+if [ ! -f "$CONTRACT_POLICY_PATH" ]; then
   echo "contract-policy.json not found, skipping policy check"
-  echo '{"violations":[]}' > .signum/policy_violations.json
+  echo '{"violations":[]}' > "$POLICY_VIOLATIONS_PATH"
 else
   FILE_COUNT=$(git diff --name-only | wc -l | tr -d '[:space:]')
-  MAX_FILES=$(jq '.max_files_changed' .signum/contract-policy.json)
+  MAX_FILES=$(jq '.max_files_changed' "$CONTRACT_POLICY_PATH")
 
   VIOLS='[]'
 
@@ -1450,9 +1708,9 @@ else
     if printf '%s' "$DIFF" | grep -qE "$pat" 2>/dev/null; then
       VIOLS=$(printf '%s' "$VIOLS" | jq --arg v "DENIED_PATTERN in diff: $pat" '. + [$v]')
     fi
-  done < <(jq -r '.bash_deny_patterns[]' .signum/contract-policy.json)
+  done < <(jq -r '.bash_deny_patterns[]' "$CONTRACT_POLICY_PATH")
 
-  printf '%s' "$VIOLS" | jq '{violations: .}' > .signum/policy_violations.json
+  printf '%s' "$VIOLS" | jq '{violations: .}' > "$POLICY_VIOLATIONS_PATH"
   VIOL_COUNT=$(printf '%s' "$VIOLS" | jq 'length')
 
   if [ "$VIOL_COUNT" -gt 0 ]; then
@@ -1472,6 +1730,10 @@ If output contains `AUTO_BLOCK`, **STOP**. Do not proceed to Phase 3.
 Use the Bash tool to verify all non-glob `inScope` paths exist after the engineer ran. This catches the failure class where files were promised but never created:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+
 MISSING_SCOPE=""
 while IFS= read -r scoped; do
   scoped=$(printf '%s' "$scoped" | sed 's/ (.*$//')
@@ -1482,7 +1744,7 @@ while IFS= read -r scoped; do
   if [ ! -e "$scoped" ]; then
     MISSING_SCOPE="$MISSING_SCOPE\n  $scoped"
   fi
-done < <(jq -r '.inScope[]' .signum/contract.json)
+done < <(jq -r '.inScope[]' "$CONTRACT_PATH")
 if [ -n "$MISSING_SCOPE" ]; then
   echo "SCOPE MISSING: expected inScope paths do not exist:$MISSING_SCOPE"
   exit 1
@@ -1498,6 +1760,12 @@ If scope existence fails, **STOP**. Do not proceed to Phase 3.
 Use the Bash tool to run deterministic boundary verification. This runs AFTER the engineer completes and verifies AC evidence, scope integrity, and artifact hashes. The boundary verifier generates the execute receipt — the engineer does NOT write its own receipt.
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_ENGINEER_PATH="${ARTIFACT_ROOT}contract-engineer.json"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+SNAPSHOT_PATH="${ARTIFACT_ROOT}snapshots/execute-attempt-01.json"
 _SIGNUM_BOUNDARY=""
 for _d in \
   "${_REAL_HOME:=$HOME}/.claude/plugins/signum/platforms/claude-code" \
@@ -1511,7 +1779,12 @@ if [ -z "$_SIGNUM_BOUNDARY" ]; then
   echo "WARNING: boundary-verifier.sh not found — skipping receipt chain verification"
 else
   bash "$_SIGNUM_BOUNDARY" execute \
-    --snapshot .signum/snapshots/execute-attempt-01.json
+    --workspace-root "$PWD" \
+    --signum-dir "$ARTIFACT_ROOT" \
+    --contract "$CONTRACT_ENGINEER_PATH" \
+    --contract-full "$CONTRACT_PATH" \
+    --execution-context "$EXECUTION_CONTEXT_PATH" \
+    --snapshot "$SNAPSHOT_PATH"
 fi
 ```
 
@@ -1522,6 +1795,11 @@ If boundary verifier exits non-zero, **STOP**. Do not proceed to Phase 3.
 Use the Bash tool to verify the execute → audit transition gate. This checks receipt integrity, contract hash chain, artifact hashes, and AC evidence completeness.
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_ENGINEER_PATH="${ARTIFACT_ROOT}contract-engineer.json"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SNAPSHOT_PATH="${ARTIFACT_ROOT}snapshots/execute-attempt-01.json"
 _SIGNUM_TRANSITION=""
 for _d in \
   "${_REAL_HOME:=$HOME}/.claude/plugins/signum/platforms/claude-code" \
@@ -1535,7 +1813,11 @@ if [ -z "$_SIGNUM_TRANSITION" ]; then
   echo "WARNING: transition-verifier.sh not found — skipping transition gate"
 else
   bash "$_SIGNUM_TRANSITION" execute audit \
-    --snapshot .signum/snapshots/execute-attempt-01.json
+    --workspace-root "$PWD" \
+    --signum-dir "$ARTIFACT_ROOT" \
+    --contract "$CONTRACT_ENGINEER_PATH" \
+    --contract-full "$CONTRACT_PATH" \
+    --snapshot "$SNAPSHOT_PATH"
 fi
 ```
 
@@ -1568,7 +1850,10 @@ Read the contract's `riskLevel` and apply the matching ceremony profile. Steps m
 Use the Bash tool to read the risk level and save it for conditional checks:
 
 ```bash
-RISK_LEVEL=$(jq -r '.riskLevel' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+RISK_LEVEL=$(jq -r '.riskLevel' "$CONTRACT_PATH")
 echo "RISK_LEVEL=$RISK_LEVEL"
 ```
 
@@ -1576,15 +1861,25 @@ Save `RISK_LEVEL` for use in all subsequent steps.
 
 ### Step 3.0.5: Repo-contract invariant check
 
-If `repo-contract.json` and `.signum/repo_contract_baseline.json` both exist, re-run invariants and detect regressions:
+If `repo-contract.json` and `repo_contract_baseline.json` under the canonical artifact root both exist, re-run invariants and detect regressions:
 
 ```bash
-if [ -f "repo-contract.json" ] && [ -f ".signum/repo_contract_baseline.json" ]; then
-  python3 -c "
-import json, subprocess
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REPO_CONTRACT_BASELINE_PATH="${ARTIFACT_ROOT}repo_contract_baseline.json"
+REPO_CONTRACT_VIOLATIONS_PATH="${ARTIFACT_ROOT}repo_contract_violations.json"
+
+if [ -f "repo-contract.json" ] && [ -f "$REPO_CONTRACT_BASELINE_PATH" ]; then
+  python3 - "$REPO_CONTRACT_BASELINE_PATH" "$REPO_CONTRACT_VIOLATIONS_PATH" <<'PY'
+import json
+import subprocess
+import sys
+
+baseline_path = sys.argv[1]
+violations_path = sys.argv[2]
 with open('repo-contract.json') as f:
     rc = json.load(f)
-with open('.signum/repo_contract_baseline.json') as f:
+with open(baseline_path) as f:
     baseline = json.load(f)
 regressions = []
 results = {}
@@ -1604,8 +1899,8 @@ for inv in rc.get('invariants', []):
         'regressed': regressed,
     }
     if regressed:
-        regressions.append(f'{iid} ({inv[\"severity\"]}): {inv[\"description\"]}')
-with open('.signum/repo_contract_violations.json', 'w') as f:
+        regressions.append(f'{iid} ({inv["severity"]}): {inv["description"]}')
+with open(violations_path, 'w') as f:
     json.dump({'invariants': results, 'regressions': regressions}, f, indent=2)
 if regressions:
     print('INVARIANT REGRESSIONS:')
@@ -1616,7 +1911,7 @@ else:
     total = len(results)
     passed = sum(1 for v in results.values() if v['passed'])
     print(f'Repo-contract: PASS ({passed}/{total} invariants holding)')
-"
+PY
 fi
 ```
 
@@ -1646,16 +1941,23 @@ if [ -z "$_SIGNUM_MECHANIC" ]; then
   echo "ERROR: mechanic-parser.sh not found in Signum plugin directories" >&2
   exit 1
 fi
-bash "$_SIGNUM_MECHANIC" .signum/baseline.json
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+BASELINE_PATH="${ARTIFACT_ROOT}baseline.json"
+bash "$_SIGNUM_MECHANIC" "$BASELINE_PATH"
 ```
 
 If any check has a NEW regression, continue to reviews — mechanic regression influences the final decision but does not block the audit.
 
 ### Step 3.1.3: Policy scanner (bash, zero LLM cost)
 
-Run the deterministic policy scanner on `.signum/combined.patch`. This step scans addition lines only for security, unsafe, and dependency patterns. Use the Bash tool:
+Run the deterministic policy scanner on `combined.patch` under the canonical artifact root. This step scans addition lines only for security, unsafe, and dependency patterns. Use the Bash tool:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+
 # Resolve policy-scanner.sh from known trusted Signum install roots only.
 # SIGNUM_PLUGIN_DIR env var is intentionally excluded to prevent environment
 # hijacking — only fixed install paths derived from $HOME are trusted.
@@ -1672,34 +1974,42 @@ if [ -z "$_SIGNUM_SCANNER" ]; then
   echo "ERROR: policy-scanner.sh not found in Signum plugin directories" >&2
   exit 1
 fi
-bash "$_SIGNUM_SCANNER" .signum/combined.patch
+bash "$_SIGNUM_SCANNER" "$COMBINED_PATCH_PATH"
 ```
 
-This writes `.signum/policy_scan.json` with fields: `scannedAt`, `patchFile`, `findings` (array), and `summaryCounts` ({critical, major, minor, total}).
+This writes `policy_scan.json` under the canonical artifact root with fields: `scannedAt`, `patchFile`, `findings` (array), and `summaryCounts` ({critical, major, minor, total}).
 
 Check for CRITICAL findings:
 
 ```bash
-POLICY_CRITICAL=$(jq -r '.summaryCounts.critical // 0' .signum/policy_scan.json)
-echo "Policy scan: critical=$POLICY_CRITICAL findings total=$(jq -r '.summaryCounts.total' .signum/policy_scan.json)"
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+POLICY_SCAN_PATH="${ARTIFACT_ROOT}policy_scan.json"
+POLICY_CRITICAL=$(jq -r '.summaryCounts.critical // 0' "$POLICY_SCAN_PATH")
+echo "Policy scan: critical=$POLICY_CRITICAL findings total=$(jq -r '.summaryCounts.total' "$POLICY_SCAN_PATH")"
 ```
 
 If `POLICY_CRITICAL` is greater than 0, the synthesizer will AUTO_BLOCK. Continue to reviews — the synthesizer reads `policy_scan.json` and applies the block rule deterministically.
 
 ### Step 3.1.5: Holdout validation
 
-**Skip if `RISK_LEVEL` is `low`.** Write an empty holdout report and proceed to Step 3.2.
+**Skip if `RISK_LEVEL` is `low`.** Write an empty holdout report under the canonical artifact root and proceed to Step 3.2.
 
 Otherwise, run holdout verification using the typed DSL runner. Supports both new format (`acceptanceCriteria` with `visibility: "holdout"`) and legacy `holdoutScenarios`:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+
 if [ "$RISK_LEVEL" = "low" ]; then
-  echo '{"total":0,"passed":0,"failed":0,"errors":0,"results":[]}' > .signum/holdout_report.json
+  echo '{"total":0,"passed":0,"failed":0,"errors":0,"results":[]}' > "$HOLDOUT_REPORT_PATH"
   echo "Holdout validation skipped (low risk)"
 else
 # Count holdouts: new format (visibility=holdout) + legacy (holdoutScenarios)
-HOLDOUT_ACS=$(jq '[.acceptanceCriteria[] | select(.visibility == "holdout")] | length' .signum/contract.json)
-LEGACY_HOLDOUTS=$(jq '.holdoutScenarios // [] | length' .signum/contract.json)
+HOLDOUT_ACS=$(jq '[.acceptanceCriteria[] | select(.visibility == "holdout")] | length' "$CONTRACT_PATH")
+LEGACY_HOLDOUTS=$(jq '.holdoutScenarios // [] | length' "$CONTRACT_PATH")
 TOTAL_HOLDOUTS=$((HOLDOUT_ACS + LEGACY_HOLDOUTS))
 
 if [ "$TOTAL_HOLDOUTS" -gt 0 ]; then
@@ -1708,11 +2018,11 @@ if [ "$TOTAL_HOLDOUTS" -gt 0 ]; then
 
   # New format: AC with visibility=holdout
   for i in $(seq 0 $((HOLDOUT_ACS - 1))); do
-    ID=$(jq -r "[.acceptanceCriteria[] | select(.visibility == \"holdout\")][$i].id" .signum/contract.json)
-    DESC=$(jq -r "[.acceptanceCriteria[] | select(.visibility == \"holdout\")][$i].description" .signum/contract.json)
+    ID=$(jq -r "[.acceptanceCriteria[] | select(.visibility == \"holdout\")][$i].id" "$CONTRACT_PATH")
+    DESC=$(jq -r "[.acceptanceCriteria[] | select(.visibility == \"holdout\")][$i].description" "$CONTRACT_PATH")
 
     VERIFY_FILE=$(mktemp)
-    jq "[.acceptanceCriteria[] | select(.visibility == \"holdout\")][$i].verify" .signum/contract.json > "$VERIFY_FILE"
+    jq "[.acceptanceCriteria[] | select(.visibility == \"holdout\")][$i].verify" "$CONTRACT_PATH" > "$VERIFY_FILE"
 
     if ! bash lib/dsl-runner.sh validate "$VERIFY_FILE" > /dev/null 2>&1; then
       ERRORS=$((ERRORS + 1))
@@ -1738,12 +2048,12 @@ if [ "$TOTAL_HOLDOUTS" -gt 0 ]; then
 
   # Legacy format: holdoutScenarios (backward compat)
   for i in $(seq 0 $((LEGACY_HOLDOUTS - 1))); do
-    ID=$(jq -r ".holdoutScenarios[$i].id // \"HO$((i+1))\"" .signum/contract.json)
-    DESC=$(jq -r ".holdoutScenarios[$i].description" .signum/contract.json)
-    HAS_STEPS=$(jq ".holdoutScenarios[$i].verify | has(\"steps\")" .signum/contract.json)
+    ID=$(jq -r ".holdoutScenarios[$i].id // \"HO$((i+1))\"" "$CONTRACT_PATH")
+    DESC=$(jq -r ".holdoutScenarios[$i].description" "$CONTRACT_PATH")
+    HAS_STEPS=$(jq ".holdoutScenarios[$i].verify | has(\"steps\")" "$CONTRACT_PATH")
     if [ "$HAS_STEPS" = "true" ]; then
       VERIFY_FILE=$(mktemp)
-      jq ".holdoutScenarios[$i].verify" .signum/contract.json > "$VERIFY_FILE"
+      jq ".holdoutScenarios[$i].verify" "$CONTRACT_PATH" > "$VERIFY_FILE"
       if bash lib/dsl-runner.sh validate "$VERIFY_FILE" > /dev/null 2>&1; then
         REPORT=$(bash lib/dsl-runner.sh run "$VERIFY_FILE" 2>&1) || true
         STATUS=$(echo "$REPORT" | jq -r '.status // "ERROR"')
@@ -1763,10 +2073,10 @@ if [ "$TOTAL_HOLDOUTS" -gt 0 ]; then
 
   echo "$RESULTS" | jq --argjson pass "$PASS" --argjson fail "$FAIL" --argjson err "$ERRORS" \
     '{total: ($pass + $fail + $err), passed: $pass, failed: $fail, errors: $err, results: .}' \
-    > .signum/holdout_report.json
+    > "$HOLDOUT_REPORT_PATH"
   echo "Holdout: $PASS passed, $FAIL failed, $ERRORS errors"
 else
-  echo '{"total":0,"passed":0,"failed":0,"errors":0,"results":[]}' > .signum/holdout_report.json
+  echo '{"total":0,"passed":0,"failed":0,"errors":0,"results":[]}' > "$HOLDOUT_REPORT_PATH"
   echo "No holdout scenarios"
 fi
 fi
@@ -1776,15 +2086,22 @@ If any holdout fails, continue to reviews but synthesizer treats it as regressio
 
 ### Step 3.2.0: Gather review context
 
-Run a single Bash block to build `.signum/review_context.json`. This file provides git history for changed files and issue references extracted from commit messages — used later to enrich the Claude reviewer prompt.
+Run a single Bash block to build `review_context.json` under the canonical artifact root. This file provides git history for changed files and issue references extracted from commit messages and is used later to enrich the Claude reviewer prompt.
 
 ```bash
-python3 - << 'PYEOF'
-import json, os, subprocess, re
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+REVIEW_CONTEXT_PATH="${ARTIFACT_ROOT}review_context.json"
+
+python3 - "$PATCH_PATH" "$REVIEW_CONTEXT_PATH" << 'PYEOF'
+import json, os, re, subprocess, sys
+
+patch_path = sys.argv[1]
+review_context_path = sys.argv[2]
 
 # --- git_history: one entry per file changed in combined.patch ---
 git_history = []
-patch_path = '.signum/combined.patch'
 if os.path.exists(patch_path):
     with open(patch_path) as f:
         patch = f.read()
@@ -1860,7 +2177,7 @@ result = {
     'issue_refs': issue_refs,
     'project_intent': project_intent,
 }
-with open('.signum/review_context.json', 'w') as f:
+with open(review_context_path, 'w') as f:
     json.dump(result, f, indent=2)
 print(f"review_context.json written: {len(git_history)} file(s), {len(issue_refs)} issue ref(s), intent={'yes' if project_intent else 'null'}")
 PYEOF
@@ -1872,37 +2189,51 @@ If the patch does not exist or contains no file paths, `git_history` and `issue_
 
 **If `RISK_LEVEL` is `low`:** skip this step entirely (no external prompts needed). Set `CODEX_AVAILABLE=false` and `GEMINI_AVAILABLE=false`, then proceed directly to Step 3.2.5 (Claude-only).
 
-Otherwise, in a single Bash block, check both codex and gemini availability, build both prompts (security-focused for codex, performance-focused for gemini), and save as `.signum/review_prompt_codex.txt` and `.signum/review_prompt_gemini.txt`:
+Otherwise, in a single Bash block, check both codex and gemini availability, build both prompts (security-focused for codex, performance-focused for gemini), and save them under the canonical artifact root as `review_prompt_codex.txt` and `review_prompt_gemini.txt`:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+DELTA_PATCH_PATH="${ARTIFACT_ROOT}iteration_delta.patch"
+REVIEW_PROMPT_CODEX_PATH="${ARTIFACT_ROOT}review_prompt_codex.txt"
+REVIEW_PROMPT_GEMINI_PATH="${ARTIFACT_ROOT}review_prompt_gemini.txt"
+
 which codex > /dev/null 2>&1 && CODEX_AVAILABLE=true || CODEX_AVAILABLE=false
 which gemini > /dev/null 2>&1 && GEMINI_AVAILABLE=true || GEMINI_AVAILABLE=false
 
 if [ "$CODEX_AVAILABLE" = "true" ]; then
-  python3 -c "
-import json, sys, os
-goal = json.load(open('.signum/contract.json'))['goal']
-diff = open('.signum/combined.patch').read()
-delta_path = '.signum/iteration_delta.patch'
+  python3 - "$CONTRACT_PATH" "$PATCH_PATH" "$DELTA_PATCH_PATH" "lib/prompts/review-template-security.md" <<'PY' > "$REVIEW_PROMPT_CODEX_PATH"
+import json
+import os
+import sys
+
+contract_path, patch_path, delta_path, template_path = sys.argv[1:]
+goal = json.load(open(contract_path))['goal']
+diff = open(patch_path).read()
 delta = open(delta_path).read() if os.path.exists(delta_path) else ''
-tmpl = open('lib/prompts/review-template-security.md').read()
+tmpl = open(template_path).read()
 print(tmpl.replace('{goal}', goal).replace('{diff}', diff).replace('{iteration_delta}', delta))
-" > .signum/review_prompt_codex.txt
+PY
   echo "codex: AVAILABLE, prompt written"
 else
   echo "codex: UNAVAILABLE"
 fi
 
 if [ "$GEMINI_AVAILABLE" = "true" ]; then
-  python3 -c "
-import json, sys, os
-goal = json.load(open('.signum/contract.json'))['goal']
-diff = open('.signum/combined.patch').read()
-delta_path = '.signum/iteration_delta.patch'
+  python3 - "$CONTRACT_PATH" "$PATCH_PATH" "$DELTA_PATCH_PATH" "lib/prompts/review-template-performance.md" <<'PY' > "$REVIEW_PROMPT_GEMINI_PATH"
+import json
+import os
+import sys
+
+contract_path, patch_path, delta_path, template_path = sys.argv[1:]
+goal = json.load(open(contract_path))['goal']
+diff = open(patch_path).read()
 delta = open(delta_path).read() if os.path.exists(delta_path) else ''
-tmpl = open('lib/prompts/review-template-performance.md').read()
+tmpl = open(template_path).read()
 print(tmpl.replace('{goal}', goal).replace('{diff}', diff).replace('{iteration_delta}', delta))
-" > .signum/review_prompt_gemini.txt
+PY
   echo "gemini: AVAILABLE, prompt written"
 else
   echo "gemini: UNAVAILABLE"
@@ -1923,33 +2254,42 @@ For medium/high risk, launch the reviewer-claude Agent with `run_in_background: 
 
 **Claude (Agent tool, `run_in_background: true`):**
 
-Before launching the Claude reviewer Agent, read `.signum/review_context.json` and serialize it to a string. Then construct the agent prompt as follows (inject the review_context JSON content inline, not as a file path):
+Before launching the Claude reviewer Agent, read `review_context.json` under the canonical artifact root and serialize it to a string. Then construct the agent prompt as follows (inject the review_context JSON content inline, not as a file path):
 
 ```
-Read .signum/contract.json, .signum/combined.patch, and .signum/mechanic_report.json.
-Also read .signum/iteration_delta.patch if it exists.
+The canonical artifact root for this review is `.signum/contracts/<activeContractId>/`.
+Read `contract.json`, `combined.patch`, and `mechanic_report.json` from that canonical artifact root.
+Also read `iteration_delta.patch` from that same root if it exists.
 The review_context for this review is: <REVIEW_CONTEXT_JSON>
-Follow lib/prompts/review-template.md and write your review to .signum/reviews/claude.json.
+Follow lib/prompts/review-template.md and write your review to `reviews/claude.json` under that same canonical artifact root.
 Use the review_context above to fill in the {review_context} placeholder in the template.
 Write ONLY the JSON object, no markers, no markdown.
 ```
 
-Replace `<REVIEW_CONTEXT_JSON>` with the full JSON content of `.signum/review_context.json` read in the previous step.
+Replace `<REVIEW_CONTEXT_JSON>` with the full JSON content of `review_context.json` from the canonical artifact root read in the previous step.
 
 **Codex (Bash tool, `run_in_background: true`, only if CODEX_AVAILABLE):**
 
 ```bash
-PROMPT=$(cat .signum/review_prompt_codex.txt)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+REVIEW_PROMPT_CODEX_PATH="${ARTIFACT_ROOT}review_prompt_codex.txt"
+CODEX_STDOUT_PATH="${REVIEWS_DIR}/codex_stdout.txt"
+CODEX_EXIT_PATH="${REVIEWS_DIR}/codex_exit_code.txt"
+CODEX_RAW_PATH="${REVIEWS_DIR}/codex_raw.txt"
+PROMPT=$(cat "$REVIEW_PROMPT_CODEX_PATH")
 OUT=$(mktemp)
 CODEX_MODEL_FLAG=""
 [ -n "$SIGNUM_CODEX_MODEL" ] && CODEX_MODEL_FLAG="--model $SIGNUM_CODEX_MODEL"
 CODEX_PROFILE_FLAG=""
 [ -n "$SIGNUM_CODEX_PROFILE" ] && CODEX_PROFILE_FLAG="-p $SIGNUM_CODEX_PROFILE"
+mkdir -p "$REVIEWS_DIR"
 codex exec --ephemeral -C "$PWD" $CODEX_PROFILE_FLAG $CODEX_MODEL_FLAG --output-last-message "$OUT" "$PROMPT" \
-  > .signum/reviews/codex_stdout.txt 2>&1
-echo $? > .signum/reviews/codex_exit_code.txt
-cp "$OUT" .signum/reviews/codex_raw.txt 2>/dev/null || \
-  cp .signum/reviews/codex_stdout.txt .signum/reviews/codex_raw.txt
+  > "$CODEX_STDOUT_PATH" 2>&1
+echo $? > "$CODEX_EXIT_PATH"
+cp "$OUT" "$CODEX_RAW_PATH" 2>/dev/null || \
+  cp "$CODEX_STDOUT_PATH" "$CODEX_RAW_PATH"
 rm -f "$OUT"
 echo "CODEX_DONE"
 ```
@@ -1957,11 +2297,18 @@ echo "CODEX_DONE"
 **Gemini (Bash tool, `run_in_background: true`, only if GEMINI_AVAILABLE):**
 
 ```bash
-PROMPT=$(cat .signum/review_prompt_gemini.txt)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+REVIEW_PROMPT_GEMINI_PATH="${ARTIFACT_ROOT}review_prompt_gemini.txt"
+GEMINI_RAW_PATH="${REVIEWS_DIR}/gemini_raw.txt"
+GEMINI_EXIT_PATH="${REVIEWS_DIR}/gemini_exit_code.txt"
+PROMPT=$(cat "$REVIEW_PROMPT_GEMINI_PATH")
 GEMINI_MODEL_FLAG=""
 [ -n "$SIGNUM_GEMINI_MODEL" ] && GEMINI_MODEL_FLAG="--model $SIGNUM_GEMINI_MODEL"
-gemini $GEMINI_MODEL_FLAG -p "$PROMPT" > .signum/reviews/gemini_raw.txt 2>&1
-echo $? > .signum/reviews/gemini_exit_code.txt
+mkdir -p "$REVIEWS_DIR"
+gemini $GEMINI_MODEL_FLAG -p "$PROMPT" > "$GEMINI_RAW_PATH" 2>&1
+echo $? > "$GEMINI_EXIT_PATH"
 echo "GEMINI_DONE"
 ```
 
@@ -1974,7 +2321,11 @@ Use the TaskOutput tool with `block: true` to wait for CLAUDE_TASK_ID. Then use 
 After all complete (or if they were never launched), verify the claude output:
 
 ```bash
-test -f .signum/reviews/claude.json && jq -e '.verdict' .signum/reviews/claude.json > /dev/null \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+CLAUDE_REVIEW_PATH="${REVIEWS_DIR}/claude.json"
+test -f "$CLAUDE_REVIEW_PATH" && jq -e '.verdict' "$CLAUDE_REVIEW_PATH" > /dev/null \
   && echo "claude review OK" || echo "WARNING: claude.json missing or invalid"
 ```
 
@@ -1982,13 +2333,21 @@ test -f .signum/reviews/claude.json && jq -e '.verdict' .signum/reviews/claude.j
 
 After collection, parse codex output and parse gemini output.
 
-If CODEX_AVAILABLE: check exit code first, then attempt 3-level parsing of `.signum/reviews/codex_raw.txt`:
+If CODEX_AVAILABLE: check exit code first, then attempt 3-level parsing of `reviews/codex_raw.txt` under the canonical artifact root:
 
 ```bash
-CODEX_EXIT=$(cat .signum/reviews/codex_exit_code.txt 2>/dev/null || echo "1")
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+CODEX_EXIT_PATH="${REVIEWS_DIR}/codex_exit_code.txt"
+CODEX_STDOUT_PATH="${REVIEWS_DIR}/codex_stdout.txt"
+CODEX_RAW_PATH="${REVIEWS_DIR}/codex_raw.txt"
+CODEX_JSON_PATH="${REVIEWS_DIR}/codex.json"
+CODEX_EXTRACTED_PATH="${ARTIFACT_ROOT}codex_extracted.json"
+CODEX_EXIT=$(cat "$CODEX_EXIT_PATH" 2>/dev/null || echo "1")
 if [ "$CODEX_EXIT" != "0" ]; then
   # Classify failure reason (transient = retry-worthy, permanent = skip)
-  RAW=$(head -c 2000 .signum/reviews/codex_stdout.txt 2>/dev/null)
+  RAW=$(head -c 2000 "$CODEX_STDOUT_PATH" 2>/dev/null)
   FAILURE_REASON="unknown"
   ERROR_TYPE="unknown"
   if [ "$CODEX_EXIT" = "124" ]; then
@@ -2004,35 +2363,35 @@ if [ "$CODEX_EXIT" != "0" ]; then
   fi
   jq -n --arg raw "$RAW" --arg code "$CODEX_EXIT" --arg reason "$FAILURE_REASON" --arg etype "$ERROR_TYPE" \
     '{"verdict":"UNAVAILABLE","findings":[],"concerns":[],"summary":("Codex invocation failed (exit " + $code + ")"),"available":false,"failure_reason":$reason,"error_type":$etype,"raw":$raw}' \
-    > .signum/reviews/codex.json
+    > "$CODEX_JSON_PATH"
   echo "codex: invocation failed (exit $CODEX_EXIT), reason=$FAILURE_REASON ($ERROR_TYPE)"
 
 # Level 1: valid JSON directly
-elif jq -e '.verdict' .signum/reviews/codex_raw.txt > /dev/null 2>&1; then
-  cp .signum/reviews/codex_raw.txt .signum/reviews/codex.json
+elif jq -e '.verdict' "$CODEX_RAW_PATH" > /dev/null 2>&1; then
+  cp "$CODEX_RAW_PATH" "$CODEX_JSON_PATH"
   echo "codex: parsed as direct JSON"
 
 # Level 2: extract between markers
-elif grep -q '###SIGNUM_REVIEW_START###' .signum/reviews/codex_raw.txt; then
-  sed -n '/###SIGNUM_REVIEW_START###/,/###SIGNUM_REVIEW_END###/p' .signum/reviews/codex_raw.txt \
-    | grep -v '###SIGNUM_REVIEW' > .signum/codex_extracted.json
-  if jq -e '.verdict' .signum/codex_extracted.json > /dev/null 2>&1; then
-    cp .signum/codex_extracted.json .signum/reviews/codex.json
+elif grep -q '###SIGNUM_REVIEW_START###' "$CODEX_RAW_PATH"; then
+  sed -n '/###SIGNUM_REVIEW_START###/,/###SIGNUM_REVIEW_END###/p' "$CODEX_RAW_PATH" \
+    | grep -v '###SIGNUM_REVIEW' > "$CODEX_EXTRACTED_PATH"
+  if jq -e '.verdict' "$CODEX_EXTRACTED_PATH" > /dev/null 2>&1; then
+    cp "$CODEX_EXTRACTED_PATH" "$CODEX_JSON_PATH"
     echo "codex: parsed via markers"
   else
-    RAW=$(cat .signum/reviews/codex_raw.txt | head -c 2000)
+    RAW=$(head -c 2000 "$CODEX_RAW_PATH")
     jq -n --arg raw "$RAW" \
       '{"verdict":"CONDITIONAL","findings":[],"summary":"Could not parse codex output","parseOk":false,"raw":$raw}' \
-      > .signum/reviews/codex.json
+      > "$CODEX_JSON_PATH"
     echo "codex: marker extraction failed, saved raw"
   fi
 
 # Level 3: save raw, mark unparseable
 else
-  RAW=$(cat .signum/reviews/codex_raw.txt | head -c 2000)
+  RAW=$(head -c 2000 "$CODEX_RAW_PATH")
   jq -n --arg raw "$RAW" \
     '{"verdict":"CONDITIONAL","findings":[],"summary":"Could not parse codex output","parseOk":false,"raw":$raw}' \
-    > .signum/reviews/codex.json
+    > "$CODEX_JSON_PATH"
   echo "codex: no markers found, saved raw"
 fi
 ```
@@ -2040,19 +2399,31 @@ fi
 If CODEX_UNAVAILABLE:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+CODEX_JSON_PATH="${REVIEWS_DIR}/codex.json"
 echo '{"verdict":"UNAVAILABLE","findings":[],"summary":"Codex CLI not installed","available":false}' \
-  > .signum/reviews/codex.json
+  > "$CODEX_JSON_PATH"
 ```
 
 Parse gemini output:
 
-If GEMINI_AVAILABLE: check exit code first, then attempt 3-level parsing of `.signum/reviews/gemini_raw.txt`:
+If GEMINI_AVAILABLE: check exit code first, then attempt 3-level parsing of `reviews/gemini_raw.txt` under the canonical artifact root:
 
 ```bash
-GEMINI_EXIT=$(cat .signum/reviews/gemini_exit_code.txt 2>/dev/null || echo "1")
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+GEMINI_EXIT_PATH="${REVIEWS_DIR}/gemini_exit_code.txt"
+GEMINI_RAW_PATH="${REVIEWS_DIR}/gemini_raw.txt"
+GEMINI_JSON_PATH="${REVIEWS_DIR}/gemini.json"
+GEMINI_STRIPPED_PATH="${ARTIFACT_ROOT}gemini_stripped.txt"
+GEMINI_EXTRACTED_PATH="${ARTIFACT_ROOT}gemini_extracted.json"
+GEMINI_EXIT=$(cat "$GEMINI_EXIT_PATH" 2>/dev/null || echo "1")
 if [ "$GEMINI_EXIT" != "0" ]; then
   # Classify failure reason (transient = retry-worthy, permanent = skip)
-  RAW=$(head -c 2000 .signum/reviews/gemini_raw.txt 2>/dev/null)
+  RAW=$(head -c 2000 "$GEMINI_RAW_PATH" 2>/dev/null)
   FAILURE_REASON="unknown"
   ERROR_TYPE="unknown"
   if [ "$GEMINI_EXIT" = "124" ]; then
@@ -2068,40 +2439,40 @@ if [ "$GEMINI_EXIT" != "0" ]; then
   fi
   jq -n --arg raw "$RAW" --arg code "$GEMINI_EXIT" --arg reason "$FAILURE_REASON" --arg etype "$ERROR_TYPE" \
     '{"verdict":"UNAVAILABLE","findings":[],"concerns":[],"summary":("Gemini invocation failed (exit " + $code + ")"),"available":false,"failure_reason":$reason,"error_type":$etype,"raw":$raw}' \
-    > .signum/reviews/gemini.json
+    > "$GEMINI_JSON_PATH"
   echo "gemini: invocation failed (exit $GEMINI_EXIT), reason=$FAILURE_REASON ($ERROR_TYPE)"
 
 # Level 0.5: strip markdown code fences (```json ... ```) if present
-elif sed -n '1{/^```/d}; ${/^```/d}; p' .signum/reviews/gemini_raw.txt | sed 's/^```json$//' | sed 's/^```$//' > .signum/reviews/gemini_stripped.txt \
-  && jq -e '.verdict' .signum/reviews/gemini_stripped.txt > /dev/null 2>&1; then
-  cp .signum/reviews/gemini_stripped.txt .signum/reviews/gemini.json
-  rm -f .signum/reviews/gemini_stripped.txt
+elif sed -n '1{/^```/d}; ${/^```/d}; p' "$GEMINI_RAW_PATH" | sed 's/^```json$//' | sed 's/^```$//' > "$GEMINI_STRIPPED_PATH" \
+  && jq -e '.verdict' "$GEMINI_STRIPPED_PATH" > /dev/null 2>&1; then
+  cp "$GEMINI_STRIPPED_PATH" "$GEMINI_JSON_PATH"
+  rm -f "$GEMINI_STRIPPED_PATH"
   echo "gemini: parsed after stripping markdown fences"
 
 # Level 1: valid JSON directly
-elif jq -e '.verdict' .signum/reviews/gemini_raw.txt > /dev/null 2>&1; then
-  cp .signum/reviews/gemini_raw.txt .signum/reviews/gemini.json
+elif jq -e '.verdict' "$GEMINI_RAW_PATH" > /dev/null 2>&1; then
+  cp "$GEMINI_RAW_PATH" "$GEMINI_JSON_PATH"
   echo "gemini: parsed as direct JSON"
 
-elif grep -q '###SIGNUM_REVIEW_START###' .signum/reviews/gemini_raw.txt; then
-  sed -n '/###SIGNUM_REVIEW_START###/,/###SIGNUM_REVIEW_END###/p' .signum/reviews/gemini_raw.txt \
-    | grep -v '###SIGNUM_REVIEW' > .signum/gemini_extracted.json
-  if jq -e '.verdict' .signum/gemini_extracted.json > /dev/null 2>&1; then
-    cp .signum/gemini_extracted.json .signum/reviews/gemini.json
+elif grep -q '###SIGNUM_REVIEW_START###' "$GEMINI_RAW_PATH"; then
+  sed -n '/###SIGNUM_REVIEW_START###/,/###SIGNUM_REVIEW_END###/p' "$GEMINI_RAW_PATH" \
+    | grep -v '###SIGNUM_REVIEW' > "$GEMINI_EXTRACTED_PATH"
+  if jq -e '.verdict' "$GEMINI_EXTRACTED_PATH" > /dev/null 2>&1; then
+    cp "$GEMINI_EXTRACTED_PATH" "$GEMINI_JSON_PATH"
     echo "gemini: parsed via markers"
   else
-    RAW=$(cat .signum/reviews/gemini_raw.txt | head -c 2000)
+    RAW=$(head -c 2000 "$GEMINI_RAW_PATH")
     jq -n --arg raw "$RAW" \
       '{"verdict":"CONDITIONAL","findings":[],"summary":"Could not parse gemini output","parseOk":false,"raw":$raw}' \
-      > .signum/reviews/gemini.json
+      > "$GEMINI_JSON_PATH"
     echo "gemini: marker extraction failed, saved raw"
   fi
 
 else
-  RAW=$(cat .signum/reviews/gemini_raw.txt | head -c 2000)
+  RAW=$(head -c 2000 "$GEMINI_RAW_PATH")
   jq -n --arg raw "$RAW" \
     '{"verdict":"CONDITIONAL","findings":[],"summary":"Could not parse gemini output","parseOk":false,"raw":$raw}' \
-    > .signum/reviews/gemini.json
+    > "$GEMINI_JSON_PATH"
   echo "gemini: no markers found, saved raw"
 fi
 ```
@@ -2109,8 +2480,12 @@ fi
 If GEMINI_UNAVAILABLE:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+GEMINI_JSON_PATH="${REVIEWS_DIR}/gemini.json"
 echo '{"verdict":"UNAVAILABLE","findings":[],"summary":"Gemini CLI not installed","available":false}' \
-  > .signum/reviews/gemini.json
+  > "$GEMINI_JSON_PATH"
 ```
 
 ### Step 3.5: Synthesizer (agent)
@@ -2118,17 +2493,18 @@ echo '{"verdict":"UNAVAILABLE","findings":[],"summary":"Gemini CLI not installed
 Use the Agent tool to launch the "synthesizer" agent with this prompt:
 
 ```
-Read .signum/mechanic_report.json, .signum/reviews/claude.json,
-.signum/reviews/codex.json, .signum/reviews/gemini.json,
-.signum/holdout_report.json, and .signum/execute_log.json.
-Apply deterministic synthesis rules, compute confidence scores,
-and write .signum/audit_summary.json.
+The canonical artifact root for this synthesis is `.signum/contracts/<activeContractId>/`.
+Read `mechanic_report.json`, `reviews/claude.json`, `reviews/codex.json`, `reviews/gemini.json`, `holdout_report.json`, and `execute_log.json` from that canonical artifact root.
+Apply deterministic synthesis rules, compute confidence scores, and write `audit_summary.json` to that same canonical artifact root.
 ```
 
 After it finishes, read and display the audit summary:
 
 ```bash
-test -f .signum/audit_summary.json || { echo "ERROR: audit_summary.json not found"; exit 1; }
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+test -f "$AUDIT_SUMMARY_PATH" || { echo "ERROR: audit_summary.json not found"; exit 1; }
 
 jq -r '"=== AUDIT SUMMARY ===",
        "Mechanic: " + (.mechanic // "unknown"),
@@ -2141,8 +2517,7 @@ jq -r '"=== AUDIT SUMMARY ===",
        "Consensus: " + .consensus,
        "Confidence: " + ((.confidence.overall // 0) | tostring) + "%",
        "DECISION: " + .decision,
-       "Reasoning: " + .reasoning' \
-  .signum/audit_summary.json
+       "Reasoning: " + .reasoning'   "$AUDIT_SUMMARY_PATH"
 ```
 
 ### Step 3.6: Iterative AUDIT Loop
@@ -2163,17 +2538,22 @@ echo "Iterative AUDIT config: max_iterations=$MAX_ITERATIONS"
 Check the audit summary decision and findings:
 
 ```bash
-AUDIT_DECISION=$(jq -r '.decision' .signum/audit_summary.json)
-HAS_MAJOR=$(jq '[.reviews[].findings[]? | select(.severity == "MAJOR" or .severity == "CRITICAL")] | length' .signum/audit_summary.json)
-HAS_REGRESSIONS=$(jq -r '.mechanic' .signum/audit_summary.json | grep -q "regression" && echo "true" || echo "false")
-HOLDOUT_FAILURES=$(jq -r '.holdout.failed // 0' .signum/audit_summary.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+AUDIT_DECISION=$(jq -r '.decision' "$AUDIT_SUMMARY_PATH")
+HAS_MAJOR=$(jq '[.reviews[].findings[]? | select(.severity == "MAJOR" or .severity == "CRITICAL")] | length' "$AUDIT_SUMMARY_PATH")
+HAS_REGRESSIONS=$(jq -r '.mechanic' "$AUDIT_SUMMARY_PATH" | grep -q "regression" && echo "true" || echo "false")
+HOLDOUT_FAILURES=$(jq -r '.holdout.failed // 0' "$AUDIT_SUMMARY_PATH")
 
 # Compute iteration score from audit_summary findings (synthesizer emits the score field in iterative mode)
-_CRITICALS=$(jq '[.reviews[].findings[]? | select(.severity == "CRITICAL")] | length' .signum/audit_summary.json)
-_MAJORS=$(jq '[.reviews[].findings[]? | select(.severity == "MAJOR")] | length' .signum/audit_summary.json)
-_MINORS=$(jq '[.reviews[].findings[]? | select(.severity == "MINOR")] | length' .signum/audit_summary.json)
-_MECH_REGRESSIONS=$(jq 'if .hasRegressions then 1 else 0 end' .signum/mechanic_report.json)
-_HOLDOUT_FAILURES=$(jq '.failed // 0' .signum/holdout_report.json 2>/dev/null || echo 0)
+_CRITICALS=$(jq '[.reviews[].findings[]? | select(.severity == "CRITICAL")] | length' "$AUDIT_SUMMARY_PATH")
+_MAJORS=$(jq '[.reviews[].findings[]? | select(.severity == "MAJOR")] | length' "$AUDIT_SUMMARY_PATH")
+_MINORS=$(jq '[.reviews[].findings[]? | select(.severity == "MINOR")] | length' "$AUDIT_SUMMARY_PATH")
+_MECH_REGRESSIONS=$(jq 'if .hasRegressions then 1 else 0 end' "$MECHANIC_REPORT_PATH")
+_HOLDOUT_FAILURES=$(jq '.failed // 0' "$HOLDOUT_REPORT_PATH" 2>/dev/null || echo 0)
 ITERATION_SCORE=$(( -(_CRITICALS * 1000) - (_MECH_REGRESSIONS * 500) - (_HOLDOUT_FAILURES * 200) - (_MAJORS * 50) - (_MINORS * 1) ))
 
 echo "Pass 1: decision=$AUDIT_DECISION major_findings=$HAS_MAJOR regressions=$HAS_REGRESSIONS holdout_failures=$HOLDOUT_FAILURES score=$ITERATION_SCORE"
@@ -2186,30 +2566,39 @@ Otherwise, enter the iterative repair loop:
 #### Step 3.6.1: Initialize iteration tracking
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+PASS1_DIR="${ARTIFACT_ROOT}iterations/01"
+PASS1_REVIEWS_DIR="${PASS1_DIR}/reviews"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+AUDIT_ITERATION_LOG_PATH="${ARTIFACT_ROOT}audit_iteration_log.json"
+
 # Store pass 1 artifacts
-mkdir -p .signum/iterations/01/reviews
-cp .signum/combined.patch .signum/iterations/01/
-cp .signum/mechanic_report.json .signum/iterations/01/
-cp .signum/holdout_report.json .signum/iterations/01/ 2>/dev/null || true
-cp .signum/execute_log.json .signum/iterations/01/ 2>/dev/null || true
-cp .signum/reviews/*.json .signum/iterations/01/reviews/ 2>/dev/null || true
-cp .signum/audit_summary.json .signum/iterations/01/
+mkdir -p "$PASS1_REVIEWS_DIR"
+cp "$COMBINED_PATCH_PATH" "$PASS1_DIR/"
+cp "$MECHANIC_REPORT_PATH" "$PASS1_DIR/"
+cp "$HOLDOUT_REPORT_PATH" "$PASS1_DIR/" 2>/dev/null || true
+cp "$EXECUTE_LOG_PATH" "$PASS1_DIR/" 2>/dev/null || true
+cp "$REVIEWS_DIR/"*.json "$PASS1_REVIEWS_DIR/" 2>/dev/null || true
+cp "$AUDIT_SUMMARY_PATH" "$PASS1_DIR/"
 
 # Initialize iteration log
 BEST_SCORE=$ITERATION_SCORE
 BEST_ITERATION=1
-PASS1_FINDINGS=$(jq '[.reviews[].findings[]? | {fingerprint: .fingerprint, severity: .severity, category: .category, file: .file, line: .line}] | unique_by(.fingerprint // (.file + ":" + (.line | tostring) + ":" + .category))' .signum/audit_summary.json)
+PASS1_FINDINGS=$(jq '[.reviews[].findings[]? | {fingerprint: .fingerprint, severity: .severity, category: .category, file: .file, line: .line}] | unique_by(.fingerprint // (.file + ":" + (.line | tostring) + ":" + .category))' "$AUDIT_SUMMARY_PATH")
 PASS1_FINDINGS_COUNT=$(jq '{
   critical: [.reviews[].findings[]? | select(.severity == "CRITICAL")] | length,
   major: [.reviews[].findings[]? | select(.severity == "MAJOR")] | length,
   minor: [.reviews[].findings[]? | select(.severity == "MINOR")] | length
-}' .signum/audit_summary.json)
-MECH_REG=$(jq -r '.hasRegressions' .signum/mechanic_report.json 2>/dev/null || echo "false")
-HOLDOUT_FAIL=$(jq '.failed // 0' .signum/holdout_report.json 2>/dev/null || echo 0)
-jq -n --argjson score "$ITERATION_SCORE" --argjson findings "$PASS1_FINDINGS" --argjson findingsCount "$PASS1_FINDINGS_COUNT" \
-  --arg mechReg "$MECH_REG" --argjson holdoutFail "$HOLDOUT_FAIL" \
-  '[{"pass": 1, "score": $score, "decision": "'"$AUDIT_DECISION"'", "findingsCount": $findingsCount, "canonicalFindings": $findings, "mechanicRegressions": ($mechReg == "true"), "holdoutFailures": $holdoutFail}]' \
-  > .signum/audit_iteration_log.json
+}' "$AUDIT_SUMMARY_PATH")
+MECH_REG=$(jq -r '.hasRegressions' "$MECHANIC_REPORT_PATH" 2>/dev/null || echo "false")
+HOLDOUT_FAIL=$(jq '.failed // 0' "$HOLDOUT_REPORT_PATH" 2>/dev/null || echo 0)
+jq -n --argjson score "$ITERATION_SCORE" --argjson findings "$PASS1_FINDINGS" --argjson findingsCount "$PASS1_FINDINGS_COUNT"   --arg mechReg "$MECH_REG" --argjson holdoutFail "$HOLDOUT_FAIL"   '[{"pass": 1, "score": $score, "decision": "'"$AUDIT_DECISION"'", "findingsCount": $findingsCount, "canonicalFindings": $findings, "mechanicRegressions": ($mechReg == "true"), "holdoutFailures": $holdoutFail}]'   > "$AUDIT_ITERATION_LOG_PATH"
 
 echo "Iteration 1 stored. Best score: $BEST_SCORE"
 ```
@@ -2240,32 +2629,42 @@ fi
 SKIP_ITERATION=false
 if [ "$ITERATION_SCORE" -lt "$BEST_SCORE" ] && [ "$CURRENT_ITERATION" -gt 1 ]; then
   echo "Current score ($ITERATION_SCORE) worse than best ($BEST_SCORE at iteration $BEST_ITERATION). Rolling back."
+  source lib/contract-dir.sh 2>/dev/null || true
+  ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+  REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+  EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+  COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+  ITERATION_DELTA_PATH="${ARTIFACT_ROOT}iteration_delta.patch"
+  MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+  HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+  EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+  AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
   # Rollback: revert files from current patch (if exists) or best iteration's stored patch
-  BASE=$(jq -r '.base_commit' .signum/execution_context.json)
-  ROLLBACK_PATCH=".signum/combined.patch"
-  [ ! -f "$ROLLBACK_PATCH" ] && ROLLBACK_PATCH=".signum/iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch"
+  BASE=$(jq -r '.base_commit' "$EXECUTION_CONTEXT_PATH")
+  ROLLBACK_PATCH="$COMBINED_PATCH_PATH"
+  [ ! -f "$ROLLBACK_PATCH" ] && ROLLBACK_PATCH="${ARTIFACT_ROOT}iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch"
   PATCH_FILES=$(grep '^diff --git' "$ROLLBACK_PATCH" 2>/dev/null | sed 's|^diff --git a/||; s| b/.*||' | sort -u)
   for f in $PATCH_FILES; do
     git checkout "$BASE" -- "$f" 2>/dev/null || rm -f "$f" 2>/dev/null || true
   done
-  if git apply .signum/iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch; then
-    # Sync .signum/ working copies from best iteration
-    BEST_DIR=".signum/iterations/$(printf '%02d' $BEST_ITERATION)"
-    cp "${BEST_DIR}/combined.patch" .signum/ 2>/dev/null || true
-    cp "${BEST_DIR}/iteration_delta.patch" .signum/ 2>/dev/null || rm -f .signum/iteration_delta.patch
-    cp "${BEST_DIR}/mechanic_report.json" .signum/ 2>/dev/null || true
-    cp "${BEST_DIR}/holdout_report.json" .signum/ 2>/dev/null || true
-    cp "${BEST_DIR}/execute_log.json" .signum/ 2>/dev/null || true
-    rm -f .signum/reviews/*.json
-    cp "${BEST_DIR}/reviews/"*.json .signum/reviews/ 2>/dev/null || true
-    cp "${BEST_DIR}/audit_summary.json" .signum/ 2>/dev/null || true
+  if git apply "${ARTIFACT_ROOT}iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch"; then
+    # Sync canonical working copies from best iteration
+    BEST_DIR="${ARTIFACT_ROOT}iterations/$(printf '%02d' $BEST_ITERATION)"
+    cp "${BEST_DIR}/combined.patch" "$COMBINED_PATCH_PATH" 2>/dev/null || true
+    cp "${BEST_DIR}/iteration_delta.patch" "$ITERATION_DELTA_PATH" 2>/dev/null || reset_active_artifact "iteration_delta.patch"
+    cp "${BEST_DIR}/mechanic_report.json" "$MECHANIC_REPORT_PATH" 2>/dev/null || true
+    cp "${BEST_DIR}/holdout_report.json" "$HOLDOUT_REPORT_PATH" 2>/dev/null || true
+    cp "${BEST_DIR}/execute_log.json" "$EXECUTE_LOG_PATH" 2>/dev/null || true
+    rm -f "$REVIEWS_DIR/"*.json
+    cp "${BEST_DIR}/reviews/"*.json "$REVIEWS_DIR/" 2>/dev/null || true
+    cp "${BEST_DIR}/audit_summary.json" "$AUDIT_SUMMARY_PATH" 2>/dev/null || true
   else
-    echo "ROLLBACK_FAILED: git apply failed for iteration $BEST_ITERATION — forcing early stop"
+    echo "ROLLBACK_FAILED: git apply failed for iteration $BEST_ITERATION - forcing early stop"
     NO_IMPROVE_COUNT=99
     SKIP_ITERATION=true
   fi
 fi
-# If rollback failed, skip repair engineer and audit re-run — the early stop condition
+# If rollback failed, skip repair engineer and audit re-run. The early stop condition
 # (NO_IMPROVE_COUNT=99) will terminate the loop on the next entry condition check.
 ```
 
@@ -2273,18 +2672,24 @@ fi
 
 **Build repair brief:**
 
-Use the Bash tool to construct `.signum/repair_brief.json` from the current audit summary (which now reflects the best candidate after any rollback):
+Use the Bash tool to construct `repair_brief.json` under the canonical artifact root from the current audit summary (which now reflects the best candidate after any rollback):
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+REPAIR_BRIEF_PATH="${ARTIFACT_ROOT}repair_brief.json"
 ITER_NUM=$((CURRENT_ITERATION + 1))
 
 # Extract MAJOR+ findings from all reviewers
-FINDINGS=$(jq '[.reviews | to_entries[] | .value.findings[]? | select(.severity == "MAJOR" or .severity == "CRITICAL") | {fingerprint: .fingerprint, severity: .severity, category: .category, file: .file, line: .line, comment: .comment, evidence: .evidence}]' .signum/audit_summary.json)
+FINDINGS=$(jq '[.reviews | to_entries[] | .value.findings[]? | select(.severity == "MAJOR" or .severity == "CRITICAL") | {fingerprint: .fingerprint, severity: .severity, category: .category, file: .file, line: .line, comment: .comment, evidence: .evidence}]' "$AUDIT_SUMMARY_PATH")
 
 # Sanitize holdout summary (category only, no details)
 HOLDOUT_SUMMARY=""
-if [ -f .signum/holdout_report.json ]; then
-  HOLDOUT_FAILED=$(jq '.failed // 0' .signum/holdout_report.json)
+if [ -f "$HOLDOUT_REPORT_PATH" ]; then
+  HOLDOUT_FAILED=$(jq '.failed // 0' "$HOLDOUT_REPORT_PATH")
   if [ "$HOLDOUT_FAILED" -gt 0 ]; then
     # Extract categories via keyword matching on descriptions
     HOLDOUT_CATS=$(jq -r '[.results[] | select(.status != "PASS") | .description | ascii_downcase |
@@ -2292,7 +2697,7 @@ if [ -f .signum/holdout_report.json ]; then
       elif test("error|exception|fail") then "error handling"
       elif test("concurrent|race|parallel") then "concurrency"
       elif test("empty|null|missing") then "null/empty input"
-      else "unspecified" end] | unique | join(", ")' .signum/holdout_report.json)
+      else "unspecified" end] | unique | join(", ")' "$HOLDOUT_REPORT_PATH")
     HOLDOUT_SUMMARY="${HOLDOUT_FAILED} holdout(s) failed (categories: ${HOLDOUT_CATS})"
   fi
 fi
@@ -2300,13 +2705,13 @@ fi
 # Build mechanic regression summary and typed findings
 MECH_SUMMARY=""
 MECH_FINDINGS='[]'
-MECH_REG=$(jq -r '.hasRegressions' .signum/mechanic_report.json)
+MECH_REG=$(jq -r '.hasRegressions' "$MECHANIC_REPORT_PATH")
 if [ "$MECH_REG" = "true" ]; then
   MECH_SUMMARY=$(jq -r '
     [if .lint.regression then "lint regression" else empty end,
      if .typecheck.regression then "typecheck regression" else empty end,
      if .tests.regression then "test regression (" + (.tests.newFailures | length | tostring) + " new failures)" else empty end
-    ] | join(", ")' .signum/mechanic_report.json)
+    ] | join(", ")' "$MECHANIC_REPORT_PATH")
   # Extract typed per-file findings from regression checks only
   MECH_FINDINGS=$(jq '[
     .findings[]? |
@@ -2315,9 +2720,9 @@ if [ "$MECH_REG" = "true" ]; then
     # Find the check entry to get category and regression flag
     ([ (if . then . else null end) ] | first) as $_ |
     $f
-  ] | if length == 0 then [] else . end' .signum/mechanic_report.json 2>/dev/null || echo '[]')
+  ] | if length == 0 then [] else . end' "$MECHANIC_REPORT_PATH" 2>/dev/null || echo '[]')
   # Filter to only regression checks
-  REGRESSION_IDS=$(jq -r '[.checks[]? | select(.regression == true) | .id] | join(" ")' .signum/mechanic_report.json 2>/dev/null || echo "")
+  REGRESSION_IDS=$(jq -r '[.checks[]? | select(.regression == true) | .id] | join(" ")' "$MECHANIC_REPORT_PATH" 2>/dev/null || echo "")
   if [ -n "$REGRESSION_IDS" ]; then
     MECH_FINDINGS=$(jq '
       (.checks // [] | map({(.id): .category}) | add // {}) as $cat_map |
@@ -2326,23 +2731,16 @@ if [ "$MECH_REG" = "true" ]; then
         # Normalize file path: reject absolute paths and path traversal attempts
         . as $entry |
         ($entry.file // "") as $raw_file |
-        (if ($raw_file | startswith("/")) or ($raw_file | test("(^|/)\\.\\.(/|$)"))
+        (if ($raw_file | startswith("/")) or ($raw_file | test("(^|/)\.\.(/|$)"))
          then ""
          else $raw_file end) as $safe_file |
-        {check_id: $entry.check_id, category: ($cat_map[$entry.check_id] // "unknown"), file: $safe_file, line: $entry.line, column: $entry.column, code: $entry.code, message: $entry.message, origin: $entry.origin}]' \
-      .signum/mechanic_report.json 2>/dev/null || echo '[]')
+        {check_id: $entry.check_id, category: ($cat_map[$entry.check_id] // "unknown"), file: $safe_file, line: $entry.line, column: $entry.column, code: $entry.code, message: $entry.message, origin: $entry.origin}]'       "$MECHANIC_REPORT_PATH" 2>/dev/null || echo '[]')
   else
     MECH_FINDINGS='[]'
   fi
 fi
 
-jq -n \
-  --argjson iteration "$ITER_NUM" \
-  --argjson findings "$FINDINGS" \
-  --arg holdout_summary "$HOLDOUT_SUMMARY" \
-  --arg mechanic_summary "$MECH_SUMMARY" \
-  --argjson mechanic_findings "$MECH_FINDINGS" \
-  '{
+jq -n   --argjson iteration "$ITER_NUM"   --argjson findings "$FINDINGS"   --arg holdout_summary "$HOLDOUT_SUMMARY"   --arg mechanic_summary "$MECH_SUMMARY"   --argjson mechanic_findings "$MECH_FINDINGS"   '{
     iteration: $iteration,
     deterministicFailures: {
       mechanic: (if $mechanic_summary != "" then $mechanic_summary else null end),
@@ -2352,13 +2750,13 @@ jq -n \
     mechanicFindings: (if ($mechanic_findings | length) > 0 then $mechanic_findings else [] end),
     constraints: [
       "Fix ONLY the listed findings",
-      "Minimal diff — no unrelated refactors",
+      "Minimal diff - no unrelated refactors",
       "Do not break already-passing acceptance criteria",
       "Re-run visible AC verifies after fix"
     ]
-  }' > .signum/repair_brief.json
+  }' > "$REPAIR_BRIEF_PATH"
 
-echo "Repair brief built: $(jq '.reviewFindings | length' .signum/repair_brief.json) findings, $(jq '.mechanicFindings | length' .signum/repair_brief.json) mechanic findings"
+echo "Repair brief built: $(jq '.reviewFindings | length' "$REPAIR_BRIEF_PATH") findings, $(jq '.mechanicFindings | length' "$REPAIR_BRIEF_PATH") mechanic findings"
 ```
 
 **Capture pre-repair snapshot (receipt chain):**
@@ -2366,6 +2764,9 @@ echo "Repair brief built: $(jq '.reviewFindings | length' .signum/repair_brief.j
 Before launching repair engineers, capture a fresh workspace snapshot for this attempt. Each attempt needs its own snapshot because `base_tree_hash` must bind to the actual starting state of this repair.
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+
 # Re-resolve snapshot-tree.sh (each Bash tool call is a fresh shell)
 _SIGNUM_SNAPSHOT=""
 for _d in \
@@ -2378,7 +2779,7 @@ for _d in \
 done
 ATTEMPT_PAD=$(printf '%02d' "$((CURRENT_ITERATION + 1))")
 if [ -n "$_SIGNUM_SNAPSHOT" ]; then
-  bash "$_SIGNUM_SNAPSHOT" "execute-attempt-${ATTEMPT_PAD}"
+  bash "$_SIGNUM_SNAPSHOT" "execute-attempt-${ATTEMPT_PAD}" --workspace-root "$PWD" --signum-dir "$ARTIFACT_ROOT"
   echo "Pre-repair snapshot captured: execute-attempt-${ATTEMPT_PAD}"
 fi
 ```
@@ -2386,15 +2787,22 @@ fi
 **Clear stale engineer artifacts before launching repair:**
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+
 # Save current best combined.patch for worktree seeding BEFORE deleting stale artifacts
 _SEED_PATCH=""
-if [ -f .signum/combined.patch ]; then
+if [ -f "$COMBINED_PATCH_PATH" ]; then
   _SEED_PATCH=$(mktemp /tmp/signum_seed_XXXXXX.patch)
-  cp .signum/combined.patch "$_SEED_PATCH"
+  cp "$COMBINED_PATCH_PATH" "$_SEED_PATCH"
 fi
 
-# Remove stale artifacts so the success gate cannot accept leftovers from prior iterations
-rm -f .signum/execute_log.json .signum/combined.patch .signum/iteration_delta.patch
+# Remove stale artifacts from both the root view and canonical active root.
+source lib/contract-dir.sh
+reset_active_artifact "combined.patch"
+reset_active_artifact "execute_log.json"
+reset_active_artifact "iteration_delta.patch"
 ```
 
 **Launch repair engineer (parallel lanes):**
@@ -2406,12 +2814,16 @@ Set up two isolated git worktrees and run both engineers in parallel. The two st
 
 If worktree creation fails for either lane, fall back to single-lane behavior (the original single-engineer dispatch) without aborting the iteration.
 
-Each lane works in an isolated git worktree seeded from `base_commit` + current best `combined.patch`. Worktree paths live under `.signum/iterations/NN/lanes/` (one subdirectory per lane).
+Each lane works in an isolated git worktree seeded from `base_commit` + current best `combined.patch`. Worktree paths live under `iterations/NN/lanes/` inside the active contract artifact root.
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+ITERATIONS_DIR="${ARTIFACT_ROOT}iterations"
 ITER_PAD=$(printf '%02d' $ITER_NUM)
-BASE_COMMIT=$(jq -r '.base_commit' .signum/execution_context.json)
-LANE_PATHS=( ".signum/iterations/$ITER_PAD/lanes/A" ".signum/iterations/$ITER_PAD/lanes/B" )
+BASE_COMMIT=$(jq -r '.base_commit' "$EXECUTION_CONTEXT_PATH")
+LANE_PATHS=( "${ITERATIONS_DIR}/${ITER_PAD}/lanes/A" "${ITERATIONS_DIR}/${ITER_PAD}/lanes/B" )
 mkdir -p "${LANE_PATHS[0]}" "${LANE_PATHS[1]}"
 
 # _prune_lanes: remove both worktrees; safe to call multiple times
@@ -2442,7 +2854,7 @@ if [ "$WORKTREE_OK" = "true" ] && [ -n "$_SEED_PATCH" ] && [ -f "$_SEED_PATCH" ]
 fi
 ```
 
-If `WORKTREE_OK` is `false`, fall back to single-lane: use the Agent tool to launch the "engineer" agent with the original prompt (no strategy hint), writing `.signum/combined.patch` and `.signum/execute_log.json` as before — then skip ahead to "After engineer completes, validate execute success".
+If `WORKTREE_OK` is `false`, fall back to single-lane: use the Agent tool to launch the "engineer" agent with the original prompt (no strategy hint), writing `combined.patch` and `execute_log.json` under the active contract artifact root, then skip ahead to "After engineer completes, validate execute success".
 
 If `WORKTREE_OK` is `true`, launch both lane engineers in parallel using the Agent tool.
 
@@ -2450,9 +2862,8 @@ For the engineer working in `${LANE_PATHS[0]}`, use this prompt (strategy: minim
 
 ```
 STRATEGY HINT: Fix with minimal targeted changes. Patch only the specific lines flagged in findings.
-Read .signum/contract-engineer.json for scope and acceptance criteria.
-Read .signum/baseline.json for pre-existing check state.
-Read .signum/repair_brief.json for the specific issues to fix.
+The canonical artifact root in this lane is `.signum/contracts/<activeContractId>/`.
+Read `contract-engineer.json`, `baseline.json`, and `repair_brief.json` from that canonical artifact root.
 Fix ONLY the issues listed in the repair brief. Do not refactor, do not add features.
 After fixing, run the visible AC verifies to confirm you didn't break them.
 Write ${LANE_PATHS[0]}/combined.patch and ${LANE_PATHS[0]}/execute_log.json.
@@ -2463,9 +2874,8 @@ For the engineer working in `${LANE_PATHS[1]}`, use this prompt (strategy: root 
 
 ```
 STRATEGY HINT: Fix by addressing the root cause. May touch more files if the findings share a common underlying issue.
-Read .signum/contract-engineer.json for scope and acceptance criteria.
-Read .signum/baseline.json for pre-existing check state.
-Read .signum/repair_brief.json for the specific issues to fix.
+The canonical artifact root in this lane is `.signum/contracts/<activeContractId>/`.
+Read `contract-engineer.json`, `baseline.json`, and `repair_brief.json` from that canonical artifact root.
 Fix ONLY the issues listed in the repair brief. Do not refactor, do not add features.
 After fixing, run the visible AC verifies to confirm you didn't break them.
 Write ${LANE_PATHS[1]}/combined.patch and ${LANE_PATHS[1]}/execute_log.json.
@@ -2489,7 +2899,7 @@ _lane_score() {
 
 SCORE_A=$(_lane_score "${LANE_PATHS[0]}")
 SCORE_B=$(_lane_score "${LANE_PATHS[1]}")
-LANE_SELECTED_DIR=".signum/iterations/$ITER_PAD/lanes"
+LANE_SELECTED_DIR="${ITERATIONS_DIR}/${ITER_PAD}/lanes"
 
 if [ "$SCORE_A" -ge "$SCORE_B" ]; then
   WINNER_LANE="A"; RUNNER_UP_LANE="B"
@@ -2520,14 +2930,22 @@ If the winner receives a MAJOR or CRITICAL finding after the panel, also send th
 **Copy winner artifacts to iteration root:**
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
 if [ "$WINNER_LANE" = "A" ]; then WINNER_DIR="${LANE_PATHS[0]}"; else WINNER_DIR="${LANE_PATHS[1]}"; fi
-cp "$WINNER_DIR/combined.patch" .signum/combined.patch
-cp "$WINNER_DIR/execute_log.json" .signum/execute_log.json 2>/dev/null || true
-cp "$WINNER_DIR/mechanic_report.json" .signum/mechanic_report.json 2>/dev/null || true
-cp "$WINNER_DIR/holdout_report.json" .signum/holdout_report.json 2>/dev/null || true
-mkdir -p .signum/reviews
-cp "$WINNER_DIR/reviews/"*.json .signum/reviews/ 2>/dev/null || true
-cp "$WINNER_DIR/audit_summary.json" .signum/audit_summary.json 2>/dev/null || true
+cp "$WINNER_DIR/combined.patch" "$COMBINED_PATCH_PATH"
+cp "$WINNER_DIR/execute_log.json" "$EXECUTE_LOG_PATH" 2>/dev/null || true
+cp "$WINNER_DIR/mechanic_report.json" "$MECHANIC_REPORT_PATH" 2>/dev/null || true
+cp "$WINNER_DIR/holdout_report.json" "$HOLDOUT_REPORT_PATH" 2>/dev/null || true
+mkdir -p "$REVIEWS_DIR"
+cp "$WINNER_DIR/reviews/"*.json "$REVIEWS_DIR/" 2>/dev/null || true
+cp "$WINNER_DIR/audit_summary.json" "$AUDIT_SUMMARY_PATH" 2>/dev/null || true
 ```
 
 **Run boundary verification on winner BEFORE pruning worktrees (receipt chain):**
@@ -2535,6 +2953,23 @@ cp "$WINNER_DIR/audit_summary.json" .signum/audit_summary.json 2>/dev/null || tr
 Boundary verification must run while the winner worktree still exists — it needs the live workspace to verify file hashes, scope integrity, and AC evidence. Pruning worktrees before verification would cause the verifier to run against stale main checkout.
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+SNAPSHOTS_DIR="${ARTIFACT_ROOT}snapshots"
+RECEIPTS_DIR="${ARTIFACT_ROOT}receipts"
+RUNS_DIR="${ARTIFACT_ROOT}runs"
+WINNER_SIGNUM_DIR="${WINNER_DIR}/.signum"
+WINNER_ACTIVE_CONTRACT_ID=$(jq -r '.activeContractId // empty' "${WINNER_SIGNUM_DIR}/contracts/index.json" 2>/dev/null || true)
+if [ -z "$WINNER_ACTIVE_CONTRACT_ID" ]; then
+  WINNER_ACTIVE_CONTRACT_ID="$(get_active_contract 2>/dev/null || true)"
+fi
+if [ -n "$WINNER_ACTIVE_CONTRACT_ID" ]; then
+  WINNER_ARTIFACT_ROOT="${WINNER_SIGNUM_DIR}/contracts/${WINNER_ACTIVE_CONTRACT_ID}/"
+else
+  WINNER_ARTIFACT_ROOT="${WINNER_SIGNUM_DIR}/"
+fi
+
 # Re-resolve boundary-verifier.sh and transition-verifier.sh (fresh shell)
 _SIGNUM_BOUNDARY=""
 _SIGNUM_TRANSITION=""
@@ -2553,26 +2988,26 @@ if [ -n "$_SIGNUM_BOUNDARY" ]; then
   ATTEMPT_PAD=$(printf '%02d' "$((CURRENT_ITERATION + 1))")
   if ! bash "$_SIGNUM_BOUNDARY" execute \
     --workspace-root "$WINNER_DIR" \
-    --signum-dir "$WINNER_DIR/.signum" \
-    --contract "$WINNER_DIR/.signum/contract-engineer.json" \
-    --contract-full "$WINNER_DIR/.signum/contract.json" \
-    --snapshot ".signum/snapshots/execute-attempt-${ATTEMPT_PAD}.json"; then
+    --signum-dir "$WINNER_SIGNUM_DIR" \
+    --contract "${WINNER_ARTIFACT_ROOT}contract-engineer.json" \
+    --contract-full "${WINNER_ARTIFACT_ROOT}contract.json" \
+    --snapshot "${SNAPSHOTS_DIR}/execute-attempt-${ATTEMPT_PAD}.json"; then
     echo "BOUNDARY_BLOCK: repair attempt $((CURRENT_ITERATION + 1)) failed boundary verification"
     RECEIPT_CHAIN_OK=false
   fi
-  # Copy receipt from winner worktree to root .signum
-  _CURRENT_RUN_ID=$(jq -r '.run_id // empty' .signum/execution_context.json)
-  mkdir -p ".signum/receipts" ".signum/runs/$_CURRENT_RUN_ID"
-  cp "$WINNER_DIR/.signum/receipts/execute.json" .signum/receipts/execute.json 2>/dev/null || true
-  if [ -d "$WINNER_DIR/.signum/runs/$_CURRENT_RUN_ID" ]; then
-    cp "$WINNER_DIR/.signum/runs/$_CURRENT_RUN_ID/execute-"*.json \
-      ".signum/runs/$_CURRENT_RUN_ID/" 2>/dev/null || true
+  # Copy receipt from winner worktree into the canonical artifact root.
+  _CURRENT_RUN_ID=$(jq -r '.run_id // empty' "$EXECUTION_CONTEXT_PATH")
+  mkdir -p "$RECEIPTS_DIR" "$RUNS_DIR/$_CURRENT_RUN_ID"
+  cp "${WINNER_ARTIFACT_ROOT}receipts/execute.json" "$RECEIPTS_DIR/execute.json" 2>/dev/null || true
+  if [ -d "${WINNER_ARTIFACT_ROOT}runs/$_CURRENT_RUN_ID" ]; then
+    cp "${WINNER_ARTIFACT_ROOT}runs/$_CURRENT_RUN_ID/execute-"*.json \
+      "$RUNS_DIR/$_CURRENT_RUN_ID/" 2>/dev/null || true
   fi
 fi
 if [ "$RECEIPT_CHAIN_OK" = "true" ] && [ -n "$_SIGNUM_TRANSITION" ]; then
   ATTEMPT_PAD=$(printf '%02d' "$((CURRENT_ITERATION + 1))")
   if ! bash "$_SIGNUM_TRANSITION" execute audit \
-    --snapshot ".signum/snapshots/execute-attempt-${ATTEMPT_PAD}.json"; then
+    --snapshot "${SNAPSHOTS_DIR}/execute-attempt-${ATTEMPT_PAD}.json"; then
     echo "TRANSITION_BLOCK: repair attempt $((CURRENT_ITERATION + 1)) failed transition gate"
     RECEIPT_CHAIN_OK=false
   fi
@@ -2591,51 +3026,57 @@ If `RECEIPT_CHAIN_OK` is `false`, **STOP** the repair iteration. Do not proceed 
 **After engineer completes, validate execute success before re-running audit:**
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+ITERATION_DELTA_PATH="${ARTIFACT_ROOT}iteration_delta.patch"
+
 # Execute success gate: verify engineer produced NEW artifacts (stale ones were cleared above)
-if [ ! -f .signum/execute_log.json ]; then
-  echo "REPAIR_SKIP: execute_log.json missing after repair engineer — skipping iteration $ITER_NUM"
+if [ ! -f "$EXECUTE_LOG_PATH" ]; then
+  echo "REPAIR_SKIP: execute_log.json missing after repair engineer - skipping iteration $ITER_NUM"
   CURRENT_ITERATION=$ITER_NUM
   continue
 fi
-REPAIR_STATUS=$(jq -r '.status // "unknown"' .signum/execute_log.json)
+REPAIR_STATUS=$(jq -r '.status // "unknown"' "$EXECUTE_LOG_PATH")
 if [ "$REPAIR_STATUS" != "SUCCESS" ]; then
-  echo "REPAIR_SKIP: execute_log.json status=$REPAIR_STATUS (not SUCCESS) — skipping iteration $ITER_NUM"
+  echo "REPAIR_SKIP: execute_log.json status=$REPAIR_STATUS (not SUCCESS) - skipping iteration $ITER_NUM"
   CURRENT_ITERATION=$ITER_NUM
   continue
 fi
-if [ ! -f .signum/combined.patch ]; then
-  echo "REPAIR_SKIP: combined.patch missing after repair engineer — skipping iteration $ITER_NUM"
+if [ ! -f "$COMBINED_PATCH_PATH" ]; then
+  echo "REPAIR_SKIP: combined.patch missing after repair engineer - skipping iteration $ITER_NUM"
   CURRENT_ITERATION=$ITER_NUM
   continue
 fi
-echo "Repair engineer succeeded for iteration $ITER_NUM — proceeding to audit"
+echo "Repair engineer succeeded for iteration $ITER_NUM - proceeding to audit"
 
 # Compute iteration delta by diffing the two stored patches (best candidate vs current)
 # The engineer already wrote combined.patch; we diff it against the best iteration's patch
-BEST_PATCH=".signum/iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch"
+BEST_PATCH="${ARTIFACT_ROOT}iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch"
 if [ -f "$BEST_PATCH" ]; then
   # Delta = lines in current patch that differ from best candidate's patch
   # Use diff on the applied file states, not on patch text
   # Simpler: extract file lists from both patches and diff only changed files
-  diff -u "$BEST_PATCH" .signum/combined.patch > .signum/iteration_delta.patch 2>/dev/null || true
+  diff -u "$BEST_PATCH" "$COMBINED_PATCH_PATH" > "$ITERATION_DELTA_PATH" 2>/dev/null || true
 else
   # No best patch to compare against (shouldn't happen after pass 1)
-  cp .signum/combined.patch .signum/iteration_delta.patch 2>/dev/null || true
+  cp "$COMBINED_PATCH_PATH" "$ITERATION_DELTA_PATH" 2>/dev/null || true
 fi
-DELTA_SIZE=$(wc -c < .signum/iteration_delta.patch 2>/dev/null || echo 0)
-FULL_SIZE=$(wc -c < .signum/combined.patch 2>/dev/null || echo 0)
+DELTA_SIZE=$(wc -c < "$ITERATION_DELTA_PATH" 2>/dev/null || echo 0)
+FULL_SIZE=$(wc -c < "$COMBINED_PATCH_PATH" 2>/dev/null || echo 0)
 echo "Delta: $DELTA_SIZE bytes, Full: $FULL_SIZE bytes"
 
 if [ "$DELTA_SIZE" -eq 0 ]; then
-  echo "Delta empty — marking as non-improving"
+  echo "Delta empty - marking as non-improving"
   NO_IMPROVE_COUNT=$((NO_IMPROVE_COUNT + 1))
   CURRENT_ITERATION=$ITER_NUM
   continue
 fi
 
 if [ "$FULL_SIZE" -gt 0 ] && [ $((DELTA_SIZE * 100 / FULL_SIZE)) -gt 80 ]; then
-  echo "Delta >80% of full patch — full-diff-only review for this iteration"
-  rm -f .signum/iteration_delta.patch
+  echo "Delta >80% of full patch - full-diff-only review for this iteration"
+  reset_active_artifact "iteration_delta.patch"
 fi
 ```
 
@@ -2646,49 +3087,54 @@ Re-run Steps 2.4 (scope gate), 2.4.5 (policy compliance if applicable), 2.4.6 (s
 Pass `currentIteration` to the synthesizer prompt:
 
 ```
-Read .signum/mechanic_report.json, .signum/reviews/claude.json,
-.signum/reviews/codex.json, .signum/reviews/gemini.json,
-.signum/holdout_report.json, .signum/execute_log.json,
-and .signum/audit_iteration_log.json.
+The canonical artifact root for this synthesis is `.signum/contracts/<activeContractId>/`.
+Read `mechanic_report.json`, `reviews/claude.json`, `reviews/codex.json`, `reviews/gemini.json`, `holdout_report.json`, `execute_log.json`, and `audit_iteration_log.json` from that canonical artifact root.
 Current iteration: <N>.
-Apply deterministic synthesis rules, compute confidence and iteration scores,
-and write .signum/audit_summary.json.
+Apply deterministic synthesis rules, compute confidence and iteration scores, and write `audit_summary.json` to that same canonical artifact root.
 ```
 
 **After synthesizer, store iteration artifacts and update tracking:**
 
 ```bash
-ITER_DIR=".signum/iterations/$(printf '%02d' $ITER_NUM)"
-mkdir -p "$ITER_DIR/reviews"
-cp .signum/combined.patch "$ITER_DIR/"
-cp .signum/iteration_delta.patch "$ITER_DIR/" 2>/dev/null || true
-cp .signum/mechanic_report.json "$ITER_DIR/"
-cp .signum/holdout_report.json "$ITER_DIR/" 2>/dev/null || true
-cp .signum/execute_log.json "$ITER_DIR/" 2>/dev/null || true
-cp .signum/reviews/*.json "$ITER_DIR/reviews/" 2>/dev/null || true
-cp .signum/audit_summary.json "$ITER_DIR/"
-cp .signum/repair_brief.json "$ITER_DIR/"
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+ITER_DIR="${ARTIFACT_ROOT}iterations/$(printf '%02d' $ITER_NUM)"
+ITER_REVIEWS_DIR="${ITER_DIR}/reviews"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+ITERATION_DELTA_PATH="${ARTIFACT_ROOT}iteration_delta.patch"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+REPAIR_BRIEF_PATH="${ARTIFACT_ROOT}repair_brief.json"
+AUDIT_ITERATION_LOG_PATH="${ARTIFACT_ROOT}audit_iteration_log.json"
+mkdir -p "$ITER_REVIEWS_DIR"
+cp "$COMBINED_PATCH_PATH" "$ITER_DIR/"
+cp "$ITERATION_DELTA_PATH" "$ITER_DIR/" 2>/dev/null || true
+cp "$MECHANIC_REPORT_PATH" "$ITER_DIR/"
+cp "$HOLDOUT_REPORT_PATH" "$ITER_DIR/" 2>/dev/null || true
+cp "$EXECUTE_LOG_PATH" "$ITER_DIR/" 2>/dev/null || true
+cp "$REVIEWS_DIR/"*.json "$ITER_REVIEWS_DIR/" 2>/dev/null || true
+cp "$AUDIT_SUMMARY_PATH" "$ITER_DIR/"
+cp "$REPAIR_BRIEF_PATH" "$ITER_DIR/"
 
 # Read new score
-NEW_SCORE=$(jq -r '.iterationScore // 0' .signum/audit_summary.json)
-NEW_DECISION=$(jq -r '.decision' .signum/audit_summary.json)
+NEW_SCORE=$(jq -r '.iterationScore // 0' "$AUDIT_SUMMARY_PATH")
+NEW_DECISION=$(jq -r '.decision' "$AUDIT_SUMMARY_PATH")
 
 # Extract deduplicated findings with fingerprints for cross-iteration comparison
-NEW_FINDINGS=$(jq '[.reviews[].findings[]? | {fingerprint: .fingerprint, severity: .severity, category: .category, file: .file, line: .line}] | unique_by(.fingerprint // (.file + ":" + (.line | tostring) + ":" + .category))' .signum/audit_summary.json)
+NEW_FINDINGS=$(jq '[.reviews[].findings[]? | {fingerprint: .fingerprint, severity: .severity, category: .category, file: .file, line: .line}] | unique_by(.fingerprint // (.file + ":" + (.line | tostring) + ":" + .category))' "$AUDIT_SUMMARY_PATH")
 NEW_FINDINGS_COUNT=$(jq '{
   critical: [.reviews[].findings[]? | select(.severity == "CRITICAL")] | length,
   major: [.reviews[].findings[]? | select(.severity == "MAJOR")] | length,
   minor: [.reviews[].findings[]? | select(.severity == "MINOR")] | length
-}' .signum/audit_summary.json)
+}' "$AUDIT_SUMMARY_PATH")
 
 # Update iteration log
-MECH_REG=$(jq -r '.hasRegressions' .signum/mechanic_report.json 2>/dev/null || echo "false")
-HOLDOUT_FAIL=$(jq '.failed // 0' .signum/holdout_report.json 2>/dev/null || echo 0)
-jq --argjson score "$NEW_SCORE" --arg decision "$NEW_DECISION" --argjson pass "$ITER_NUM" --argjson findings "$NEW_FINDINGS" --argjson findingsCount "$NEW_FINDINGS_COUNT" \
-  --arg mechReg "$MECH_REG" --argjson holdoutFail "$HOLDOUT_FAIL" \
-  '. + [{"pass": $pass, "score": $score, "decision": $decision, "findingsCount": $findingsCount, "canonicalFindings": $findings, "mechanicRegressions": ($mechReg == "true"), "holdoutFailures": $holdoutFail}]' \
-  .signum/audit_iteration_log.json > .signum/audit_iteration_log.json.tmp \
-  && mv .signum/audit_iteration_log.json.tmp .signum/audit_iteration_log.json
+MECH_REG=$(jq -r '.hasRegressions' "$MECHANIC_REPORT_PATH" 2>/dev/null || echo "false")
+HOLDOUT_FAIL=$(jq '.failed // 0' "$HOLDOUT_REPORT_PATH" 2>/dev/null || echo 0)
+jq --argjson score "$NEW_SCORE" --arg decision "$NEW_DECISION" --argjson pass "$ITER_NUM" --argjson findings "$NEW_FINDINGS" --argjson findingsCount "$NEW_FINDINGS_COUNT"   --arg mechReg "$MECH_REG" --argjson holdoutFail "$HOLDOUT_FAIL"   '. + [{"pass": $pass, "score": $score, "decision": $decision, "findingsCount": $findingsCount, "canonicalFindings": $findings, "mechanicRegressions": ($mechReg == "true"), "holdoutFailures": $holdoutFail}]'   "$AUDIT_ITERATION_LOG_PATH" > "${AUDIT_ITERATION_LOG_PATH}.tmp"   && mv "${AUDIT_ITERATION_LOG_PATH}.tmp" "$AUDIT_ITERATION_LOG_PATH"
 
 # Update best tracking
 if [ "$NEW_SCORE" -gt "$BEST_SCORE" ] || [ "$NEW_SCORE" -eq "$BEST_SCORE" -a "$ITER_NUM" -le "$BEST_ITERATION" ]; then
@@ -2723,38 +3169,46 @@ ITERATIONS_USED=$CURRENT_ITERATION
 
 RESTORE_FAILED=false
 if [ "$BEST_ITERATION" -ne "$CURRENT_ITERATION" ]; then
-  echo "Restoring best candidate from iteration $BEST_ITERATION"
-  # Rollback using stored patch: revert only files listed in current iteration's combined.patch
-  BASE=$(jq -r '.base_commit' .signum/execution_context.json)
-  PATCH_FILES=$(grep '^diff --git' .signum/combined.patch | sed 's|^diff --git a/||; s| b/.*||' | sort -u)
-  for f in $PATCH_FILES; do
-    git checkout "$BASE" -- "$f" 2>/dev/null || rm -f "$f" 2>/dev/null || true
-  done
-  # Always sync audit artifacts from best iteration so PACK reads consistent data
-  BEST_DIR=".signum/iterations/$(printf '%02d' $BEST_ITERATION)"
-  cp "${BEST_DIR}/combined.patch" .signum/
-  cp "${BEST_DIR}/iteration_delta.patch" .signum/ 2>/dev/null || rm -f .signum/iteration_delta.patch
-  cp "${BEST_DIR}/mechanic_report.json" .signum/
-  cp "${BEST_DIR}/holdout_report.json" .signum/ 2>/dev/null || true
-  cp "${BEST_DIR}/execute_log.json" .signum/ 2>/dev/null || true
-  rm -f .signum/reviews/*.json
-  cp "${BEST_DIR}/reviews/"*.json .signum/reviews/ 2>/dev/null || true
-  cp "${BEST_DIR}/audit_summary.json" .signum/
+echo "Restoring best candidate from iteration $BEST_ITERATION"
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+ITERATION_DELTA_PATH="${ARTIFACT_ROOT}iteration_delta.patch"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+# Rollback using stored patch: revert only files listed in current iteration's combined.patch
+BASE=$(jq -r '.base_commit' "$EXECUTION_CONTEXT_PATH")
+PATCH_FILES=$(grep '^diff --git' "$COMBINED_PATCH_PATH" | sed 's|^diff --git a/||; s| b/.*||' | sort -u)
+for f in $PATCH_FILES; do
+  git checkout "$BASE" -- "$f" 2>/dev/null || rm -f "$f" 2>/dev/null || true
+done
+# Always sync audit artifacts from best iteration so PACK reads consistent data
+BEST_DIR="${ARTIFACT_ROOT}iterations/$(printf '%02d' $BEST_ITERATION)"
+cp "${BEST_DIR}/combined.patch" "$COMBINED_PATCH_PATH"
+cp "${BEST_DIR}/iteration_delta.patch" "$ITERATION_DELTA_PATH" 2>/dev/null || reset_active_artifact "iteration_delta.patch"
+cp "${BEST_DIR}/mechanic_report.json" "$MECHANIC_REPORT_PATH"
+cp "${BEST_DIR}/holdout_report.json" "$HOLDOUT_REPORT_PATH" 2>/dev/null || true
+cp "${BEST_DIR}/execute_log.json" "$EXECUTE_LOG_PATH" 2>/dev/null || true
+rm -f "$REVIEWS_DIR/"*.json
+cp "${BEST_DIR}/reviews/"*.json "$REVIEWS_DIR/" 2>/dev/null || true
+cp "${BEST_DIR}/audit_summary.json" "$AUDIT_SUMMARY_PATH"
 
-  if ! git apply .signum/iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch; then
-    echo "ERROR: Failed to apply best candidate patch — forcing HUMAN_REVIEW"
+if ! git apply "${ARTIFACT_ROOT}iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch"; then
+    echo "ERROR: Failed to apply best candidate patch - forcing HUMAN_REVIEW"
     RESTORE_FAILED=true
     FINAL_DECISION="HUMAN_REVIEW"
     # Override decision in the already-synced audit_summary
-    jq '.decision = "HUMAN_REVIEW" | .terminalReason = "final restore of best candidate patch failed"' \
-      .signum/audit_summary.json > .signum/audit_summary.json.tmp \
-      && mv .signum/audit_summary.json.tmp .signum/audit_summary.json
+    jq '.decision = "HUMAN_REVIEW" | .terminalReason = "final restore of best candidate patch failed"'       "$AUDIT_SUMMARY_PATH" > "${AUDIT_SUMMARY_PATH}.tmp"       && mv "${AUDIT_SUMMARY_PATH}.tmp" "$AUDIT_SUMMARY_PATH"
   fi
 fi
 
 # Determine terminal decision from best candidate
 if [ "$RESTORE_FAILED" != "true" ]; then
-  FINAL_DECISION=$(jq -r '.decision' .signum/audit_summary.json)
+  FINAL_DECISION=$(jq -r '.decision' "$AUDIT_SUMMARY_PATH")
 fi
 EARLY_STOP=$( [ "$NO_IMPROVE_COUNT" -ge 2 ] && echo "true" || echo "false" )
 EARLY_STOP_REASON=""
@@ -2762,28 +3216,22 @@ EARLY_STOP_REASON=""
 [ "$CURRENT_ITERATION" -ge "$MAX_ITERATIONS" ] && EARLY_STOP="true" && EARLY_STOP_REASON="max iterations reached"
 
 # Write iteration metadata unconditionally so PACK always has correct fields
-jq --argjson iters_used "$ITERATIONS_USED" \
-   --argjson iters_max "$MAX_ITERATIONS" \
-   --argjson best "$BEST_ITERATION" \
-   --arg early_stop "$EARLY_STOP" \
-   --arg early_stop_reason "$EARLY_STOP_REASON" \
-   '. + {
+jq --argjson iters_used "$ITERATIONS_USED"    --argjson iters_max "$MAX_ITERATIONS"    --argjson best "$BEST_ITERATION"    --arg early_stop "$EARLY_STOP"    --arg early_stop_reason "$EARLY_STOP_REASON"    '. + {
      iterationsUsed: $iters_used,
      iterationsMax: $iters_max,
      bestIteration: $best,
      earlyStop: ($early_stop == "true"),
      earlyStopReason: (if $early_stop_reason != "" then $early_stop_reason else null end)
-   }' .signum/audit_summary.json > .signum/audit_summary.json.tmp \
-   && mv .signum/audit_summary.json.tmp .signum/audit_summary.json
+   }' "$AUDIT_SUMMARY_PATH" > "${AUDIT_SUMMARY_PATH}.tmp"    && mv "${AUDIT_SUMMARY_PATH}.tmp" "$AUDIT_SUMMARY_PATH"
 
 if [ "$RESTORE_FAILED" != "true" ]; then
   # Terminal override based on remaining findings in best candidate
-  REMAINING_CRITICAL=$(jq '[.reviews[].findings[]? | select(.severity == "CRITICAL")] | length' .signum/audit_summary.json)
-  REMAINING_MAJOR=$(jq '[.reviews[].findings[]? | select(.severity == "MAJOR")] | length' .signum/audit_summary.json)
-  REMAINING_MINOR=$(jq '[.reviews[].findings[]? | select(.severity == "MINOR")] | length' .signum/audit_summary.json)
+  REMAINING_CRITICAL=$(jq '[.reviews[].findings[]? | select(.severity == "CRITICAL")] | length' "$AUDIT_SUMMARY_PATH")
+  REMAINING_MAJOR=$(jq '[.reviews[].findings[]? | select(.severity == "MAJOR")] | length' "$AUDIT_SUMMARY_PATH")
+  REMAINING_MINOR=$(jq '[.reviews[].findings[]? | select(.severity == "MINOR")] | length' "$AUDIT_SUMMARY_PATH")
 
-  BEST_MECH_REGRESSIONS=$(jq -r '.hasRegressions' .signum/mechanic_report.json 2>/dev/null || echo "false")
-  BEST_HOLDOUT_FAILED=$(jq '.failed // 0' .signum/holdout_report.json 2>/dev/null || echo 0)
+  BEST_MECH_REGRESSIONS=$(jq -r '.hasRegressions' "$MECHANIC_REPORT_PATH" 2>/dev/null || echo "false")
+  BEST_HOLDOUT_FAILED=$(jq '.failed // 0' "$HOLDOUT_REPORT_PATH" 2>/dev/null || echo 0)
 
   if [ "$REMAINING_CRITICAL" -gt 0 ]; then
     FINAL_DECISION="AUTO_BLOCK"
@@ -2808,15 +3256,11 @@ if [ "$RESTORE_FAILED" != "true" ]; then
   fi
 
   # Update audit_summary with decision metadata
-  jq --arg remaining_sev "$REMAINING_SEV" \
-     --arg final_decision "$FINAL_DECISION" \
-     --arg terminal_reason "$TERMINAL_REASON" \
-     '. + {
+  jq --arg remaining_sev "$REMAINING_SEV"      --arg final_decision "$FINAL_DECISION"      --arg terminal_reason "$TERMINAL_REASON"      '. + {
        decision: $final_decision,
        terminalReason: (if $final_decision != "AUTO_OK" then $terminal_reason else null end),
        remainingSeverity: $remaining_sev
-     }' .signum/audit_summary.json > .signum/audit_summary.json.tmp \
-     && mv .signum/audit_summary.json.tmp .signum/audit_summary.json
+     }' "$AUDIT_SUMMARY_PATH" > "${AUDIT_SUMMARY_PATH}.tmp"      && mv "${AUDIT_SUMMARY_PATH}.tmp" "$AUDIT_SUMMARY_PATH"
 fi
 
 echo "=== ITERATIVE AUDIT COMPLETE ==="
@@ -2840,11 +3284,15 @@ Proceed to Phase 4: PACK.
 Transition the contract status from `active` to `completed` and record the `completedAt` timestamp:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+CONTRACT_TMP_PATH="${CONTRACT_PATH%.json}-tmp.json"
 COMPLETED_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 jq --arg ts "$COMPLETED_TS" \
   '.status = "completed" | .timestamps.completedAt = $ts' \
-  .signum/contract.json > .signum/contract-tmp.json && \
-  mv .signum/contract-tmp.json .signum/contract.json
+  "$CONTRACT_PATH" > "$CONTRACT_TMP_PATH" && \
+  mv "$CONTRACT_TMP_PATH" "$CONTRACT_PATH"
 echo "Contract status: active → completed at $COMPLETED_TS"
 ```
 
@@ -2874,34 +3322,55 @@ file_size() {
   wc -c < "$f" | tr -d ' '
 }
 
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+BASELINE_PATH="${ARTIFACT_ROOT}baseline.json"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+POLICY_SCAN_PATH="${ARTIFACT_ROOT}policy_scan.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+APPROVAL_PATH="${ARTIFACT_ROOT}approval.json"
+PROOFPACK_PATH="${ARTIFACT_ROOT}proofpack.json"
+ANTI_ENTROPY_PATH="${ARTIFACT_ROOT}anti_entropy_report.json"
+CONTRACT_HASH_PATH="${ARTIFACT_ROOT}contract-hash.txt"
+EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+AUDIT_ITERATION_LOG_PATH="${ARTIFACT_ROOT}audit_iteration_log.json"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+RECEIPTS_EXEC_PATH="${ARTIFACT_ROOT}receipts/execute.json"
+
 # Metadata
-DECISION=$(jq -r '.decision' .signum/audit_summary.json)
-GOAL=$(jq -r '.goal' .signum/contract.json)
-RISK=$(jq -r '.riskLevel' .signum/contract.json)
-ATTEMPTS=$(jq -r '.totalAttempts' .signum/execute_log.json 2>/dev/null || echo "unknown")
-MECHANIC=$(jq -r '.mechanic' .signum/audit_summary.json)
-CONFIDENCE=$(jq -r '.confidence.overall // 0' .signum/audit_summary.json)
+DECISION=$(jq -r '.decision' "$AUDIT_SUMMARY_PATH")
+GOAL=$(jq -r '.goal' "$CONTRACT_PATH")
+RISK=$(jq -r '.riskLevel' "$CONTRACT_PATH")
+ATTEMPTS=$(jq -r '.totalAttempts' "$EXECUTE_LOG_PATH" 2>/dev/null || echo "unknown")
+MECHANIC=$(jq -r '.mechanic' "$AUDIT_SUMMARY_PATH")
+CONFIDENCE=$(jq -r '.confidence.overall // 0' "$AUDIT_SUMMARY_PATH")
 RUN_DATE=$(date +%Y-%m-%dT%H:%M:%SZ)
 RUN_RANDOM=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 6)
 RUN_ID="signum-$(date +%Y-%m-%d)-${RUN_RANDOM}"
 
 # Audit chain
-CONTRACT_HASH=$(grep 'contract_sha256:' .signum/contract-hash.txt 2>/dev/null | awk '{print $2}' || echo "unavailable")
-APPROVED_AT=$(grep 'approved_at:' .signum/contract-hash.txt 2>/dev/null | awk '{print $2}' || echo "unavailable")
-BASE_COMMIT=$(jq -r '.base_commit // "unavailable"' .signum/execution_context.json 2>/dev/null || echo "unavailable")
+CONTRACT_HASH=$(grep 'contract_sha256:' "$CONTRACT_HASH_PATH" 2>/dev/null | awk '{print $2}' || echo "unavailable")
+APPROVED_AT=$(grep 'approved_at:' "$CONTRACT_HASH_PATH" 2>/dev/null | awk '{print $2}' || echo "unavailable")
+BASE_COMMIT=$(jq -r '.base_commit // "unavailable"' "$EXECUTION_CONTEXT_PATH" 2>/dev/null || echo "unavailable")
 
 # Contract redaction: strip holdoutScenarios, save to temp file
 REDACTED_CONTRACT=$(mktemp /tmp/signum-contract-redacted.XXXXXX.json)
-python3 -c "
-import json, sys
-with open('.signum/contract.json') as f:
+python3 - "$CONTRACT_PATH" <<'PY' > "$REDACTED_CONTRACT"
+import json
+import sys
+
+with open(sys.argv[1]) as f:
     data = json.load(f)
 data.pop('holdoutScenarios', None)
 json.dump(data, sys.stdout)
-" > "$REDACTED_CONTRACT"
+PY
 
 CONTRACT_SHA256=$(hash_file "$REDACTED_CONTRACT")
-CONTRACT_FULL_SHA256=$(hash_file .signum/contract.json)
+CONTRACT_FULL_SHA256=$(hash_file "$CONTRACT_PATH")
 
 # Envelope builder: embeds file content if <=102400 bytes, else omits
 # JSON files (.json) are embedded as objects, text files as strings
@@ -2942,34 +3411,34 @@ else
 fi
 
 # Diff embedding
-DIFF_ENV=$(build_envelope .signum/combined.patch)
+DIFF_ENV=$(build_envelope "$COMBINED_PATCH_PATH")
 
 # Baseline envelope (optional artifact)
-BASELINE_ENV=$(build_envelope .signum/baseline.json)
+BASELINE_ENV=$(build_envelope "$BASELINE_PATH")
 
 # Execute log envelope
-EXECUTE_ENV=$(build_envelope .signum/execute_log.json)
+EXECUTE_ENV=$(build_envelope "$EXECUTE_LOG_PATH")
 
 # Mechanic and holdout envelopes
-MECHANIC_ENV=$(build_envelope .signum/mechanic_report.json)
-HOLDOUT_ENV=$(build_envelope .signum/holdout_report.json)
+MECHANIC_ENV=$(build_envelope "$MECHANIC_REPORT_PATH")
+HOLDOUT_ENV=$(build_envelope "$HOLDOUT_REPORT_PATH")
 
 # Policy scan envelope — written to temp file so jq reads content directly,
 # avoiding shell variable limits on large reports.
 POLICY_SCAN_ENV_TMP=$(mktemp)
 trap 'rm -f "$POLICY_SCAN_ENV_TMP"' EXIT
-build_envelope .signum/policy_scan.json > "$POLICY_SCAN_ENV_TMP"
+build_envelope "$POLICY_SCAN_PATH" > "$POLICY_SCAN_ENV_TMP"
 
 # Audit summary envelope
-AUDIT_ENV=$(build_envelope .signum/audit_summary.json)
+AUDIT_ENV=$(build_envelope "$AUDIT_SUMMARY_PATH")
 
 # Approval envelope
-APPROVAL_ENV=$(build_envelope .signum/approval.json)
+APPROVAL_ENV=$(build_envelope "$APPROVAL_PATH")
 
-# Dynamic reviews: enumerate .signum/reviews/*.json
+# Dynamic reviews: enumerate canonical reviews/*.json
 REVIEWS_JSON='{'
 first=1
-for review_file in .signum/reviews/*.json; do
+for review_file in "$REVIEWS_DIR"/*.json; do
   [ -f "$review_file" ] || continue
   provider=$(basename "$review_file" .json)
   env_json=$(build_envelope "$review_file")
@@ -3023,23 +3492,23 @@ if [ -n "$PREV_PROOFPACK" ] && [ -f "$PREV_PROOFPACK" ]; then
 fi
 
 # Extract contractId for lineage
-PACK_CONTRACT_ID=$(jq -r '.contractId // empty' .signum/contract.json)
+PACK_CONTRACT_ID=$(jq -r '.contractId // empty' "$CONTRACT_PATH")
 
 # Read iteration metadata for iterativeAudit section
-ITERATIONS_USED_PACK=$(jq -r '.iterationsUsed // 1' .signum/audit_summary.json 2>/dev/null || echo 1)
-BEST_ITERATION_PACK=$(jq -r '.bestIteration // 1' .signum/audit_summary.json 2>/dev/null || echo 1)
+ITERATIONS_USED_PACK=$(jq -r '.iterationsUsed // 1' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo 1)
+BEST_ITERATION_PACK=$(jq -r '.bestIteration // 1' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo 1)
 ITERATIVE_AUDIT_JSON="null"
-if [ "$ITERATIONS_USED_PACK" -gt 1 ] && [ -f .signum/audit_iteration_log.json ]; then
+if [ "$ITERATIONS_USED_PACK" -gt 1 ] && [ -f "$AUDIT_ITERATION_LOG_PATH" ]; then
   # Read audit_summary metadata fields required by iterativeAudit schema
-  PACK_ITERS_MAX=$(jq -r '.iterationsMax // 20' .signum/audit_summary.json 2>/dev/null || echo 20)
-  PACK_EARLY_STOP=$(jq -r '.earlyStop // false' .signum/audit_summary.json 2>/dev/null || echo false)
-  PACK_EARLY_STOP_REASON=$(jq -r '.earlyStopReason // ""' .signum/audit_summary.json 2>/dev/null || echo "")
-  PACK_TERMINAL_REASON=$(jq -r '.terminalReason // ""' .signum/audit_summary.json 2>/dev/null || echo "")
-  PACK_REMAINING_SEV=$(jq -r '.remainingSeverity // "none"' .signum/audit_summary.json 2>/dev/null || echo "none")
+  PACK_ITERS_MAX=$(jq -r '.iterationsMax // 20' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo 20)
+  PACK_EARLY_STOP=$(jq -r '.earlyStop // false' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo false)
+  PACK_EARLY_STOP_REASON=$(jq -r '.earlyStopReason // ""' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo "")
+  PACK_TERMINAL_REASON=$(jq -r '.terminalReason // ""' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo "")
+  PACK_REMAINING_SEV=$(jq -r '.remainingSeverity // "none"' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo "none")
   # Build resolvedFindings: findings present in pass 1 but absent in best pass (by fingerprint)
   # Use .pass field lookup instead of array index to handle sparse logs from skipped iterations
   PACK_RESOLVED=$(jq -n \
-    --argjson log "$(cat .signum/audit_iteration_log.json)" \
+    --argjson log "$(cat "$AUDIT_ITERATION_LOG_PATH")" \
     --argjson best "$BEST_ITERATION_PACK" \
     '($log[0].canonicalFindings // []) as $first |
      (($log[] | select(.pass == $best)).canonicalFindings // []) as $last |
@@ -3047,7 +3516,7 @@ if [ "$ITERATIONS_USED_PACK" -gt 1 ] && [ -f .signum/audit_iteration_log.json ];
      [$first[] | select((.fingerprint // (.file + ":" + (.line|tostring) + ":" + .category)) as $fp | $lastFps | index($fp) | not)]')
   # Build remainingFindings: findings present in the best pass
   # Use .pass field lookup instead of array index to handle sparse logs from skipped iterations
-  PACK_REMAINING=$(jq --argjson best "$BEST_ITERATION_PACK" '(.[].pass as $p | select($p == $best) | .canonicalFindings) // []' .signum/audit_iteration_log.json 2>/dev/null || echo "[]")
+  PACK_REMAINING=$(jq --argjson best "$BEST_ITERATION_PACK" '(.[].pass as $p | select($p == $best) | .canonicalFindings) // []' "$AUDIT_ITERATION_LOG_PATH" 2>/dev/null || echo "[]")
   ITERATIVE_AUDIT_JSON=$(jq -n \
     --argjson iters_used "$ITERATIONS_USED_PACK" \
     --argjson iters_max "$PACK_ITERS_MAX" \
@@ -3058,7 +3527,7 @@ if [ "$ITERATIONS_USED_PACK" -gt 1 ] && [ -f .signum/audit_iteration_log.json ];
     --arg remaining_sev "$PACK_REMAINING_SEV" \
     --argjson resolved "$PACK_RESOLVED" \
     --argjson remaining "$PACK_REMAINING" \
-    --argjson log "$(cat .signum/audit_iteration_log.json)" \
+    --argjson log "$(cat "$AUDIT_ITERATION_LOG_PATH")" \
     '{iterationsUsed: $iters_used, iterationsMax: $iters_max, bestIteration: $best,
       earlyStop: $early_stop, earlyStopReason: $early_stop_reason,
       terminalReason: $terminal_reason, remainingSeverity: $remaining_sev,
@@ -3067,11 +3536,11 @@ if [ "$ITERATIONS_USED_PACK" -gt 1 ] && [ -f .signum/audit_iteration_log.json ];
 fi
 
 # Receipt metadata (specpunk receipt v1 compatible fields)
-PACK_STARTED_AT=$(jq -r '.started_at // empty' .signum/execute_log.json 2>/dev/null || echo "$RUN_DATE")
-PACK_DURATION_MS=$(jq -r '.duration_ms // 0' .signum/execute_log.json 2>/dev/null || echo "0")
-PACK_RISK_LEVEL=$(jq -r '.riskLevel // "low"' .signum/contract.json 2>/dev/null || echo "low")
-PACK_RELEASE_VERDICT=$(jq -r '.releaseVerdict // "HOLD"' .signum/audit_summary.json 2>/dev/null || echo "HOLD")
-PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' .signum/audit_summary.json 2>/dev/null || echo "0")
+PACK_STARTED_AT=$(jq -r '.started_at // empty' "$EXECUTE_LOG_PATH" 2>/dev/null || echo "$RUN_DATE")
+PACK_DURATION_MS=$(jq -r '.duration_ms // 0' "$EXECUTE_LOG_PATH" 2>/dev/null || echo "0")
+PACK_RISK_LEVEL=$(jq -r '.riskLevel // "low"' "$CONTRACT_PATH" 2>/dev/null || echo "low")
+PACK_RELEASE_VERDICT=$(jq -r '.releaseVerdict // "HOLD"' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo "HOLD")
+PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo "0")
 
 # Final assembly
 jq -n \
@@ -3140,15 +3609,18 @@ jq -n \
   | if $ciContext != null then . + {ciContext: $ciContext} else . end
   | if $baselineComp != null then . + {baselineComparison: $baselineComp} else . end
   | if $iterativeAuditJson != null then . + {iterativeAudit: $iterativeAuditJson} else . end
-  ' > .signum/proofpack.json
+  ' > "$PROOFPACK_PATH"
 
 # Removal evidence (v4.7): if contract has removals or cleanupObligations, build evidence
-HAS_REMOVALS=$(jq 'if (.removals // [] | length) > 0 then "yes" else "no" end' .signum/contract.json)
-HAS_OBLIGATIONS=$(jq 'if (.cleanupObligations // [] | length) > 0 then "yes" else "no" end' .signum/contract.json)
+HAS_REMOVALS=$(jq 'if (.removals // [] | length) > 0 then "yes" else "no" end' "$CONTRACT_PATH")
+HAS_OBLIGATIONS=$(jq 'if (.cleanupObligations // [] | length) > 0 then "yes" else "no" end' "$CONTRACT_PATH")
 if [ "$HAS_REMOVALS" = '"yes"' ] || [ "$HAS_OBLIGATIONS" = '"yes"' ]; then
-  REMOVAL_EV=$(python3 -c "
-import json, os
-contract = json.load(open('.signum/contract.json'))
+  REMOVAL_EV=$(python3 - "$CONTRACT_PATH" <<'PY'
+import json
+import os
+import sys
+
+contract = json.load(open(sys.argv[1]))
 evidence = {'removals': [], 'obligations': []}
 for rm in contract.get('removals', []):
     exists = os.path.exists(rm['path'])
@@ -3163,10 +3635,11 @@ for co in contract.get('cleanupObligations', []):
         'fulfilled': True, 'blocking': co.get('blocking', True)
     })
 print(json.dumps(evidence))
-")
+PY
+)
   jq --argjson re "$REMOVAL_EV" '. + {removalEvidence: $re}' \
-    .signum/proofpack.json > .signum/proofpack-tmp.json \
-    && mv .signum/proofpack-tmp.json .signum/proofpack.json
+    "$PROOFPACK_PATH" > "${PROOFPACK_PATH%.json}-tmp.json" \
+    && mv "${PROOFPACK_PATH%.json}-tmp.json" "$PROOFPACK_PATH"
 fi
 
 # Cleanup temp files
@@ -3175,16 +3648,16 @@ rm -f "$REDACTED_CONTRACT"
 # Append to proofpack index (hash-linked chain)
 if [ -f lib/proofpack-index.sh ]; then
   source lib/proofpack-index.sh
-  proofpack_index_append .signum/proofpack.json && echo "Proofpack indexed (chain hash linked)" || true
+  proofpack_index_append "$PROOFPACK_PATH" && echo "Proofpack indexed (chain hash linked)" || true
 fi
 
 # Advisory anti-entropy artifact (non-blocking, report-only)
 if [ -f lib/pack-anti-entropy.sh ]; then
   bash lib/pack-anti-entropy.sh \
     --project-root . \
-    --contract .signum/contract.json \
-    --proofpack .signum/proofpack.json \
-    --output .signum/anti_entropy_report.json || true
+    --contract "$CONTRACT_PATH" \
+    --proofpack "$PROOFPACK_PATH" \
+    --output "$ANTI_ENTROPY_PATH" || true
 fi
 
 echo "Proofpack written: $RUN_ID (schema v4.8)"
@@ -3197,12 +3670,16 @@ Use the Bash tool to transition the contract to `completed`:
 ```bash
 if [ -f lib/contract-dir.sh ]; then
   source lib/contract-dir.sh
-  CONTRACT_ID=$(jq -r '.contractId // empty' .signum/contract.json)
+  ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+  CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+  EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+  RECEIPTS_EXEC_PATH="${ARTIFACT_ROOT}receipts/execute.json"
+  CONTRACT_ID=$(jq -r '.contractId // empty' "$CONTRACT_PATH")
   if [ -n "$CONTRACT_ID" ]; then
     update_contract_status "$CONTRACT_ID" "completed"
-    RUN_ID=$(jq -r '.run_id // empty' .signum/execution_context.json 2>/dev/null || true)
+    RUN_ID=$(jq -r '.run_id // empty' "$EXECUTION_CONTEXT_PATH" 2>/dev/null || true)
     if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-      RUN_ID=$(jq -r '.run_id // empty' .signum/receipts/execute.json 2>/dev/null || true)
+      RUN_ID=$(jq -r '.run_id // empty' "$RECEIPTS_EXEC_PATH" 2>/dev/null || true)
     fi
     # Sync durable artifacts for this completed contract.
     sync_contract_artifacts "$CONTRACT_ID" \
@@ -3231,22 +3708,39 @@ Display to the user:
 Use the Bash tool to list all produced artifacts:
 
 ```bash
-echo "=== Artifacts in .signum/ ==="
-ls -1 .signum/ .signum/reviews/ 2>/dev/null
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+PROOFPACK_PATH="${ARTIFACT_ROOT}proofpack.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+DIFF_PATH="${ARTIFACT_ROOT}combined.patch"
+ANTI_ENTROPY_PATH="${ARTIFACT_ROOT}anti_entropy_report.json"
+
+echo "=== Canonical artifact root ==="
+echo "$ARTIFACT_ROOT"
 echo ""
-echo "Decision:   $(jq -r .decision .signum/proofpack.json)"
-echo "Confidence: $(jq -r '.confidence.overall' .signum/proofpack.json)%"
-echo "Run ID:     $(jq -r .runId   .signum/proofpack.json)"
-if [ -f .signum/anti_entropy_report.json ]; then
-  echo "Anti-entropy: $(jq -r '.status + \" — \" + .summary' .signum/anti_entropy_report.json 2>/dev/null || echo 'unknown')"
+echo "=== Artifacts ==="
+if [ -d "$ARTIFACT_ROOT" ]; then
+  (
+    cd "$ARTIFACT_ROOT" &&
+    find . -maxdepth 2 -mindepth 1 | sed 's#^\./##' | LC_ALL=C sort
+  )
+else
+  echo "WARNING: artifact root not found"
+fi
+echo ""
+echo "Decision:   $(jq -r .decision "$PROOFPACK_PATH")"
+echo "Confidence: $(jq -r '.confidence.overall' "$PROOFPACK_PATH")%"
+echo "Run ID:     $(jq -r .runId "$PROOFPACK_PATH")"
+if [ -f "$ANTI_ENTROPY_PATH" ]; then
+  echo "Anti-entropy: $(jq -r '.status + \" — \" + .summary' "$ANTI_ENTROPY_PATH" 2>/dev/null || echo 'unknown')"
 fi
 ```
 
 Then display the appropriate next steps based on the decision:
 
-- **AUTO_OK**: "Changes are verified. Review `.signum/combined.patch` and commit when ready."
-- **AUTO_BLOCK**: "Issues found. Review `.signum/audit_summary.json` and fix before committing."
-- **HUMAN_REVIEW**: "Audit inconclusive. Review `.signum/audit_summary.json`, then either: (1) refine acceptance criteria and re-run `/signum`, or (2) manually verify the flagged findings."
+- **AUTO_OK**: "Changes are verified. Review `combined.patch` under the canonical artifact root shown above and commit when ready."
+- **AUTO_BLOCK**: "Issues found. Review `audit_summary.json` under the canonical artifact root shown above and fix before committing."
+- **HUMAN_REVIEW**: "Audit inconclusive. Review `audit_summary.json` under the canonical artifact root shown above, then either: (1) refine acceptance criteria and re-run `/signum`, or (2) manually verify the flagged findings."
 
 ### Step 4.5: Finalize run (artifact cleanup)
 
@@ -3255,85 +3749,56 @@ After displaying results, finalize the current run to prevent stale artifacts fr
 **Decision-based behavior:**
 
 - **AUTO_OK** → auto-finalize (archive + purge working set). Zero-friction success path.
-- **HUMAN_REVIEW** → ask the user: "Pipeline complete (HUMAN_REVIEW). Artifacts in .signum/. Options: (1) archive — save to .signum/archive/ and clean working set, (2) keep — leave all artifacts for review, (3) delete — remove working set entirely." Default if no answer: keep.
-- **AUTO_BLOCK** → ask the user: "Pipeline blocked (AUTO_BLOCK). Options: (1) keep — leave artifacts for debugging (default), (2) delete — remove working set." Default if no answer: keep.
+- **HUMAN_REVIEW** → ask the user: "Pipeline complete (HUMAN_REVIEW). Artifacts remain under the canonical artifact root shown above. Options: (1) archive — save to .signum/archive/ and clean working set, (2) keep — leave all artifacts for review, (3) delete — remove working set entirely." Default if no answer: keep.
+- **AUTO_BLOCK** → ask the user: "Pipeline blocked (AUTO_BLOCK). Options: (1) keep — leave artifacts under the canonical artifact root for debugging (default), (2) delete — remove the working set." Default if no answer: keep.
 
 **Finalize flow (archive + purge):**
 
 Use the Bash tool:
 
 ```bash
-DECISION=$(jq -r '.decision' .signum/audit_summary.json)
-CONTRACT_ID=$(jq -r '.contractId // empty' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+DECISION=$(jq -r '.decision' "$AUDIT_SUMMARY_PATH")
+CONTRACT_ID=$(jq -r '.contractId // empty' "$CONTRACT_PATH")
 
 finalize_run() {
-  # Step 1: Create temp archive dir
   ARCHIVE_TMP=$(mktemp -d .signum/archive-tmp.XXXXXX)
+  archive_contract_artifacts "$CONTRACT_ID" "$ARCHIVE_TMP"
 
-  # Step 2: Copy durable artifacts to temp
-  cp .signum/contract.json "$ARCHIVE_TMP/" 2>/dev/null
-  cp .signum/proofpack.json "$ARCHIVE_TMP/" 2>/dev/null
-  cp .signum/approval.json "$ARCHIVE_TMP/" 2>/dev/null
-  cp .signum/audit_summary.json "$ARCHIVE_TMP/" 2>/dev/null
-  cp .signum/anti_entropy_report.json "$ARCHIVE_TMP/" 2>/dev/null || true
-  cp .signum/execution_context.json "$ARCHIVE_TMP/" 2>/dev/null || true
-  cp -R .signum/receipts "$ARCHIVE_TMP/" 2>/dev/null || true
-  cp -R .signum/runs "$ARCHIVE_TMP/" 2>/dev/null || true
-  cp -R .signum/snapshots "$ARCHIVE_TMP/" 2>/dev/null || true
-
-  # Step 3: Verify required files exist in temp
   if [ ! -f "$ARCHIVE_TMP/contract.json" ] || [ ! -f "$ARCHIVE_TMP/proofpack.json" ]; then
     echo "ERROR: archive incomplete — keeping working set intact"
     rm -rf "$ARCHIVE_TMP"
     return 1
   fi
 
-  # Step 4: Atomic move to final archive location
   if [ -n "$CONTRACT_ID" ]; then
     ARCHIVE_FINAL=".signum/archive/${CONTRACT_ID}"
     mkdir -p "$ARCHIVE_FINAL"
-    cp "$ARCHIVE_TMP/"* "$ARCHIVE_FINAL/" 2>/dev/null
+    cp -R "$ARCHIVE_TMP"/. "$ARCHIVE_FINAL"/
   fi
   rm -rf "$ARCHIVE_TMP"
 
-  # Step 5: Update session context (cross-run memory)
   source lib/session-manager.sh 2>/dev/null || true
   if type session_append &>/dev/null; then
-    GOAL=$(jq -r '.goal // "unknown"' .signum/contract.json 2>/dev/null | head -c 120)
+    GOAL=$(jq -r '.goal // "unknown"' "$CONTRACT_PATH" 2>/dev/null | head -c 120)
     if [ "$DECISION" = "AUTO_OK" ]; then
       session_append "success" "AUTO_OK: $GOAL"
     elif [ "$DECISION" = "AUTO_BLOCK" ]; then
-      REASON=$(jq -r '.reasoning // "unknown"' .signum/audit_summary.json 2>/dev/null | head -c 120)
+      REASON=$(jq -r '.reasoning // "unknown"' "$AUDIT_SUMMARY_PATH" 2>/dev/null | head -c 120)
       session_append "failure" "AUTO_BLOCK ($REASON): $GOAL"
     elif [ "$DECISION" = "HUMAN_REVIEW" ]; then
       session_append "model_disagreement" "HUMAN_REVIEW: $GOAL"
     fi
-    # Check for scope violations
-    if jq -e '.reviews | to_entries[] | select(.value.findings[]? | .category == "scope")' .signum/audit_summary.json &>/dev/null; then
+    if jq -e '.reviews | to_entries[] | select(.value.findings[]? | .category == "scope")' "$AUDIT_SUMMARY_PATH" &>/dev/null; then
       session_append "scope_violation" "Scope issue detected in: $GOAL" 8
     fi
   fi
 
-  # Step 5.5: Clear activeContractId
-  if [ -f .signum/contracts/index.json ] && [ -n "$CONTRACT_ID" ]; then
-    jq '.activeContractId = null' .signum/contracts/index.json > .signum/contracts/index.json.tmp \
-      && mv .signum/contracts/index.json.tmp .signum/contracts/index.json
-  fi
-
-  # Step 6: Purge root working set (keep contracts/, index, and session.json)
-  rm -f .signum/contract.json .signum/contract-engineer.json .signum/contract-policy.json \
-       .signum/execute_log.json .signum/combined.patch .signum/iteration_delta.patch \
-       .signum/baseline.json .signum/mechanic_report.json .signum/holdout_report.json \
-       .signum/audit_summary.json .signum/proofpack.json .signum/approval.json \
-       .signum/anti_entropy_report.json \
-       .signum/policy_violations.json .signum/policy_scan.json \
-       .signum/spec_quality.json .signum/spec_validation.json \
-       .signum/repo_contract_baseline.json .signum/repo_contract_violations.json \
-       .signum/contract-hash.txt .signum/execution_context.json \
-       .signum/review_prompt_codex.txt .signum/review_prompt_gemini.txt \
-       .signum/clover_report.json .signum/intent_check.json \
-       .signum/audit_iteration_log.json .signum/repair_brief.json .signum/flaky_tests.json
-  rm -rf .signum/reviews/ .signum/iterations/ .signum/receipts/ .signum/runs/ .signum/snapshots/
+  clear_active_contract >/dev/null 2>&1 || true
+  purge_root_working_set_views >/dev/null 2>&1 || true
 
   echo "Run finalized: archived to .signum/archive/$CONTRACT_ID/, working set cleaned"
 }
@@ -3348,66 +3813,32 @@ If `DECISION` is `AUTO_OK`, finalize runs automatically. For `HUMAN_REVIEW` or `
 **If user chooses "archive":**
 
 ```bash
-CONTRACT_ID=$(jq -r '.contractId // empty' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+CONTRACT_ID=$(jq -r '.contractId // empty' "$CONTRACT_PATH")
 ARCHIVE_TMP=$(mktemp -d .signum/archive-tmp.XXXXXX)
-cp .signum/contract.json "$ARCHIVE_TMP/" 2>/dev/null
-cp .signum/proofpack.json "$ARCHIVE_TMP/" 2>/dev/null
-cp .signum/approval.json "$ARCHIVE_TMP/" 2>/dev/null
-cp .signum/audit_summary.json "$ARCHIVE_TMP/" 2>/dev/null
-cp .signum/anti_entropy_report.json "$ARCHIVE_TMP/" 2>/dev/null || true
-cp .signum/execution_context.json "$ARCHIVE_TMP/" 2>/dev/null || true
-cp -R .signum/receipts "$ARCHIVE_TMP/" 2>/dev/null || true
-cp -R .signum/runs "$ARCHIVE_TMP/" 2>/dev/null || true
-cp -R .signum/snapshots "$ARCHIVE_TMP/" 2>/dev/null || true
+archive_contract_artifacts "$CONTRACT_ID" "$ARCHIVE_TMP"
 if [ ! -f "$ARCHIVE_TMP/contract.json" ] || [ ! -f "$ARCHIVE_TMP/proofpack.json" ]; then
   echo "ERROR: archive incomplete — keeping working set intact"
   rm -rf "$ARCHIVE_TMP"; exit 1
 fi
 if [ -n "$CONTRACT_ID" ]; then
   mkdir -p ".signum/archive/${CONTRACT_ID}"
-  cp "$ARCHIVE_TMP/"* ".signum/archive/${CONTRACT_ID}/" 2>/dev/null
+  cp -R "$ARCHIVE_TMP"/. ".signum/archive/${CONTRACT_ID}/"
 fi
 rm -rf "$ARCHIVE_TMP"
-if [ -f .signum/contracts/index.json ] && [ -n "$CONTRACT_ID" ]; then
-  jq '.activeContractId = null' .signum/contracts/index.json > .signum/contracts/index.json.tmp \
-    && mv .signum/contracts/index.json.tmp .signum/contracts/index.json
-fi
-rm -f .signum/contract.json .signum/contract-engineer.json .signum/contract-policy.json \
-     .signum/execute_log.json .signum/combined.patch .signum/iteration_delta.patch \
-     .signum/baseline.json .signum/mechanic_report.json .signum/holdout_report.json \
-     .signum/audit_summary.json .signum/proofpack.json .signum/approval.json \
-     .signum/anti_entropy_report.json \
-     .signum/policy_violations.json .signum/policy_scan.json \
-     .signum/spec_quality.json .signum/spec_validation.json \
-     .signum/repo_contract_baseline.json .signum/repo_contract_violations.json \
-     .signum/contract-hash.txt .signum/execution_context.json \
-     .signum/review_prompt_codex.txt .signum/review_prompt_gemini.txt \
-     .signum/clover_report.json .signum/intent_check.json \
-     .signum/audit_iteration_log.json .signum/repair_brief.json .signum/flaky_tests.json
-rm -rf .signum/reviews/ .signum/iterations/ .signum/receipts/ .signum/runs/ .signum/snapshots/
+clear_active_contract >/dev/null 2>&1 || true
+purge_root_working_set_views >/dev/null 2>&1 || true
 echo "Run finalized: archived to .signum/archive/$CONTRACT_ID/, working set cleaned"
 ```
 
 **If user chooses "delete":**
 
 ```bash
-if [ -f .signum/contracts/index.json ]; then
-  jq '.activeContractId = null' .signum/contracts/index.json > .signum/contracts/index.json.tmp \
-    && mv .signum/contracts/index.json.tmp .signum/contracts/index.json 2>/dev/null || true
-fi
-rm -f .signum/contract.json .signum/contract-engineer.json .signum/contract-policy.json \
-     .signum/execute_log.json .signum/combined.patch .signum/iteration_delta.patch \
-     .signum/baseline.json .signum/mechanic_report.json .signum/holdout_report.json \
-     .signum/audit_summary.json .signum/proofpack.json .signum/approval.json \
-     .signum/anti_entropy_report.json \
-     .signum/policy_violations.json .signum/policy_scan.json \
-     .signum/spec_quality.json .signum/spec_validation.json \
-     .signum/repo_contract_baseline.json .signum/repo_contract_violations.json \
-     .signum/contract-hash.txt .signum/execution_context.json \
-     .signum/review_prompt_codex.txt .signum/review_prompt_gemini.txt \
-     .signum/clover_report.json .signum/intent_check.json \
-     .signum/audit_iteration_log.json .signum/repair_brief.json .signum/flaky_tests.json
-rm -rf .signum/reviews/ .signum/iterations/ .signum/receipts/ .signum/runs/ .signum/snapshots/
+source lib/contract-dir.sh 2>/dev/null || true
+clear_active_contract >/dev/null 2>&1 || true
+purge_root_working_set_views >/dev/null 2>&1 || true
 echo "Working set deleted (no archive)"
 ```
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -43,7 +43,7 @@ Risk is assessed structurally (file count, keywords, surface area). Holdout scen
 
 **Orchestrator:** captures baseline, launches Engineer, enforces scope gate.
 
-1. **Baseline capture**: orchestrator runs lint/typecheck/tests BEFORE any changes and saves exit codes to `.signum/baseline.json`. This is the trust anchor for regression detection.
+1. **Baseline capture**: orchestrator runs lint/typecheck/tests BEFORE any changes and saves exit codes to `baseline.json` under the active contract artifact root. This is the trust anchor for regression detection.
 2. **Engineer** (sonnet) implements against the contract with a 3-attempt repair loop.
 3. **Scope gate**: deterministic check that all modified files are within `inScope` or `allowNewFilesUnder`. Stops pipeline on violation.
 
@@ -134,7 +134,7 @@ If the CLI returns malformed output or a non-zero exit code, the provider is mar
 
 ## Artifacts
 
-Live working-set artifacts are written to `.signum/` (auto-added to `.gitignore`). Signum also mirrors durable per-contract snapshots into `.signum/contracts/<contractId>/` for history/archive flows. That per-contract directory is not the active workspace while a run is in flight.
+Canonical run artifacts live under the active contract artifact root `.signum/contracts/<contractId>/`. Root `.signum/` stays auto-added to `.gitignore` and now mainly holds registry/state surfaces plus compatibility views during the contract-dir migration. The contract, pre-execute metadata, execute outputs, selected audit/pack file artifacts (`contract.json`, `spec_quality.json`, `spec_validation.json`, `clover_report.json`, `intent_check.json`, `approval.json`, `contract-hash.txt`, `contract-engineer.json`, `contract-policy.json`, `execution_context.json`, `baseline.json`, `combined.patch`, `execute_log.json`, `iteration_delta.patch`, `mechanic_report.json`, `holdout_report.json`, `policy_violations.json`, `policy_scan.json`, `audit_iteration_log.json`, `repair_brief.json`, `flaky_tests.json`, `audit_summary.json`, `proofpack.json`, `anti_entropy_report.json`), and active run directories (`reviews/`, `iterations/`, `receipts/`, `runs/`, `snapshots/`) are canonical under that contract directory.
 
 | File | Phase | Description |
 |------|-------|-------------|
@@ -160,6 +160,8 @@ Durable per-contract snapshots typically mirror:
 - `audit_summary.json`
 - `approval.json`
 - `execution_context.json`
+- `reviews/`
+- `iterations/`
 - `receipts/`
 - `runs/<runId>/`
 - `snapshots/`

--- a/docs/plans/2026-03-04-self-contained-proofpack-plan.md
+++ b/docs/plans/2026-03-04-self-contained-proofpack-plan.md
@@ -157,28 +157,41 @@ file_size() {
 }
 
 # Metadata
-DECISION=$(jq -r '.decision' .signum/audit_summary.json)
-GOAL=$(jq -r '.goal' .signum/contract.json)
-RISK=$(jq -r '.riskLevel' .signum/contract.json)
-ATTEMPTS=$(jq -r '.totalAttempts' .signum/execute_log.json 2>/dev/null || echo "unknown")
-MECHANIC=$(jq -r '.mechanic' .signum/audit_summary.json)
-CONFIDENCE=$(jq -r '.confidence.overall // 0' .signum/audit_summary.json)
+ARTIFACT_ROOT=".signum/contracts/<contractId>"
+CONTRACT_PATH="$ARTIFACT_ROOT/contract.json"
+AUDIT_SUMMARY_PATH="$ARTIFACT_ROOT/audit_summary.json"
+EXECUTE_LOG_PATH="$ARTIFACT_ROOT/execute_log.json"
+BASELINE_PATH="$ARTIFACT_ROOT/baseline.json"
+MECHANIC_REPORT_PATH="$ARTIFACT_ROOT/mechanic_report.json"
+HOLDOUT_REPORT_PATH="$ARTIFACT_ROOT/holdout_report.json"
+COMBINED_PATCH_PATH="$ARTIFACT_ROOT/combined.patch"
+CONTRACT_HASH_PATH="$ARTIFACT_ROOT/contract-hash.txt"
+EXECUTION_CONTEXT_PATH="$ARTIFACT_ROOT/execution_context.json"
+REVIEWS_DIR="$ARTIFACT_ROOT/reviews"
+PROOFPACK_PATH="$ARTIFACT_ROOT/proofpack.json"
+
+DECISION=$(jq -r '.decision' "$AUDIT_SUMMARY_PATH")
+GOAL=$(jq -r '.goal' "$CONTRACT_PATH")
+RISK=$(jq -r '.riskLevel' "$CONTRACT_PATH")
+ATTEMPTS=$(jq -r '.totalAttempts' "$EXECUTE_LOG_PATH" 2>/dev/null || echo "unknown")
+MECHANIC=$(jq -r '.mechanic' "$AUDIT_SUMMARY_PATH")
+CONFIDENCE=$(jq -r '.confidence.overall // 0' "$AUDIT_SUMMARY_PATH")
 RUN_DATE=$(date +%Y-%m-%d)
 RUN_RANDOM=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 6)
 RUN_ID="signum-${RUN_DATE}-${RUN_RANDOM}"
 CREATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # Audit chain
-CONTRACT_HASH=$(grep 'contract_sha256:' .signum/contract-hash.txt 2>/dev/null | awk '{print $2}' || echo "unavailable")
-APPROVED_AT=$(grep 'approved_at:' .signum/contract-hash.txt 2>/dev/null | awk '{print $2}' || echo "unavailable")
-BASE_COMMIT=$(jq -r '.base_commit // "unavailable"' .signum/execution_context.json 2>/dev/null || echo "unavailable")
+CONTRACT_HASH=$(grep 'contract_sha256:' "$CONTRACT_HASH_PATH" 2>/dev/null | awk '{print $2}' || echo "unavailable")
+APPROVED_AT=$(grep 'approved_at:' "$CONTRACT_HASH_PATH" 2>/dev/null | awk '{print $2}' || echo "unavailable")
+BASE_COMMIT=$(jq -r '.base_commit // "unavailable"' "$EXECUTION_CONTEXT_PATH" 2>/dev/null || echo "unavailable")
 
 # Contract: redact holdouts, compute both hashes
-FULL_CONTRACT_SHA=$(hash_file .signum/contract.json)
-FULL_CONTRACT_SIZE=$(file_size .signum/contract.json)
+FULL_CONTRACT_SHA=$(hash_file "$CONTRACT_PATH")
+FULL_CONTRACT_SIZE=$(file_size "$CONTRACT_PATH")
 python3 -c "
 import json, sys
-with open('.signum/contract.json') as f:
+with open('$CONTRACT_PATH') as f:
     c = json.load(f)
 c.pop('holdoutScenarios', None)
 json.dump(c, sys.stdout, indent=2)
@@ -186,8 +199,8 @@ json.dump(c, sys.stdout, indent=2)
 REDACTED_CONTRACT_SHA=$(hash_file /tmp/signum-contract-redacted.json)
 
 # Diff: embed if <100KB, otherwise omit-but-hash
-DIFF_SIZE=$(file_size .signum/combined.patch)
-DIFF_SHA=$(hash_file .signum/combined.patch)
+DIFF_SIZE=$(file_size "$COMBINED_PATCH_PATH")
+DIFF_SHA=$(hash_file "$COMBINED_PATCH_PATH")
 DIFF_THRESHOLD=102400
 if [ "$DIFF_SIZE" -le "$DIFF_THRESHOLD" ]; then
   DIFF_STATUS="present"
@@ -220,7 +233,7 @@ ENV_CONTRACT=$(jq -n \
   '{content: $content, sha256: $sha, fullSha256: $fullSha, sizeBytes: $size, status: "present"}')
 
 if [ "$DIFF_STATUS" = "present" ]; then
-  DIFF_CONTENT=$(jq -Rs '.' .signum/combined.patch)
+  DIFF_CONTENT=$(jq -Rs '.' "$COMBINED_PATCH_PATH")
   ENV_DIFF=$(jq -n --argjson content "$DIFF_CONTENT" --arg sha "$DIFF_SHA" --argjson size "$DIFF_SIZE" \
     '{content: $content, sha256: $sha, sizeBytes: $size, status: "present"}')
 else
@@ -228,22 +241,22 @@ else
     '{content: null, sha256: $sha, sizeBytes: $size, status: "omitted", omitReason: $reason}')
 fi
 
-ENV_BASELINE=$(build_envelope .signum/baseline.json)
-ENV_EXEC_LOG=$(build_envelope .signum/execute_log.json)
-ENV_MECHANIC=$(build_envelope .signum/mechanic_report.json)
-ENV_AUDIT=$(build_envelope .signum/audit_summary.json)
+ENV_BASELINE=$(build_envelope "$BASELINE_PATH")
+ENV_EXEC_LOG=$(build_envelope "$EXECUTE_LOG_PATH")
+ENV_MECHANIC=$(build_envelope "$MECHANIC_REPORT_PATH")
+ENV_AUDIT=$(build_envelope "$AUDIT_SUMMARY_PATH")
 
 # Holdout report (optional)
-if [ -f .signum/holdout_report.json ]; then
-  ENV_HOLDOUT=$(build_envelope .signum/holdout_report.json)
+if [ -f "$HOLDOUT_REPORT_PATH" ]; then
+  ENV_HOLDOUT=$(build_envelope "$HOLDOUT_REPORT_PATH")
 else
   ENV_HOLDOUT=$(jq -n '{content: null, sha256: null, sizeBytes: 0, status: "omitted", omitReason: "no holdout scenarios"}')
 fi
 
-# Reviews (dynamic — enumerate .signum/reviews/)
+# Reviews (dynamic — enumerate $REVIEWS_DIR)
 REVIEWS_JSON="{}"
-if [ -d .signum/reviews ]; then
-  for REVIEW_FILE in .signum/reviews/*.json; do
+if [ -d "$REVIEWS_DIR" ]; then
+  for REVIEW_FILE in "$REVIEWS_DIR"/*.json; do
     [ -f "$REVIEW_FILE" ] || continue
     PROVIDER=$(basename "$REVIEW_FILE" .json)
     ENV=$(build_envelope "$REVIEW_FILE")
@@ -294,10 +307,10 @@ jq -n \
       reviews: $reviews,
       auditSummary: $auditSummary
     }
-  }' > .signum/proofpack.json
+  }' > "$PROOFPACK_PATH"
 
 rm -f /tmp/signum-contract-redacted.json
-echo "Proofpack v4.0 written: $RUN_ID ($(file_size .signum/proofpack.json) bytes)"
+echo "Proofpack v4.0 written: $RUN_ID ($(file_size "$PROOFPACK_PATH") bytes)"
 ```
 ````
 
@@ -475,27 +488,28 @@ Create a minimal test to verify the bash envelope builder works:
 
 ```bash
 cd /Users/vi/personal/skill7/devtools/signum
-mkdir -p /tmp/signum-test/.signum/reviews
-echo '{"goal":"test","riskLevel":"low"}' > /tmp/signum-test/.signum/contract.json
-echo 'diff content' > /tmp/signum-test/.signum/combined.patch
-echo '{"lint":0,"typecheck":0}' > /tmp/signum-test/.signum/baseline.json
-echo '{"totalAttempts":1}' > /tmp/signum-test/.signum/execute_log.json
-echo '{"mechanic":"pass","decision":"AUTO_OK","confidence":{"overall":90}}' > /tmp/signum-test/.signum/audit_summary.json
-echo '{"passed":0,"failed":0}' > /tmp/signum-test/.signum/mechanic_report.json
-echo '{"verdict":"APPROVE","findings":[],"summary":"ok"}' > /tmp/signum-test/.signum/reviews/claude.json
-echo 'contract_sha256: abc123' > /tmp/signum-test/.signum/contract-hash.txt
-echo 'approved_at: 2026-03-04T10:00:00Z' >> /tmp/signum-test/.signum/contract-hash.txt
-echo '{"base_commit":"def456"}' > /tmp/signum-test/.signum/execution_context.json
+ARTIFACT_ROOT=/tmp/signum-test/.signum/contracts/sig-test
+mkdir -p "$ARTIFACT_ROOT/reviews"
+echo '{"goal":"test","riskLevel":"low"}' > "$ARTIFACT_ROOT/contract.json"
+echo 'diff content' > "$ARTIFACT_ROOT/combined.patch"
+echo '{"lint":0,"typecheck":0}' > "$ARTIFACT_ROOT/baseline.json"
+echo '{"totalAttempts":1}' > "$ARTIFACT_ROOT/execute_log.json"
+echo '{"mechanic":"pass","decision":"AUTO_OK","confidence":{"overall":90}}' > "$ARTIFACT_ROOT/audit_summary.json"
+echo '{"passed":0,"failed":0}' > "$ARTIFACT_ROOT/mechanic_report.json"
+echo '{"verdict":"APPROVE","findings":[],"summary":"ok"}' > "$ARTIFACT_ROOT/reviews/claude.json"
+echo 'contract_sha256: abc123' > "$ARTIFACT_ROOT/contract-hash.txt"
+echo 'approved_at: 2026-03-04T10:00:00Z' >> "$ARTIFACT_ROOT/contract-hash.txt"
+echo '{"base_commit":"def456"}' > "$ARTIFACT_ROOT/execution_context.json"
 
 # Verify the generated proofpack has expected structure
 cd /tmp/signum-test
 # (paste the Phase 4 bash script and run it)
 # Then verify:
-jq '.schemaVersion' .signum/proofpack.json  # should be "4.0"
-jq '.contract.status' .signum/proofpack.json  # should be "present"
-jq '.contract.fullSha256' .signum/proofpack.json  # should be non-null
-jq '.diff.status' .signum/proofpack.json  # should be "present" (small diff)
-jq '.checks.reviews | keys' .signum/proofpack.json  # should be ["claude"]
+jq '.schemaVersion' "$ARTIFACT_ROOT/proofpack.json"  # should be "4.0"
+jq '.contract.status' "$ARTIFACT_ROOT/proofpack.json"  # should be "present"
+jq '.contract.fullSha256' "$ARTIFACT_ROOT/proofpack.json"  # should be non-null
+jq '.diff.status' "$ARTIFACT_ROOT/proofpack.json"  # should be "present" (small diff)
+jq '.checks.reviews | keys' "$ARTIFACT_ROOT/proofpack.json"  # should be ["claude"]
 rm -rf /tmp/signum-test
 ```
 

--- a/docs/plans/2026-03-15-diff-progression-design.md
+++ b/docs/plans/2026-03-15-diff-progression-design.md
@@ -31,11 +31,13 @@ The reviewer prompt instructs: "Focus your review on the delta. Use the full pat
 The **orchestrator** owns delta generation — not the engineer. After the repair success gate (Step 3.6.2) passes, the orchestrator runs both capture commands from a single place:
 
 ```bash
+ARTIFACT_ROOT=".signum/contracts/<contractId>"
+
 # After engineer completes repair and repair success gate passes (Step 3.6.2):
 # git diff (unstaged) = iteration delta; engineer started from best candidate state
-git diff > .signum/iteration_delta.patch
+git diff > "$ARTIFACT_ROOT/iteration_delta.patch"
 # git diff $BASE = full combined patch from base commit
-git diff $BASE > .signum/combined.patch
+git diff "$BASE" > "$ARTIFACT_ROOT/combined.patch"
 ```
 
 The engineer always starts from the best candidate state (after rollback), so `git diff` (unstaged changes) equals exactly what the fix changed. `git diff $BASE` then gives the full feature diff. Both are computed by the orchestrator immediately after the repair gate, before launching reviews.
@@ -45,13 +47,15 @@ The engineer always starts from the best candidate state (after rollback), so `g
 **Before repair** — clear stale artifacts alongside execute_log and combined.patch:
 
 ```bash
-rm -f .signum/iteration_delta.patch .signum/execute_log .signum/combined.patch
+rm -f "$ARTIFACT_ROOT/iteration_delta.patch" \
+      "$ARTIFACT_ROOT/execute_log.json" \
+      "$ARTIFACT_ROOT/combined.patch"
 ```
 
 **Post-repair guard** — if delta is absent or zero-length after repair, mark iteration as non-improving and skip Steps 3.1.5–3.5 (delta-focused review path):
 
 ```bash
-DELTA_SIZE=$(wc -c < .signum/iteration_delta.patch 2>/dev/null || echo 0)
+DELTA_SIZE=$(wc -c < "$ARTIFACT_ROOT/iteration_delta.patch" 2>/dev/null || echo 0)
 if [ "$DELTA_SIZE" -eq 0 ]; then
   echo "Delta absent or empty — non-improving iteration, skipping delta review path"
   # falls through to existing REPAIR_SKIP / no-op handling
@@ -61,13 +65,14 @@ fi
 **Store in iteration directory** — copy delta alongside combined.patch:
 
 ```bash
-cp .signum/iteration_delta.patch "$ITER_DIR/"
+cp "$ARTIFACT_ROOT/iteration_delta.patch" "$ITER_DIR/iteration_delta.patch"
 ```
 
 **Rollback sync** — when rolling back to a best iteration, copy its delta:
 
 ```bash
-cp ".signum/iterations/$(printf '%02d' $BEST_ITERATION)/iteration_delta.patch" .signum/iteration_delta.patch 2>/dev/null || rm -f .signum/iteration_delta.patch
+cp "$ARTIFACT_ROOT/iterations/$(printf '%02d' "$BEST_ITERATION")/iteration_delta.patch" \
+   "$ARTIFACT_ROOT/iteration_delta.patch" 2>/dev/null || rm -f "$ARTIFACT_ROOT/iteration_delta.patch"
 ```
 
 **Restart/archive cleanup** — add `iteration_delta.patch` to cleanup lists alongside combined.patch and execute_log in both restart and archive routines.
@@ -99,8 +104,8 @@ FOCUS your review on the DELTA — these are the changes made to fix previous fi
 ### Storage
 
 ```
-.signum/
-  iteration_delta.patch          # current delta (working copy)
+.signum/contracts/<contractId>/
+  iteration_delta.patch          # current delta (canonical working copy)
   iterations/
     01/
       combined.patch             # full diff (no delta for pass 1)

--- a/docs/plans/2026-03-15-iterative-audit-design.md
+++ b/docs/plans/2026-03-15-iterative-audit-design.md
@@ -136,20 +136,20 @@ Order matters — deterministic signals first:
 
 ### 6.1. Repair Brief — Engineer Invocation
 
-Repair-mode engineer reads the SAME files as normal mode plus the brief:
-- `.signum/contract-engineer.json` (original contract, holdouts redacted)
-- `.signum/baseline.json` (pre-change check state)
-- `.signum/repair_brief.json` (new — the repair brief)
+Repair-mode engineer reads the SAME canonical files as normal mode plus the brief, all under the active contract artifact root (`$ARTIFACT_ROOT`):
+- `$ARTIFACT_ROOT/contract-engineer.json` (original contract, holdouts redacted)
+- `$ARTIFACT_ROOT/baseline.json` (pre-change check state)
+- `$ARTIFACT_ROOT/repair_brief.json` (new — the repair brief)
 
 Orchestrator prompt to engineer agent:
 
 ```
-Read .signum/contract-engineer.json for scope and acceptance criteria.
-Read .signum/baseline.json for pre-existing check state.
-Read .signum/repair_brief.json for the specific issues to fix.
+Read $ARTIFACT_ROOT/contract-engineer.json for scope and acceptance criteria.
+Read $ARTIFACT_ROOT/baseline.json for pre-existing check state.
+Read $ARTIFACT_ROOT/repair_brief.json for the specific issues to fix.
 Fix ONLY the issues listed in the repair brief. Do not refactor, do not add features.
 After fixing, run the visible AC verifies to confirm you didn't break them.
-Write .signum/combined.patch and .signum/execute_log.json.
+Write $ARTIFACT_ROOT/combined.patch and $ARTIFACT_ROOT/execute_log.json.
 ```
 
 The brief is a delta — engineer still works within the original contract boundaries.
@@ -172,7 +172,7 @@ Categories derived from holdout description via simple keyword extraction:
 ### 8. Per-Iteration Storage
 
 ```
-.signum/
+.signum/contracts/<contractId>/
   iterations/
     01/
       combined.patch
@@ -189,7 +189,7 @@ Categories derived from holdout description via simple keyword extraction:
   audit_iteration_log.json   # summary of all iterations
 ```
 
-Each iteration's artifacts stored separately. No overwrites. Working copies in `.signum/` always overwritten to match the active candidate; `iterations/*` remain immutable snapshots.
+Each iteration's artifacts stored separately. No overwrites. Canonical working copies in the active contract artifact root are always overwritten to match the active candidate; `iterations/*` remain immutable snapshots. Root `.signum/` compatibility views may exist during the migration, but they are not the source of truth.
 
 **Iteration 01** = initial EXECUTE candidate (pass 1 artifacts, before any fix).
 
@@ -289,7 +289,7 @@ Add to proofpack schema:
 }
 ```
 
-Full per-iteration artifacts stored in `.signum/iterations/` but NOT embedded in proofpack (too large). Proofpack embeds summaries only.
+Full per-iteration artifacts are stored under the active contract artifact root in `iterations/` but NOT embedded in proofpack (too large). Proofpack embeds summaries only.
 
 ### 13. Synthesizer Changes
 
@@ -358,7 +358,7 @@ done
 
 **Non-rerunnable failures** (build errors, panics before test discovery, infra timeouts): always counted as real regressions, no retry.
 
-Flaky state persisted in `.signum/flaky_tests.json`:
+Flaky state persisted in `flaky_tests.json` under the active contract artifact root:
 ```json
 {
   "tests": [
@@ -387,10 +387,10 @@ Flaky state persisted in `.signum/flaky_tests.json`:
 Procedure:
 1. `git clean -fd` (remove untracked files from failed candidate — they survive `git checkout`)
 2. `git checkout $BASE_COMMIT -- .` (BASE_COMMIT from `execution_context.json`, captured in Step 2.0)
-3. `git apply .signum/iterations/<best>/combined.patch`
-4. Copy `.signum/iterations/<best>/{mechanic_report,holdout_report,audit_summary}.json` → `.signum/` working copies
-5. Copy `.signum/iterations/<best>/reviews/*` → `.signum/reviews/`
-6. Regenerate working `.signum/combined.patch`
+3. `git apply "$ARTIFACT_ROOT/iterations/<best>/combined.patch"`
+4. Copy `$ARTIFACT_ROOT/iterations/<best>/{mechanic_report,holdout_report,audit_summary}.json` → canonical working copies in `$ARTIFACT_ROOT/`
+5. Copy `$ARTIFACT_ROOT/iterations/<best>/reviews/*` → `$ARTIFACT_ROOT/reviews/`
+6. Regenerate canonical `$ARTIFACT_ROOT/combined.patch`
 7. If apply fails → stop, return `HUMAN_REVIEW` with `terminalReason: "rollback_patch_apply_failed"`
 
 Each iteration's `combined.patch` already persisted in `iterations/N/`. No git stash, no worktrees, no temporary commits.
@@ -412,7 +412,7 @@ When mechanic detects a NEW test failure:
 1. Retry the failing test(s) **2 more times** (3 total observations)
 2. **2 of 3 fail** → real regression, counted in `hasRegressions` and score
 3. **Mixed results** (1 of 3 or 2 of 3 pass) → `flaky candidate`, excluded from `hasRegressions` and score
-4. Persist in `.signum/flaky_tests.json` (run-local, not committed)
+4. Persist in `$ARTIFACT_ROOT/flaky_tests.json` (run-local, not committed)
 5. If same test flip-flops across iterations → promote to `knownFlaky`
 6. If instability is suite-level (not attributable to specific tests) → cap at `HUMAN_REVIEW`
 

--- a/docs/plans/2026-03-15-phase1-project-intent-layer-design.md
+++ b/docs/plans/2026-03-15-phase1-project-intent-layer-design.md
@@ -197,7 +197,7 @@ Output JSON:
 Parse the subagent response as JSON. If parsing fails (malformed output), write:
 `{"aligned": null, "concerns": [], "glossary_violations": [], "parse_error": true}`.
 Note: `aligned: null` (not true) — so display shows "skipped" rather than false "OK".
-Write result to `.signum/intent_check.json`.
+Assume `CONTRACT_PATH="$ARTIFACT_ROOT/contract.json"` and `INTENT_CHECK_PATH="$ARTIFACT_ROOT/intent_check.json"` are already available, then write the result to `$INTENT_CHECK_PATH`.
 
 **Display in Step 1.4:** If `aligned=false` or concerns non-empty:
 ```
@@ -214,20 +214,20 @@ This is informational — does NOT block the pipeline.
 
 Add after risk signals display:
 ```bash
-if [ -f .signum/intent_check.json ]; then
-  ALIGNED=$(jq -r '.aligned // "null"' .signum/intent_check.json)
-  PARSE_ERR=$(jq -r '.parse_error // false' .signum/intent_check.json)
-  CONCERNS=$(jq -r '.concerns | length' .signum/intent_check.json)
+if [ -f "$INTENT_CHECK_PATH" ]; then
+  ALIGNED=$(jq -r '.aligned // "null"' "$INTENT_CHECK_PATH")
+  PARSE_ERR=$(jq -r '.parse_error // false' "$INTENT_CHECK_PATH")
+  CONCERNS=$(jq -r '.concerns | length' "$INTENT_CHECK_PATH")
   if [ "$PARSE_ERR" = "true" ] || [ "$ALIGNED" = "null" ]; then
     echo "Intent alignment: skipped (check failed)"
   elif [ "$ALIGNED" = "false" ] || [ "$CONCERNS" -gt 0 ]; then
     echo ""
     echo "--- Intent alignment WARNING ---"
-    jq -r '.concerns[]' .signum/intent_check.json | sed 's/^/  - /'
-    GLOSSARY_V=$(jq -r '.glossary_violations | length' .signum/intent_check.json)
+    jq -r '.concerns[]' "$INTENT_CHECK_PATH" | sed 's/^/  - /'
+    GLOSSARY_V=$(jq -r '.glossary_violations | length' "$INTENT_CHECK_PATH")
     if [ "$GLOSSARY_V" -gt 0 ]; then
       echo "Glossary violations:"
-      jq -r '.glossary_violations[]' .signum/intent_check.json | sed 's/^/  - /'
+      jq -r '.glossary_violations[]' "$INTENT_CHECK_PATH" | sed 's/^/  - /'
     fi
   else
     echo "Intent alignment: OK"
@@ -238,14 +238,14 @@ fi
 Also show projectRef in contract summary:
 ```bash
 # Use jq -e to test for null explicitly (jq -r turns null into "null" string)
-if jq -e '.contextInheritance.projectRef' .signum/contract.json >/dev/null 2>&1; then
-  PROJECT_REF=$(jq -r '.contextInheritance.projectRef' .signum/contract.json)
+if jq -e '.contextInheritance.projectRef' "$CONTRACT_PATH" >/dev/null 2>&1; then
+  PROJECT_REF=$(jq -r '.contextInheritance.projectRef' "$CONTRACT_PATH")
   if [ "$PROJECT_REF" = "not_found" ]; then
     echo "Project intent: not found (low risk, continued)"
   else
     echo "Project intent: $PROJECT_REF (loaded)"
   fi
-elif jq -e '.contextInheritance | has("projectRef")' .signum/contract.json >/dev/null 2>&1; then
+elif jq -e '.contextInheritance | has("projectRef")' "$CONTRACT_PATH" >/dev/null 2>&1; then
   # projectRef exists but is null → waiver
   echo "Project intent: waived by user"
 fi
@@ -271,7 +271,7 @@ The redacted contract already includes it via the updated whitelist above.
 
 ### Cleanup list
 
-Add `.signum/intent_check.json` to:
+Add `intent_check.json` under the active contract artifact root to:
 - Archive mode cleanup (transient, discard — not copied to archive dir)
 - Setup cleanup (rm at pipeline start)
 - Per-contract directory intermediate purge (archive command)

--- a/docs/plans/2026-03-15-phase1-project-intent-layer-plan.md
+++ b/docs/plans/2026-03-15-phase1-project-intent-layer-plan.md
@@ -159,11 +159,17 @@ git commit -m "feat: contractor reads project.intent.md, sets contextInheritance
 
 Step 1.2 validates `schemaVersion, goal, inScope, acceptanceCriteria, riskLevel`. `contextInheritance` is optional — existing validation passes without it. No code change needed, but confirm by reading the validation jq command (~line 389) to verify it won't reject contracts with unknown fields.
 
+Assume the active contract artifact root is already resolved and these canonical paths are available in the orchestration snippets below:
+```bash
+CONTRACT_PATH="$ARTIFACT_ROOT/contract.json"
+INTENT_CHECK_PATH="$ARTIFACT_ROOT/intent_check.json"
+```
+
 - [ ] **Step 1: Add intent_check.json to setup cleanup list**
 
-Find the `rm -f` block in setup cleanup (~line 355) and add `.signum/intent_check.json`:
+Find the setup cleanup block (~line 355 in the original draft) and add the canonical intent-check artifact:
 ```bash
-       .signum/intent_check.json \
+       "$INTENT_CHECK_PATH" \
 ```
 
 - [ ] **Step 2: Add intent_check.json to archive mode purge list**
@@ -218,8 +224,8 @@ After Step 1.3.5 (spec quality gate + prose check) and before Step 1.3.7 (multi-
 Check if contract has a project intent reference:
 
 ```bash
-PROJECT_REF=$(jq -r '.contextInheritance.projectRef // "absent"' .signum/contract.json)
-RISK=$(jq -r '.riskLevel' .signum/contract.json)
+PROJECT_REF=$(jq -r '.contextInheritance.projectRef // "absent"' "$CONTRACT_PATH")
+RISK=$(jq -r '.riskLevel' "$CONTRACT_PATH")
 if [ "$RISK" = "low" ] || [ "$PROJECT_REF" = "absent" ] || [ "$PROJECT_REF" = "null" ] || [ "$PROJECT_REF" = "not_found" ]; then
   echo "Intent alignment check: skipped (risk=$RISK, projectRef=$PROJECT_REF)"
 else
@@ -256,7 +262,7 @@ Output JSON only:
 Parse the subagent response as JSON. If parsing fails, write safe default:
 `{"aligned": null, "concerns": [], "glossary_violations": [], "parse_error": true}`
 
-Write result to `.signum/intent_check.json`.
+Write result to `$INTENT_CHECK_PATH`.
 ````
 
 - [ ] **Step 2: Commit**
@@ -288,14 +294,14 @@ Find Step 1.4 display section (~line 836, after riskSignals display). Add:
 
 ```bash
 # Show project intent status
-if jq -e '.contextInheritance.projectRef' .signum/contract.json >/dev/null 2>&1; then
-  PROJECT_REF=$(jq -r '.contextInheritance.projectRef' .signum/contract.json)
+if jq -e '.contextInheritance.projectRef' "$CONTRACT_PATH" >/dev/null 2>&1; then
+  PROJECT_REF=$(jq -r '.contextInheritance.projectRef' "$CONTRACT_PATH")
   if [ "$PROJECT_REF" = "not_found" ]; then
     echo "Project intent: not found (low risk, continued)"
   else
     echo "Project intent: $PROJECT_REF (loaded)"
   fi
-elif jq -e '.contextInheritance | has("projectRef")' .signum/contract.json >/dev/null 2>&1; then
+elif jq -e '.contextInheritance | has("projectRef")' "$CONTRACT_PATH" >/dev/null 2>&1; then
   echo "Project intent: waived by user"
 fi
 ```
@@ -306,20 +312,20 @@ After clover results display, add:
 
 ```bash
 # Show intent alignment results
-if [ -f .signum/intent_check.json ]; then
-  ALIGNED=$(jq -r '.aligned // "null"' .signum/intent_check.json)
-  PARSE_ERR=$(jq -r '.parse_error // false' .signum/intent_check.json)
-  CONCERNS=$(jq -r '.concerns | length' .signum/intent_check.json)
+if [ -f "$INTENT_CHECK_PATH" ]; then
+  ALIGNED=$(jq -r '.aligned // "null"' "$INTENT_CHECK_PATH")
+  PARSE_ERR=$(jq -r '.parse_error // false' "$INTENT_CHECK_PATH")
+  CONCERNS=$(jq -r '.concerns | length' "$INTENT_CHECK_PATH")
   if [ "$PARSE_ERR" = "true" ] || [ "$ALIGNED" = "null" ]; then
     echo "Intent alignment: skipped (check failed)"
   elif [ "$ALIGNED" = "false" ] || [ "$CONCERNS" -gt 0 ]; then
     echo ""
     echo "--- Intent alignment WARNING ---"
-    jq -r '.concerns[]' .signum/intent_check.json | sed 's/^/  - /'
-    GLOSSARY_V=$(jq -r '.glossary_violations | length' .signum/intent_check.json)
+    jq -r '.concerns[]' "$INTENT_CHECK_PATH" | sed 's/^/  - /'
+    GLOSSARY_V=$(jq -r '.glossary_violations | length' "$INTENT_CHECK_PATH")
     if [ "$GLOSSARY_V" -gt 0 ]; then
       echo "Glossary violations:"
-      jq -r '.glossary_violations[]' .signum/intent_check.json | sed 's/^/  - /'
+      jq -r '.glossary_violations[]' "$INTENT_CHECK_PATH" | sed 's/^/  - /'
     fi
   else
     echo "Intent alignment: OK"

--- a/docs/plans/2026-04-10-root-anti-entropy-reconcile-design.md
+++ b/docs/plans/2026-04-10-root-anti-entropy-reconcile-design.md
@@ -32,7 +32,7 @@ Current `platforms/claude-code/commands/signum.md` `Phase 5: RECONCILE`:
 - runs after `AUTO_OK`
 - may update docs / roadmap / manifests
 - may remove code
-- mutates `.signum/contract.json` timestamps after audit
+- mutates canonical `contract.json` metadata after audit (under the active contract artifact root, with a root compatibility view during the migration)
 
 This is too broad for canonical promotion because it blurs three different concerns:
 
@@ -132,7 +132,7 @@ Rule:
 
 After or alongside PACK, root Signum can generate a **report artifact** only:
 
-- `.signum/anti_entropy_report.json`
+- `anti_entropy_report.json` under the active contract artifact root (`.signum/contracts/<contractId>/anti_entropy_report.json`)
 
 This artifact is advisory and does not mutate the repo.
 
@@ -197,9 +197,9 @@ This gives a principled split:
 ### Stage 1 — Report only
 
 Add a deterministic anti-entropy report generator that:
-- reads `contract.json`, `proofpack.json`, `modules.yaml`
+- reads canonical `contract.json`, `proofpack.json`, `modules.yaml`
 - optionally consumes doc parity output and metric-ratchet output
-- emits `.signum/anti_entropy_report.json`
+- emits `anti_entropy_report.json` under the active contract artifact root
 - never edits repo files
 
 This is the safest first canonical step.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -63,7 +63,7 @@ Estimated cost: ~$0.50-1.00.
 
 # Reopen and run the same command
 /signum refactor the payment module
-# Signum detects .signum/contract.json and asks: resume from Phase 2, or restart?
+# Signum checks contracts/index.json.activeContractId and asks: resume from Phase 2, or restart?
 ```
 
 ## Pipeline Phases
@@ -74,17 +74,17 @@ CONTRACT → EXECUTE → AUDIT → PACK
 
 ### Phase 1: CONTRACT
 
-Contractor agent (haiku) scans the codebase and produces `.signum/contract.json` — a structured specification with goal, scope, acceptance criteria, holdout scenarios, and risk assessment.
+Contractor agent (haiku) scans the codebase and produces `contract.json` under the active contract artifact root (`.signum/contracts/<contractId>/`), with a root `.signum/contract.json` compatibility path during the migration.
 
 Hard stop if `openQuestions` is non-empty — the user must answer before proceeding.
 
 ### Phase 2: EXECUTE
 
-1. **Baseline capture** — orchestrator runs lint/typecheck/tests BEFORE any changes, saves to `.signum/baseline.json`.
+1. **Baseline capture** — orchestrator runs lint/typecheck/tests BEFORE any changes and saves `baseline.json` under the active contract artifact root.
 2. **Engineer agent** (sonnet) implements the contract. Repair loop: up to 3 attempts of implement → check acceptance criteria → fix failures.
 3. **Scope gate** — deterministic check that all modified files are within `inScope` or `allowNewFilesUnder`. Pipeline stops on scope violation.
 
-Outputs: `.signum/baseline.json`, `.signum/combined.patch`, `.signum/execute_log.json`.
+Outputs under the active contract artifact root: `baseline.json`, `combined.patch`, `execute_log.json`.
 
 ### Phase 3: AUDIT
 
@@ -105,11 +105,11 @@ Pre-existing failures (checks that failed in baseline AND still fail) no longer 
 
 ### Phase 4: PACK
 
-Assembles `.signum/proofpack.json` — self-contained evidence bundle with embedded artifact contents, SHA-256 checksums, and confidence score.
+Assembles `proofpack.json` under the active contract artifact root — a self-contained evidence bundle with embedded artifact contents, SHA-256 checksums, and confidence score.
 
 ## Artifacts
 
-Live working-set artifacts are written to `.signum/` (auto-added to `.gitignore`). Durable per-contract snapshots are mirrored under `.signum/contracts/<contractId>/` for history/archive flows. The per-contract directory is not the active workspace for an in-flight run.
+Canonical run artifacts live under the active contract artifact root `.signum/contracts/<contractId>/`. Root `.signum/` stays auto-added to `.gitignore` and now mainly holds registry/state surfaces plus compatibility views during the contract-dir migration. The contract, pre-execute metadata, execute outputs, selected audit/pack file artifacts (`contract.json`, `spec_quality.json`, `spec_validation.json`, `clover_report.json`, `intent_check.json`, `approval.json`, `contract-hash.txt`, `contract-engineer.json`, `contract-policy.json`, `execution_context.json`, `baseline.json`, `combined.patch`, `execute_log.json`, `iteration_delta.patch`, `mechanic_report.json`, `holdout_report.json`, `policy_violations.json`, `policy_scan.json`, `audit_iteration_log.json`, `repair_brief.json`, `flaky_tests.json`, `audit_summary.json`, `proofpack.json`, `anti_entropy_report.json`), and active run directories (`reviews/`, `iterations/`, `receipts/`, `runs/`, `snapshots/`) are canonical under that contract directory.
 
 | File | Phase | Contents |
 |------|-------|----------|
@@ -126,13 +126,15 @@ Live working-set artifacts are written to `.signum/` (auto-added to `.gitignore`
 | `proofpack.json` | Pack | Self-contained evidence bundle with embedded artifacts, checksums, and confidence |
 | `anti_entropy_report.json` | Pack | Advisory anti-entropy follow-up findings; report-only, does not change pipeline decision |
 
-Durable per-contract snapshots typically mirror:
+Canonical contract directories typically contain:
 - `contract.json`
 - `proofpack.json`
 - `anti_entropy_report.json`
 - `audit_summary.json`
 - `approval.json`
 - `execution_context.json`
+- `reviews/`
+- `iterations/`
 - `receipts/`
 - `runs/<runId>/`
 - `snapshots/`
@@ -266,7 +268,7 @@ When AUDIT finds MAJOR or CRITICAL issues, it enters an iterative repair loop:
 | `SIGNUM_AUDIT_MAX_ITERATIONS` | `20` | Maximum audit fix iterations before terminal decision |
 | `SIGNUM_CI_RELAXED` | `false` | If `"true"`, HUMAN_REVIEW maps to exit 0 instead of 78 |
 
-Iteration artifacts are stored in `.signum/iterations/01/`, `.signum/iterations/02/`, etc. Each contains the full set of audit artifacts for that pass.
+Iteration artifacts are stored under the active contract artifact root, for example `.signum/contracts/<contractId>/iterations/01/`, `.signum/contracts/<contractId>/iterations/02/`, etc. Each contains the full set of audit artifacts for that pass.
 
 The proofpack includes an `iterativeAudit` section when >1 iteration was used, with per-iteration summaries, resolved/remaining findings, and the best iteration number.
 
@@ -365,7 +367,7 @@ Signum continues without the provider if auth fails.
 
 ### Provider timeout
 
-External providers are killed after 180 seconds. The review continues with remaining providers. Check `.signum/reviews/` for provider status.
+External providers are killed after 180 seconds. The review continues with remaining providers. Check `reviews/` under the canonical artifact root for provider status.
 
 ### `.signum/` exists from previous run
 

--- a/docs/research/2026-03-15-codex-contract-clarification-self-improvement-loops.md
+++ b/docs/research/2026-03-15-codex-contract-clarification-self-improvement-loops.md
@@ -96,7 +96,7 @@ Relevant local lines / sections:
 ### A. Within-task loop: recommended now
 
 Artifact under improvement:
-- `.signum/contract.json` in `draft`
+- `.signum/contracts/<contractId>/contract.json` in `draft`
 
 Loop:
 1. Generate initial `draft contract`

--- a/docs/research/2026-03-15-contract-hierarchy-clarification-architecture-2026.md
+++ b/docs/research/2026-03-15-contract-hierarchy-clarification-architecture-2026.md
@@ -151,12 +151,12 @@ Layer 2: Initiative / Epic
 │   └── INIT-002-name.md
 │
 Layer 3: Task Contract
-├── .signum/contract.json      — narrow executable slice
-├── .signum/contract-engineer.json  (derived, holdouts removed)
-├── .signum/contract-policy.json    (derived, tool constraints)
+├── .signum/contracts/<contractId>/contract.json      — narrow executable slice
+├── .signum/contracts/<contractId>/contract-engineer.json  (derived, holdouts removed)
+├── .signum/contracts/<contractId>/contract-policy.json    (derived, tool constraints)
 │
 Layer 4: Audit
-└── .signum/proofpack.json     — tamper-evident execution record
+└── .signum/contracts/<contractId>/proofpack.json     — tamper-evident execution record
 ```
 
 ### 4.2 Contract Inheritance Model

--- a/docs/research/2026-03-15-extractable-checks-architecture.md
+++ b/docs/research/2026-03-15-extractable-checks-architecture.md
@@ -78,7 +78,8 @@ Signum's checks are 100% deterministic (jq, grep, shasum) — they should NEVER 
 Each check becomes `lib/<name>.sh` with identical logic, just pulled out of markdown. The markdown block becomes a 2-line call:
 
 ```bash
-RESULT=$(lib/glossary-check.sh .signum/contract.json "$GLOSSARY_PATH" 2>/dev/null || echo '{}')
+CONTRACT_PATH=".signum/contracts/<contractId>/contract.json"
+RESULT=$(lib/glossary-check.sh "$CONTRACT_PATH" "$GLOSSARY_PATH" 2>/dev/null || echo '{}')
 echo "$RESULT" | jq -r '.summary // "glossary check: no output"'
 ```
 

--- a/docs/research/2026-03-15-signum-codex-semantic-drift-across-contracts.md
+++ b/docs/research/2026-03-15-signum-codex-semantic-drift-across-contracts.md
@@ -93,7 +93,7 @@ Add a project-level layer above task contracts:
   - decision rationale
 - existing `repo-contract.json`
   - executable repo-wide invariants
-- existing task `.signum/contract.json`
+- existing task `.signum/contracts/<contractId>/contract.json`
   - narrow executable slice
 
 ### 4.2 Contract inheritance

--- a/lib/anti-entropy-report.sh
+++ b/lib/anti-entropy-report.sh
@@ -11,8 +11,8 @@
 set -euo pipefail
 
 PROJECT_ROOT="."
-CONTRACT_PATH=".signum/contract.json"
-PROOFPACK_PATH=".signum/proofpack.json"
+CONTRACT_PATH=""
+PROOFPACK_PATH=""
 DOC_PARITY_JSON=""
 METRIC_RATCHET_JSON=""
 AS_OF="$(date +%F)"
@@ -45,6 +45,62 @@ fi
 
 cd "$PROJECT_ROOT"
 ROOT_ABS="$(pwd)"
+
+abspath_from_root() {
+  local path="$1"
+  if [[ "$path" = /* ]]; then
+    printf '%s\n' "$path"
+  else
+    printf '%s/%s\n' "$ROOT_ABS" "$path"
+  fi
+}
+
+resolve_active_artifact_root() {
+  local index_path="$ROOT_ABS/.signum/contracts/index.json"
+  local active_id=""
+
+  [ -f "$index_path" ] || return 1
+  active_id="$(jq -r '.activeContractId // empty' "$index_path" 2>/dev/null || true)"
+  [ -n "$active_id" ] || return 1
+  [ -d "$ROOT_ABS/.signum/contracts/$active_id" ] || return 1
+
+  printf '%s\n' "$ROOT_ABS/.signum/contracts/$active_id"
+}
+
+resolve_artifact_root() {
+  local output_dir=""
+
+  if [ -n "$OUTPUT_PATH" ]; then
+    output_dir="$(dirname "$(abspath_from_root "$OUTPUT_PATH")")"
+    if [ -f "$output_dir/contract.json" ] || [ -f "$output_dir/proofpack.json" ] || [ "$(basename "$OUTPUT_PATH")" = "anti_entropy_report.json" ]; then
+      printf '%s\n' "$output_dir"
+      return 0
+    fi
+  fi
+
+  if [ -n "$CONTRACT_PATH" ]; then
+    dirname "$(abspath_from_root "$CONTRACT_PATH")"
+    return 0
+  fi
+
+  if [ -n "$PROOFPACK_PATH" ]; then
+    dirname "$(abspath_from_root "$PROOFPACK_PATH")"
+    return 0
+  fi
+
+  if resolve_active_artifact_root >/dev/null 2>&1; then
+    resolve_active_artifact_root
+    return 0
+  fi
+
+  printf '%s\n' "$ROOT_ABS/.signum"
+}
+
+ARTIFACT_ROOT="$(resolve_artifact_root)"
+
+[ -n "$OUTPUT_PATH" ] && OUTPUT_PATH="$(abspath_from_root "$OUTPUT_PATH")"
+[ -n "$CONTRACT_PATH" ] || CONTRACT_PATH="$ARTIFACT_ROOT/contract.json"
+[ -n "$PROOFPACK_PATH" ] || PROOFPACK_PATH="$ARTIFACT_ROOT/proofpack.json"
 
 if [ -n "$DOC_PARITY_JSON" ] && [ ! -f "$DOC_PARITY_JSON" ]; then
   echo "doc parity JSON not found: $DOC_PARITY_JSON" >&2

--- a/lib/boundary-verifier.sh
+++ b/lib/boundary-verifier.sh
@@ -9,9 +9,9 @@
 #
 # Options:
 #   --workspace-root PATH       Workspace root to inspect (default: $PWD)
-#   --signum-dir PATH           Signum artifact dir (default: .signum)
-#   --contract PATH             Engineer-visible contract (default: .signum/contract-engineer.json)
-#   --contract-full PATH        Full contract (default: .signum/contract.json)
+#   --signum-dir PATH           Signum artifact dir (default: active contract root from .signum/contracts/index.json, else .signum)
+#   --contract PATH             Engineer-visible contract (default: <signum-dir>/contract-engineer.json)
+#   --contract-full PATH        Full contract (default: <signum-dir>/contract.json)
 #   --snapshot PATH             Snapshot JSON from snapshot-tree.sh
 #   --execution-context PATH    Execution context JSON
 #   --artifacts CSV             Artifact names under signum dir (default: combined.patch,execute_log.json)
@@ -26,7 +26,7 @@ else
 fi
 
 WORKSPACE_ROOT="$PWD"
-SIGNUM_DIR=".signum"
+SIGNUM_DIR=""
 CONTRACT_ENGINEER=""
 CONTRACT_FULL=""
 SNAPSHOT_JSON=""
@@ -74,6 +74,22 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "boundary-verifier.sh: jq not found" >&2
   exit 1
 fi
+
+resolve_default_signum_dir() {
+  local workspace_root="$1"
+  local index_path="$workspace_root/.signum/contracts/index.json"
+  local active_id=""
+
+  if [[ -f "$index_path" ]]; then
+    active_id="$(jq -r '.activeContractId // empty' "$index_path" 2>/dev/null || true)"
+    if [[ -n "$active_id" && -d "$workspace_root/.signum/contracts/$active_id" ]]; then
+      printf '%s\n' "$workspace_root/.signum/contracts/$active_id"
+      return 0
+    fi
+  fi
+
+  printf '%s\n' "$workspace_root/.signum"
+}
 
 hash_file() {
   local path="$1"
@@ -195,6 +211,9 @@ classify_verify_strength() {
 }
 
 ABS_WORKSPACE=$(CDPATH= cd "$WORKSPACE_ROOT" && pwd)
+if [[ -z "$SIGNUM_DIR" ]]; then
+  SIGNUM_DIR="$(resolve_default_signum_dir "$ABS_WORKSPACE")"
+fi
 if [[ "$SIGNUM_DIR" = /* ]]; then
   ABS_SIGNUM_DIR="$SIGNUM_DIR"
 else

--- a/lib/contract-dir.sh
+++ b/lib/contract-dir.sh
@@ -1,10 +1,85 @@
 #!/usr/bin/env bash
 # contract-dir.sh — per-contract directory management for Signum
-# Functions: contract_dir, init_contract_dir, sync_contract_artifacts,
-#            register_contract, update_contract_status,
-#            get_active_contract, current_contract_dir
+# Functions: new_contract_id, contract_dir, init_contract_dir,
+#            sync_contract_artifacts, register_contract, set_active_contract,
+#            clear_active_contract, update_contract_status,
+#            get_active_contract, get_contract_status,
+#            describe_active_contract_state,
+#            active_artifact_root, active_artifact_path,
+#            link_active_artifact, ensure_active_artifact_dir,
+#            remove_root_artifact_view, archive_contract_artifacts,
+#            purge_root_working_set_views, reset_active_artifact,
+#            promote_root_artifact_to_active, current_contract_dir
 #
 # Requires: jq, bash 4.0+, standard POSIX utils
+
+# _random_hex4
+# Returns 4 lowercase hex chars.
+_random_hex4() {
+  if command -v od >/dev/null 2>&1; then
+    od -An -N2 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n'
+  else
+    printf '%04x' "$((RANDOM % 65536))"
+  fi
+}
+
+# new_contract_id
+# Returns a canonical contract id for a new run.
+new_contract_id() {
+  printf 'sig-%s-%s\n' "$(date -u +%Y%m%d-%H%M)" "$(_random_hex4)"
+}
+
+# _relative_path <target> <from_dir>
+# Returns a relative path from from_dir to target.
+_relative_path() {
+  local target="${1:-}"
+  local from_dir="${2:-}"
+  if [[ -z "$target" || -z "$from_dir" ]]; then
+    echo "_relative_path: target and from_dir required" >&2
+    return 1
+  fi
+  python3 - "$target" "$from_dir" <<'PY'
+import os
+import sys
+
+target = sys.argv[1]
+from_dir = sys.argv[2]
+print(os.path.relpath(target, from_dir))
+PY
+}
+
+# _realpath_or_self <path>
+# Returns the normalized absolute path, resolving symlinks where possible.
+_realpath_or_self() {
+  local path="${1:-}"
+  if [[ -z "$path" ]]; then
+    echo "_realpath_or_self: path required" >&2
+    return 1
+  fi
+  python3 - "$path" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))
+PY
+}
+
+# _remove_artifact_path <path>
+# Removes a file, symlink, or directory path without following symlinked dirs.
+_remove_artifact_path() {
+  local path="${1:-}"
+  if [[ -z "$path" ]]; then
+    echo "_remove_artifact_path: path required" >&2
+    return 1
+  fi
+  if [[ -L "$path" ]]; then
+    rm -f "$path"
+  elif [[ -d "$path" ]]; then
+    rm -rf "$path"
+  elif [[ -e "$path" ]]; then
+    rm -f "$path"
+  fi
+}
 
 # contract_dir <contractId>
 # Returns the path for a contract's isolated directory.
@@ -31,7 +106,7 @@ init_contract_dir() {
     return 1
   fi
   local dir
-  dir=$(contract_dir "$contract_id")
+  dir=$(contract_dir "$contract_id") || return 1
   mkdir -p "${dir}"
   echo "Initialized contract directory: ${dir}"
 }
@@ -52,10 +127,10 @@ sync_contract_artifacts() {
   fi
 
   local dir
-  dir=$(contract_dir "$contract_id")
+  dir=$(contract_dir "$contract_id") || return 1
   mkdir -p "$dir"
 
-  local rel src dst copied=0
+  local rel src dst src_real dst_real copied=0
   for rel in "$@"; do
     if [[ -z "$rel" ]]; then
       continue
@@ -65,6 +140,11 @@ sync_contract_artifacts() {
       continue
     fi
     dst="${dir}${rel}"
+    src_real=$(_realpath_or_self "$src")
+    dst_real=$(_realpath_or_self "$dst")
+    if [[ "$src_real" == "$dst_real" ]]; then
+      continue
+    fi
     if [[ -d "$src" ]]; then
       mkdir -p "$dst"
       cp -R "$src"/. "$dst"/
@@ -90,7 +170,7 @@ _ensure_index() {
 
 # register_contract <contractId> <contract_status>
 # Adds or updates an entry in .signum/contracts/index.json.
-# Sets activeContractId to this contract.
+# Does not change activeContractId; callers must set that explicitly.
 register_contract() {
   local contract_id="${1:-}"
   local contract_status="${2:-draft}"
@@ -116,7 +196,7 @@ register_contract() {
     assumptions_arg=$(jq -c '[(.assumptions // [])[] | .text // .]' "$contract_file" 2>/dev/null || echo '[]')
   fi
 
-  # Add or update entry; also set activeContractId
+  # Add or update entry
   jq --arg id "$contract_id" \
      --arg st "$contract_status" \
      --arg dir "$dir" \
@@ -125,7 +205,6 @@ register_contract() {
      --argjson inscope "${inscope_arg:-[]}" \
      --argjson assumptions "${assumptions_arg:-[]}" \
      '
-     .activeContractId = $id |
      if any(.contracts[]; .contractId == $id) then
        .contracts = [.contracts[] |
          if .contractId == $id then
@@ -137,6 +216,69 @@ register_contract() {
      ' "$index" > "${index}.tmp" && mv "${index}.tmp" "$index"
 
   echo "Registered contract ${contract_id} (status=${contract_status}) in ${index}"
+}
+
+# set_active_contract <contractId>
+# Updates activeContractId for an already-registered contract.
+set_active_contract() {
+  local contract_id="${1:-}"
+  if [[ -z "$contract_id" ]]; then
+    echo "set_active_contract: contractId required" >&2
+    return 1
+  fi
+
+  _ensure_index
+
+  local index=".signum/contracts/index.json"
+  local exists
+  exists=$(jq --arg id "$contract_id" 'any(.contracts[]; .contractId == $id)' "$index")
+  if [[ "$exists" != "true" ]]; then
+    echo "set_active_contract: contractId '${contract_id}' not found in index" >&2
+    return 1
+  fi
+
+  jq --arg id "$contract_id" '.activeContractId = $id' \
+    "$index" > "${index}.tmp" && mv "${index}.tmp" "$index"
+
+  echo "Set active contract to ${contract_id}"
+}
+
+# clear_active_contract
+# Clears activeContractId in index.json.
+clear_active_contract() {
+  _ensure_index
+
+  local index=".signum/contracts/index.json"
+  jq '.activeContractId = null' \
+    "$index" > "${index}.tmp" && mv "${index}.tmp" "$index"
+
+  echo "Cleared active contract"
+}
+
+# _is_terminal_status <status>
+# Returns success for statuses that must not remain active.
+_is_terminal_status() {
+  case "${1:-}" in
+    completed|archived|closed|superseded)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# _is_resumable_status <status>
+# Returns success for statuses that may remain active/resumable.
+_is_resumable_status() {
+  case "${1:-}" in
+    draft|active|approved|executing|auditing|human_review|blocked)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 # update_contract_status <contractId> <newStatus>
@@ -168,6 +310,12 @@ update_contract_status() {
        if .contractId == $id then . + {status: $st} else . end]' \
      "$index" > "${index}.tmp" && mv "${index}.tmp" "$index"
 
+  local active
+  active=$(jq -r '.activeContractId // empty' "$index")
+  if [[ "$active" == "$contract_id" ]] && _is_terminal_status "$new_status"; then
+    clear_active_contract >/dev/null
+  fi
+
   echo "Updated contract ${contract_id} status to ${new_status}"
 }
 
@@ -182,14 +330,324 @@ get_active_contract() {
   jq -r '.activeContractId // empty' "$index"
 }
 
-# current_contract_dir
-# Returns the directory path for the currently active contract.
-current_contract_dir() {
+# get_contract_status <contractId>
+# Reads and returns the status for a contract in index.json.
+get_contract_status() {
+  local contract_id="${1:-}"
+  if [[ -z "$contract_id" ]]; then
+    echo "get_contract_status: contractId required" >&2
+    return 1
+  fi
+
+  local index=".signum/contracts/index.json"
+  if [[ ! -f "$index" ]]; then
+    echo "get_contract_status: index.json not found" >&2
+    return 1
+  fi
+
+  local status
+  status=$(jq -r --arg id "$contract_id" '.contracts[] | select(.contractId == $id) | .status // empty' "$index")
+  if [[ -z "$status" ]]; then
+    echo "get_contract_status: contractId '${contract_id}' not found in index" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$status"
+}
+
+# describe_active_contract_state
+# Emits JSON describing the current active/resumable contract state.
+describe_active_contract_state() {
+  local state="NONE"
+  local active=""
+  local status=""
+  local root=""
+
+  active=$(get_active_contract 2>/dev/null || true)
+  if [[ -n "$active" ]]; then
+    status=$(get_contract_status "$active" 2>/dev/null || true)
+    root=$(contract_dir "$active" 2>/dev/null || true)
+
+    if [[ -z "$root" ]]; then
+      clear_active_contract >/dev/null 2>&1 || true
+      active=""
+      status=""
+    elif [[ -n "$status" ]] && ! _is_resumable_status "$status"; then
+      clear_active_contract >/dev/null 2>&1 || true
+      active=""
+      status=""
+      root=""
+    elif [[ -f "${root}contract.json" && -f "${root}execution_context.json" ]]; then
+      state="RESUMABLE"
+    elif [[ -f "${root}contract.json" ]]; then
+      state="CONTRACT_ONLY"
+    else
+      clear_active_contract >/dev/null 2>&1 || true
+      active=""
+      status=""
+      root=""
+    fi
+  fi
+
+  jq -n \
+    --arg state "$state" \
+    --arg contract_id "$active" \
+    --arg status "$status" \
+    --arg artifact_root "$root" \
+    '{
+      state: $state,
+      contractId: (if $contract_id == "" then null else $contract_id end),
+      status: (if $status == "" then null else $status end),
+      artifactRoot: (if $artifact_root == "" then null else $artifact_root end)
+    }'
+}
+
+# active_artifact_root
+# Returns the canonical artifact root for the currently active contract.
+active_artifact_root() {
   local active
   active=$(get_active_contract)
   if [[ -z "$active" ]]; then
-    echo "current_contract_dir: no active contract in index.json" >&2
+    echo "active_artifact_root: no active contract in index.json" >&2
     return 1
   fi
   contract_dir "$active"
+}
+
+# active_artifact_path <relative_path>
+# Returns the path for an artifact under the active contract root.
+active_artifact_path() {
+  local rel="${1:-}"
+  if [[ -z "$rel" ]]; then
+    echo "active_artifact_path: relative path required" >&2
+    return 1
+  fi
+  local root
+  root=$(active_artifact_root) || return 1
+  printf '%s%s\n' "$root" "$rel"
+}
+
+# remove_root_artifact_view <relative_path>
+# Removes only the root .signum/ compatibility view for an artifact.
+remove_root_artifact_view() {
+  local rel="${1:-}"
+  if [[ -z "$rel" ]]; then
+    echo "remove_root_artifact_view: relative path required" >&2
+    return 1
+  fi
+
+  local root_path=".signum/${rel}"
+  _remove_artifact_path "$root_path"
+
+  echo "Removed root artifact view: ${root_path}"
+}
+
+# archive_contract_artifacts <contractId> <archive_dir>
+# Copies archive-worthy canonical artifacts for a contract into archive_dir.
+archive_contract_artifacts() {
+  local contract_id="${1:-}"
+  local archive_dir="${2:-}"
+  if [[ -z "$contract_id" || -z "$archive_dir" ]]; then
+    echo "archive_contract_artifacts: contractId and archive_dir required" >&2
+    return 1
+  fi
+
+  local dir
+  dir=$(contract_dir "$contract_id") || return 1
+  if [[ ! -d "$dir" ]]; then
+    echo "archive_contract_artifacts: contract directory not found: ${dir}" >&2
+    return 1
+  fi
+
+  mkdir -p "$archive_dir"
+
+  local rel copied=0
+  for rel in \
+    contract.json \
+    proofpack.json \
+    approval.json \
+    audit_summary.json \
+    anti_entropy_report.json \
+    execution_context.json \
+    reconcile_report.json \
+    retro.json; do
+    if [[ -f "${dir}${rel}" ]]; then
+      cp "${dir}${rel}" "$archive_dir/"
+      copied=$((copied + 1))
+    fi
+  done
+
+  for rel in receipts runs snapshots; do
+    if [[ -d "${dir}${rel}" ]]; then
+      mkdir -p "${archive_dir}/${rel}"
+      cp -R "${dir}${rel}/." "${archive_dir}/${rel}/"
+      copied=$((copied + 1))
+    fi
+  done
+
+  echo "Archived ${copied} contract artifact(s) from ${dir} to ${archive_dir}"
+}
+
+# purge_root_working_set_views
+# Removes the root .signum/ compatibility surface for the active working set.
+purge_root_working_set_views() {
+  local rel
+  for rel in \
+    contract.json \
+    contract-engineer.json \
+    contract-policy.json \
+    execute_log.json \
+    combined.patch \
+    iteration_delta.patch \
+    baseline.json \
+    mechanic_report.json \
+    holdout_report.json \
+    audit_summary.json \
+    proofpack.json \
+    approval.json \
+    anti_entropy_report.json \
+    policy_violations.json \
+    policy_scan.json \
+    spec_quality.json \
+    spec_validation.json \
+    repo_contract_baseline.json \
+    repo_contract_violations.json \
+    contract-hash.txt \
+    execution_context.json \
+    review_prompt_codex.txt \
+    review_prompt_gemini.txt \
+    review_context.json \
+    clover_report.json \
+    intent_check.json \
+    audit_iteration_log.json \
+    repair_brief.json \
+    flaky_tests.json \
+    reconcile_report.json \
+    retro.json; do
+    remove_root_artifact_view "$rel" >/dev/null 2>&1 || true
+  done
+
+  for rel in reviews iterations receipts runs snapshots; do
+    remove_root_artifact_view "$rel" >/dev/null 2>&1 || true
+  done
+
+  echo "Purged root working set views"
+}
+
+# link_active_artifact <relative_path>
+# Creates a compatibility symlink in root .signum/ that points at the active contract artifact.
+link_active_artifact() {
+  local rel="${1:-}"
+  if [[ -z "$rel" ]]; then
+    echo "link_active_artifact: relative path required" >&2
+    return 1
+  fi
+
+  local root_path=".signum/${rel}"
+  local active_path
+  active_path=$(active_artifact_path "$rel") || return 1
+
+  mkdir -p "$(dirname "$root_path")" "$(dirname "$active_path")"
+
+  if [[ -e "$root_path" || -L "$root_path" ]]; then
+    remove_root_artifact_view "$rel" >/dev/null
+  fi
+
+  local link_target
+  link_target=$(_relative_path "$active_path" "$(dirname "$root_path")")
+  ln -s "$link_target" "$root_path"
+
+  echo "Linked ${root_path} -> ${active_path}"
+}
+
+# ensure_active_artifact_dir <relative_path>
+# Ensures a canonical directory exists in the active contract root and exposes
+# it through a root compatibility symlink.
+ensure_active_artifact_dir() {
+  local rel="${1:-}"
+  if [[ -z "$rel" ]]; then
+    echo "ensure_active_artifact_dir: relative path required" >&2
+    return 1
+  fi
+
+  local active_path
+  active_path=$(active_artifact_path "$rel") || return 1
+  mkdir -p "$active_path"
+  link_active_artifact "$rel" >/dev/null
+
+  echo "Ensured active artifact dir: ${active_path}"
+}
+
+# reset_active_artifact <relative_path> [file|dir]
+# Clears both the root compatibility path and the canonical active artifact,
+# then recreates the compatibility link for the requested kind.
+reset_active_artifact() {
+  local rel="${1:-}"
+  local kind="${2:-file}"
+  if [[ -z "$rel" ]]; then
+    echo "reset_active_artifact: relative path required" >&2
+    return 1
+  fi
+
+  local active_path
+  active_path=$(active_artifact_path "$rel") || return 1
+
+  remove_root_artifact_view "$rel" >/dev/null
+  _remove_artifact_path "$active_path"
+
+  case "$kind" in
+    file)
+      link_active_artifact "$rel" >/dev/null
+      ;;
+    dir)
+      ensure_active_artifact_dir "$rel" >/dev/null
+      ;;
+    *)
+      echo "reset_active_artifact: kind must be file or dir" >&2
+      return 1
+      ;;
+  esac
+
+  echo "Reset active artifact: ${active_path} (${kind})"
+}
+
+# promote_root_artifact_to_active <relative_path>
+# Moves an existing root .signum artifact into the active contract dir, then
+# recreates the root path as a compatibility symlink to the canonical location.
+promote_root_artifact_to_active() {
+  local rel="${1:-}"
+  if [[ -z "$rel" ]]; then
+    echo "promote_root_artifact_to_active: relative path required" >&2
+    return 1
+  fi
+
+  local root_path=".signum/${rel}"
+  local active_path
+  active_path=$(active_artifact_path "$rel") || return 1
+
+  mkdir -p "$(dirname "$root_path")" "$(dirname "$active_path")"
+
+  if [[ -L "$root_path" ]]; then
+    rm -f "$root_path"
+  elif [[ -d "$root_path" ]]; then
+    mkdir -p "$active_path"
+    cp -R "$root_path"/. "$active_path"/
+    rm -rf "$root_path"
+  elif [[ -e "$root_path" ]]; then
+    if [[ -e "$active_path" ]]; then
+      cp -f "$root_path" "$active_path"
+      rm -f "$root_path"
+    else
+      mv "$root_path" "$active_path"
+    fi
+  fi
+
+  link_active_artifact "$rel" >/dev/null
+  echo "Promoted ${root_path} -> ${active_path}"
+}
+
+# current_contract_dir
+# Backward-compatible alias for active_artifact_root.
+current_contract_dir() {
+  active_artifact_root
 }

--- a/lib/contract-injection-scan.sh
+++ b/lib/contract-injection-scan.sh
@@ -8,19 +8,46 @@
 # Glassworm research (variation selectors, bidi overrides, tag characters).
 #
 # Usage: contract-injection-scan.sh [contract_file]
-# Default: .signum/contract.json
+# Default: active contract root from .signum/contracts/index.json, then a single canonical contract dir, then legacy .signum/contract.json
 # Exit 0: clean (no injection found)
 # Exit 1: blocked (invisible Unicode detected)
 # Exit 2: usage error (missing file, missing tools)
 
 set -euo pipefail
 
-CONTRACT_FILE="${1:-.signum/contract.json}"
+resolve_default_contract_file() {
+  local index_path=".signum/contracts/index.json"
+  local contracts_root=".signum/contracts"
+  local active_id=""
+  local canonical_path=""
+  local dir_count=""
+  local only_dir=""
 
-if [ ! -f "$CONTRACT_FILE" ]; then
-  echo "ERROR: contract file not found: $CONTRACT_FILE" >&2
-  exit 2
-fi
+  if [ -f "$index_path" ]; then
+    active_id="$(jq -r '.activeContractId // empty' "$index_path" 2>/dev/null || true)"
+    if [ -n "$active_id" ]; then
+      canonical_path=".signum/contracts/${active_id}/contract.json"
+      if [ -f "$canonical_path" ]; then
+        printf '%s\n' "$canonical_path"
+        return 0
+      fi
+    fi
+  fi
+
+  if [ -d "$contracts_root" ]; then
+    dir_count=$(find "$contracts_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d '[:space:]')
+    if [ "$dir_count" = "1" ]; then
+      only_dir=$(find "$contracts_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -n 1)
+      canonical_path="${only_dir}/contract.json"
+      if [ -f "$canonical_path" ]; then
+        printf '%s\n' "$canonical_path"
+        return 0
+      fi
+    fi
+  fi
+
+  printf '%s\n' ".signum/contract.json"
+}
 
 if ! command -v jq > /dev/null 2>&1; then
   echo "ERROR: jq not found" >&2
@@ -32,24 +59,35 @@ if ! command -v python3 > /dev/null 2>&1; then
   exit 2
 fi
 
+CONTRACT_FILE="${1:-}"
+
+if [ -z "$CONTRACT_FILE" ]; then
+  CONTRACT_FILE="$(resolve_default_contract_file)"
+fi
+
+if [ ! -f "$CONTRACT_FILE" ]; then
+  echo "ERROR: contract file not found: $CONTRACT_FILE" >&2
+  exit 2
+fi
+
 # Extract all human-readable text fields from contract.json
 # These are the injection surfaces: goal, scope items, AC descriptions, assumptions
 jq -r '
   [
-    .goal // empty,
-    (.inScope // [])[] // empty,
-    (.outOfScope // [])[] // empty,
-    (.acceptanceCriteria // [])[].description // empty,
-    (.acceptanceCriteria // [])[].verify // empty | tostring,
-    ((.assumptions // [])[] | if type == "object" then .text else . end) // empty,
-    (.openQuestions // [])[] // empty,
-    (.removals // [])[].reason // empty,
-    (.cleanupObligations // [])[].description // empty,
-    .implementationStrategy // empty,
-    (.allowNewFilesUnder // [])[] // empty,
-    (.riskSignals // [])[] // empty,
-    (.contextInheritance // {} | .. | strings) // empty
-  ] | .[]
+    (.goal // empty),
+    ((.inScope // [])[]?),
+    ((.outOfScope // [])[]?),
+    ((.acceptanceCriteria // [])[]? | .description // empty),
+    ((.acceptanceCriteria // [])[]? | .verify // empty | tostring),
+    ((.assumptions // [])[]? | if type == "object" then (.text // empty) else . end),
+    ((.openQuestions // [])[]?),
+    ((.removals // [])[]? | .reason // empty),
+    ((.cleanupObligations // [])[]? | .description // empty),
+    (.implementationStrategy // empty),
+    ((.allowNewFilesUnder // [])[]?),
+    ((.riskSignals // [])[]?),
+    ((.contextInheritance // {}) | .. | strings)
+  ] | .[] | select(. != "")
 ' "$CONTRACT_FILE" 2>/dev/null | python3 -c "
 import re, sys
 

--- a/lib/mechanic-parser.sh
+++ b/lib/mechanic-parser.sh
@@ -5,18 +5,26 @@
 # Structured JSON output for ruff (--output-format json) and eslint (-f json).
 # Parseable text patterns for pytest/cargo test (origin:stable_text).
 # Usage: mechanic-parser.sh <baseline_json_path>
-# Output: .signum/mechanic_report.json
+# Output: <baseline_dir>/mechanic_report.json
 # Exit 0: report written (checks may have regressions — that is not a fatal error)
 # Exit 1: fatal error (missing jq, missing baseline file)
 
 set -uo pipefail
 
 BASELINE_FILE="${1:-}"
+OUTPUT_DIR=""
+MECHANIC_REPORT_PATH=""
+FLAKY_TESTS_PATH=""
 
 if [ -z "$BASELINE_FILE" ]; then
   echo "Usage: mechanic-parser.sh <baseline_json_path>" >&2
   exit 1
 fi
+
+OUTPUT_DIR=$(dirname "$BASELINE_FILE")
+[ -n "$OUTPUT_DIR" ] || OUTPUT_DIR="."
+MECHANIC_REPORT_PATH="${OUTPUT_DIR}/mechanic_report.json"
+FLAKY_TESTS_PATH="${OUTPUT_DIR}/flaky_tests.json"
 
 if ! command -v jq > /dev/null 2>&1; then
   echo "ERROR: jq not found" >&2
@@ -28,7 +36,7 @@ if [ ! -f "$BASELINE_FILE" ]; then
   exit 1
 fi
 
-mkdir -p .signum
+mkdir -p "$OUTPUT_DIR"
 
 # ---------------------------------------------------------------------------
 # Read baseline exit codes
@@ -183,7 +191,7 @@ if [ -f "pyproject.toml" ] && grep -q "pytest" pyproject.toml 2>/dev/null; then
   # Persist flaky tests
   jq -n --argjson flaky "$FLAKY_TESTS" \
     '{"detectedAt": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'", "flakyTests": $flaky}' \
-    > .signum/flaky_tests.json
+    > "$FLAKY_TESTS_PATH"
   if [ "$(echo "$FLAKY_TESTS" | jq 'length')" -gt 0 ]; then
     echo "Flaky tests detected (removed from NEW_FAILURES): $(echo "$FLAKY_TESTS" | jq -r '.[]' | tr '\n' ' ')"
   fi
@@ -394,6 +402,6 @@ jq -n \
                  regression: (if ($new_failures | length) > 0 then true
                               elif $bl_test == 0 and $test_exit != 0 then true
                               else false end) }
-  }' > .signum/mechanic_report.json
+  }' > "$MECHANIC_REPORT_PATH"
 
 echo "Mechanic done. Lint=${LINT_ID}:${LINT_EXIT}(bl:${BL_LINT}) Typecheck=${TYPE_ID}:${TYPE_EXIT}(bl:${BL_TYPE}) Tests=${TEST_ID}:${TEST_EXIT}(bl:${BL_TEST})"

--- a/lib/metric-ratchet.sh
+++ b/lib/metric-ratchet.sh
@@ -5,7 +5,7 @@
 #
 # Usage: metric-ratchet.sh [days_current] [days_previous]
 # Default: 7 days current vs 7 days previous
-# Output: .signum/metrics/ratchet-report.json
+# Output: project-level .signum/metrics/ratchet-report.json
 # Exit 0: metrics computed (may include regressions)
 # Exit 1: no data available
 # Exit 2: usage error
@@ -20,9 +20,16 @@ if ! [[ "$DAYS_CURRENT" =~ ^[0-9]+$ ]] || ! [[ "$DAYS_PREVIOUS" =~ ^[0-9]+$ ]]; 
   exit 2
 fi
 
-METRICS_DIR=".signum/metrics"
-ARCHIVE_DIR=".signum/archive"
-INDEX_FILE=".signum/proofpack-index.jsonl"
+PROJECT_ROOT="${SIGNUM_PROJECT_ROOT:-$PWD}"
+if [[ "$PROJECT_ROOT" = /* ]]; then
+  ABS_PROJECT_ROOT="$PROJECT_ROOT"
+else
+  ABS_PROJECT_ROOT="$PWD/$PROJECT_ROOT"
+fi
+
+METRICS_DIR="$ABS_PROJECT_ROOT/.signum/metrics"
+ARCHIVE_DIR="$ABS_PROJECT_ROOT/.signum/archive"
+INDEX_FILE="$ABS_PROJECT_ROOT/.signum/proofpack-index.jsonl"
 REPORT_FILE="${METRICS_DIR}/ratchet-report.json"
 
 mkdir -p "$METRICS_DIR"
@@ -109,17 +116,20 @@ json.dump({
 # Collect current and previous period
 CURRENT_DATA=$(collect_proofpacks "$DAYS_CURRENT")
 TOTAL_DAYS=$((DAYS_CURRENT + DAYS_PREVIOUS))
-PREVIOUS_DATA=$(collect_proofpacks "$TOTAL_DAYS" | python3 - "$DAYS_CURRENT" <<'PYEOF'
+PREVIOUS_DATA=$(collect_proofpacks "$TOTAL_DAYS" | python3 -c '
 import json, sys
 from datetime import datetime, timedelta, timezone
+
 cutoff = datetime.now(timezone.utc) - timedelta(days=int(sys.argv[1]))
-cutoff_str = cutoff.strftime('%Y-%m-%dT%H:%M:%SZ')
+cutoff_str = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
+
 for line in sys.stdin:
-    if line.strip():
-        e = json.loads(line)
-        if e.get('createdAt', '') < cutoff_str:
-            print(line.strip())
-PYEOF
+    if not line.strip():
+        continue
+    entry = json.loads(line)
+    if entry.get("createdAt", "") < cutoff_str:
+        print(line.strip())
+' "$DAYS_CURRENT"
 )
 
 CURRENT_METRICS=$(echo "$CURRENT_DATA" | compute_metrics)
@@ -134,7 +144,7 @@ if [ "$CURRENT_COUNT" -eq 0 ] && [ "$PREVIOUS_COUNT" -eq 0 ]; then
 fi
 
 # Compare and detect regressions
-REPORT=$(printf '%s\n%s' "$CURRENT_METRICS" "$PREVIOUS_METRICS" | python3 - "$DAYS_CURRENT" "$DAYS_PREVIOUS" <<'PYEOF'
+REPORT=$(printf '%s\n%s\n' "$CURRENT_METRICS" "$PREVIOUS_METRICS" | python3 -c '
 import json, sys
 
 current = json.loads(sys.stdin.readline())
@@ -143,41 +153,41 @@ regressions = []
 improvements = []
 
 def compare(metric, label, higher_is_better=True):
-    c = current.get(metric, 0)
-    p = previous.get(metric, 0)
-    if previous.get('count', 0) == 0:
-        return  # no baseline
-    delta = c - p
-    threshold = 10  # 10 percentage points
+    current_value = current.get(metric, 0)
+    previous_value = previous.get(metric, 0)
+    if previous.get("count", 0) == 0:
+        return
+    delta = current_value - previous_value
+    threshold = 10
     if higher_is_better and delta < -threshold:
-        regressions.append({'metric': label, 'current': c, 'previous': p, 'delta': round(delta, 1)})
+        regressions.append({"metric": label, "current": current_value, "previous": previous_value, "delta": round(delta, 1)})
     elif not higher_is_better and delta > threshold:
-        regressions.append({'metric': label, 'current': c, 'previous': p, 'delta': round(delta, 1)})
+        regressions.append({"metric": label, "current": current_value, "previous": previous_value, "delta": round(delta, 1)})
     elif higher_is_better and delta > threshold:
-        improvements.append({'metric': label, 'current': c, 'previous': p, 'delta': round(delta, 1)})
+        improvements.append({"metric": label, "current": current_value, "previous": previous_value, "delta": round(delta, 1)})
     elif not higher_is_better and delta < -threshold:
-        improvements.append({'metric': label, 'current': c, 'previous': p, 'delta': round(delta, 1)})
+        improvements.append({"metric": label, "current": current_value, "previous": previous_value, "delta": round(delta, 1)})
 
-compare('auto_ok_rate', 'AUTO_OK rate', True)
-compare('auto_block_rate', 'AUTO_BLOCK rate', False)
-compare('human_review_rate', 'HUMAN_REVIEW rate', False)
-compare('avg_confidence', 'Average confidence', True)
-compare('promote_rate', 'PROMOTE rate', True)
+compare("auto_ok_rate", "AUTO_OK rate", True)
+compare("auto_block_rate", "AUTO_BLOCK rate", False)
+compare("human_review_rate", "HUMAN_REVIEW rate", False)
+compare("avg_confidence", "Average confidence", True)
+compare("promote_rate", "PROMOTE rate", True)
 
-status = 'regression' if regressions else ('improved' if improvements else 'stable')
+status = "regression" if regressions else ("improved" if improvements else "stable")
 days_current = int(sys.argv[1])
 days_previous = int(sys.argv[2])
 
 report = {
-    'status': status,
-    'period': {'current_days': days_current, 'previous_days': days_previous},
-    'current': current,
-    'previous': previous,
-    'regressions': regressions,
-    'improvements': improvements
+    "status": status,
+    "period": {"current_days": days_current, "previous_days": days_previous},
+    "current": current,
+    "previous": previous,
+    "regressions": regressions,
+    "improvements": improvements,
 }
 print(json.dumps(report, indent=2))
-PYEOF
+' "$DAYS_CURRENT" "$DAYS_PREVIOUS"
 )
 
 echo "$REPORT" > "$REPORT_FILE"

--- a/lib/pack-anti-entropy.sh
+++ b/lib/pack-anti-entropy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# pack-anti-entropy.sh -- safe writer for .signum/anti_entropy_report.json
+# pack-anti-entropy.sh -- safe writer for anti_entropy_report.json beside canonical contract artifacts
 # Always exits 0. If anti-entropy-report.sh fails, writes a fallback error artifact instead.
 #
 # Usage:
@@ -11,11 +11,11 @@
 set -euo pipefail
 
 PROJECT_ROOT="."
-CONTRACT_PATH=".signum/contract.json"
-PROOFPACK_PATH=".signum/proofpack.json"
+CONTRACT_PATH=""
+PROOFPACK_PATH=""
 DOC_PARITY_JSON=""
 METRIC_RATCHET_JSON=""
-OUTPUT_PATH=".signum/anti_entropy_report.json"
+OUTPUT_PATH=""
 AS_OF=""
 
 while [[ $# -gt 0 ]]; do
@@ -38,9 +38,65 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPORTER="$SCRIPT_DIR/anti-entropy-report.sh"
 PROJECT_ROOT_ABS="$(cd "$PROJECT_ROOT" && pwd)"
 
-if [[ "$OUTPUT_PATH" != /* ]]; then
-  OUTPUT_PATH="$PROJECT_ROOT_ABS/$OUTPUT_PATH"
-fi
+abspath_from_root() {
+  local path="$1"
+  if [[ "$path" = /* ]]; then
+    printf '%s\n' "$path"
+  else
+    printf '%s/%s\n' "$PROJECT_ROOT_ABS" "$path"
+  fi
+}
+
+resolve_active_artifact_root() {
+  local index_path="$PROJECT_ROOT_ABS/.signum/contracts/index.json"
+  local active_id=""
+
+  [ -f "$index_path" ] || return 1
+  active_id="$(jq -r '.activeContractId // empty' "$index_path" 2>/dev/null || true)"
+  [ -n "$active_id" ] || return 1
+  [ -d "$PROJECT_ROOT_ABS/.signum/contracts/$active_id" ] || return 1
+
+  printf '%s\n' "$PROJECT_ROOT_ABS/.signum/contracts/$active_id"
+}
+
+resolve_artifact_root() {
+  local output_dir=""
+
+  if [ -n "$OUTPUT_PATH" ]; then
+    output_dir="$(dirname "$(abspath_from_root "$OUTPUT_PATH")")"
+    if [ -f "$output_dir/contract.json" ] || [ -f "$output_dir/proofpack.json" ] || [ "$(basename "$OUTPUT_PATH")" = "anti_entropy_report.json" ]; then
+      printf '%s\n' "$output_dir"
+      return 0
+    fi
+  fi
+
+  if [ -n "$CONTRACT_PATH" ]; then
+    dirname "$(abspath_from_root "$CONTRACT_PATH")"
+    return 0
+  fi
+
+  if [ -n "$PROOFPACK_PATH" ]; then
+    dirname "$(abspath_from_root "$PROOFPACK_PATH")"
+    return 0
+  fi
+
+  if resolve_active_artifact_root >/dev/null 2>&1; then
+    resolve_active_artifact_root
+    return 0
+  fi
+
+  printf '%s\n' "$PROJECT_ROOT_ABS/.signum"
+}
+
+ARTIFACT_ROOT="$(resolve_artifact_root)"
+
+[ -n "$OUTPUT_PATH" ] || OUTPUT_PATH="$ARTIFACT_ROOT/anti_entropy_report.json"
+[ -n "$CONTRACT_PATH" ] || CONTRACT_PATH="$ARTIFACT_ROOT/contract.json"
+[ -n "$PROOFPACK_PATH" ] || PROOFPACK_PATH="$ARTIFACT_ROOT/proofpack.json"
+
+OUTPUT_PATH="$(abspath_from_root "$OUTPUT_PATH")"
+CONTRACT_PATH="$(abspath_from_root "$CONTRACT_PATH")"
+PROOFPACK_PATH="$(abspath_from_root "$PROOFPACK_PATH")"
 
 if [ -z "$METRIC_RATCHET_JSON" ] && [ -f "$PROJECT_ROOT_ABS/.signum/metrics/ratchet-report.json" ]; then
   METRIC_RATCHET_JSON="$PROJECT_ROOT_ABS/.signum/metrics/ratchet-report.json"

--- a/lib/policy-scanner.sh
+++ b/lib/policy-scanner.sh
@@ -2,18 +2,24 @@
 # policy-scanner.sh -- deterministic policy scan on combined.patch (zero LLM cost)
 # Scans only addition lines (+) in the patch for security, unsafe, and dependency patterns.
 # Usage: policy-scanner.sh <patch_file>
-# Output: .signum/policy_scan.json
+# Output: <patch_dir>/policy_scan.json
 # Exit 0: scan complete (findings may be empty)
 # Exit 1: fatal error (missing tools, missing patch file — writes JSON error + exits non-zero)
 
 set -euo pipefail
 
 PATCH_FILE="${1:-}"
+OUTPUT_DIR=""
+OUTPUT_PATH=""
 
 if [ -z "$PATCH_FILE" ]; then
   echo "Usage: policy-scanner.sh <patch_file>" >&2
   exit 1
 fi
+
+OUTPUT_DIR=$(dirname "$PATCH_FILE")
+[ -n "$OUTPUT_DIR" ] || OUTPUT_DIR="."
+OUTPUT_PATH="${OUTPUT_DIR}/policy_scan.json"
 
 if ! command -v jq > /dev/null 2>&1; then
   echo "ERROR: jq not found" >&2
@@ -22,10 +28,10 @@ fi
 
 if [ ! -f "$PATCH_FILE" ]; then
   echo "ERROR: policy-scanner.sh: patch file not found: $PATCH_FILE" >&2
-  mkdir -p .signum
+  mkdir -p "$OUTPUT_DIR"
   jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg pf "$PATCH_FILE" \
     '{scannedAt:$ts, patchFile:$pf, error:"missing_combined_patch", findings:[], summaryCounts:{critical:0,major:0,minor:0,total:0}}' \
-    > .signum/policy_scan.json
+    > "$OUTPUT_PATH"
   exit 1
 fi
 
@@ -201,7 +207,7 @@ jq -n \
     patchFile: $patchFile,
     findings: $findings,
     summaryCounts: $summaryCounts
-  }' > .signum/policy_scan.json
+  }' > "$OUTPUT_PATH"
 
 TOTAL=$(echo "$COUNTS" | jq -r '.total')
 CRITICAL=$(echo "$COUNTS" | jq -r '.critical')

--- a/lib/proofpack-index.sh
+++ b/lib/proofpack-index.sh
@@ -5,15 +5,102 @@
 #
 # Usage:
 #   source lib/proofpack-index.sh
-#   proofpack_index_append .signum/proofpack.json    # append after PACK
+#   proofpack_index_append .signum/contracts/<contractId>/proofpack.json  # append after PACK
 #   proofpack_index_verify                            # verify chain integrity
 #   proofpack_index_query --since 7d                  # query recent entries
 #
-# Storage: .signum/proofpack-index.jsonl (one JSON object per line)
+# Storage: project-level .signum/proofpack-index.jsonl (one JSON object per line)
 
 set -euo pipefail
 
-INDEX_FILE="${SIGNUM_INDEX_FILE:-.signum/proofpack-index.jsonl}"
+INDEX_FILE="${SIGNUM_INDEX_FILE:-}"
+
+_proofpack_index_project_root_from_path() {
+  local input_path="${1:-}"
+  local abs_path=""
+
+  if [[ -z "$input_path" ]]; then
+    return 1
+  fi
+
+  if [[ "$input_path" = /* ]]; then
+    abs_path="${input_path%/}"
+  else
+    abs_path="${PWD}/${input_path}"
+    abs_path="${abs_path%/}"
+  fi
+
+  case "$abs_path" in
+    */.signum/contracts/*/proofpack.json)
+      printf '%s\n' "${abs_path%/.signum/contracts/*/proofpack.json}"
+      return 0
+      ;;
+    */.signum/contracts/*)
+      printf '%s\n' "${abs_path%/.signum/contracts/*}"
+      return 0
+      ;;
+    */.signum/proofpack.json)
+      printf '%s\n' "${abs_path%/.signum/proofpack.json}"
+      return 0
+      ;;
+    */.signum)
+      printf '%s\n' "${abs_path%/.signum}"
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+_proofpack_index_default_file() {
+  local pp_path="${1:-}"
+  local base_root="${SIGNUM_PROJECT_ROOT:-}"
+  local abs_pp=""
+  local inferred_root=""
+
+  if [[ -n "$INDEX_FILE" ]]; then
+    if [[ "$INDEX_FILE" = /* ]]; then
+      printf '%s\n' "$INDEX_FILE"
+    else
+      if [[ -z "$base_root" ]]; then
+        base_root="$(_proofpack_index_project_root_from_path "$PWD" 2>/dev/null || printf '%s\n' "$PWD")"
+      fi
+      printf '%s/%s\n' "$base_root" "$INDEX_FILE"
+    fi
+    return 0
+  fi
+
+  if [[ -n "$pp_path" ]]; then
+    if [[ "$pp_path" = /* ]]; then
+      abs_pp="$pp_path"
+    else
+      abs_pp="$PWD/$pp_path"
+    fi
+
+    inferred_root="$(_proofpack_index_project_root_from_path "$abs_pp" 2>/dev/null || true)"
+    if [[ -n "$inferred_root" ]]; then
+      printf '%s/.signum/proofpack-index.jsonl\n' "$inferred_root"
+      return 0
+    fi
+
+    case "$abs_pp" in
+      */.signum/contracts/*/proofpack.json)
+        printf '%s/.signum/proofpack-index.jsonl\n' "${abs_pp%/.signum/contracts/*/proofpack.json}"
+        return 0
+        ;;
+      */.signum/proofpack.json)
+        printf '%s/.signum/proofpack-index.jsonl\n' "${abs_pp%/.signum/proofpack.json}"
+        return 0
+        ;;
+    esac
+  fi
+
+  if [[ -z "$base_root" ]]; then
+    base_root="$(_proofpack_index_project_root_from_path "$PWD" 2>/dev/null || printf '%s\n' "$PWD")"
+  fi
+
+  printf '%s/.signum/proofpack-index.jsonl\n' "$base_root"
+}
 
 # Cross-platform sha256
 _sha256() {
@@ -31,16 +118,20 @@ _sha256() {
 # Args: proofpack_path
 proofpack_index_append() {
   local pp_path="${1:?proofpack path required}"
+  local index_file=""
 
   if [ ! -f "$pp_path" ]; then
     echo "ERROR: proofpack not found: $pp_path" >&2
     return 1
   fi
 
+  index_file="$(_proofpack_index_default_file "$pp_path")"
+  mkdir -p "$(dirname "$index_file")"
+
   # Get previous chain hash (last line of index)
   local prev_hash="genesis"
-  if [ -f "$INDEX_FILE" ]; then
-    prev_hash=$(tail -1 "$INDEX_FILE" | jq -r '.chain_hash // "genesis"' 2>/dev/null || echo "genesis")
+  if [ -f "$index_file" ]; then
+    prev_hash=$(tail -1 "$index_file" | jq -r '.chain_hash // "genesis"' 2>/dev/null || echo "genesis")
   fi
 
   # Extract key fields from proofpack
@@ -79,17 +170,20 @@ proofpack_index_append() {
     '.proofpack_sha256 = $pph | .chain_hash = $ch')
 
   # Atomic append
-  echo "$entry" >> "$INDEX_FILE"
+  echo "$entry" >> "$index_file"
 }
 
 # Verify chain integrity
 proofpack_index_verify() {
-  if [ ! -f "$INDEX_FILE" ]; then
+  local index_file=""
+  index_file="$(_proofpack_index_default_file)"
+
+  if [ ! -f "$index_file" ]; then
     echo "No index file found"
     return 0
   fi
 
-  python3 - "$INDEX_FILE" <<'PYEOF'
+  python3 - "$index_file" <<'PYEOF'
 import json, hashlib, sys
 
 prev_hash = 'genesis'
@@ -131,7 +225,10 @@ PYEOF
 # Query recent entries
 # Args: --since Nd (days) or --last N (entries)
 proofpack_index_query() {
-  if [ ! -f "$INDEX_FILE" ]; then
+  local index_file=""
+  index_file="$(_proofpack_index_default_file)"
+
+  if [ ! -f "$index_file" ]; then
     echo "[]"
     return 0
   fi
@@ -143,10 +240,10 @@ proofpack_index_query() {
     --since)
       local cutoff
       cutoff=$(date -u -v-${value} +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "${value} ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
-      jq -sc --arg cutoff "$cutoff" '[.[] | select(.createdAt >= $cutoff)]' "$INDEX_FILE" 2>/dev/null
+      jq -sc --arg cutoff "$cutoff" '[.[] | select(.createdAt >= $cutoff)]' "$index_file" 2>/dev/null
       ;;
     --last)
-      tail -"$value" "$INDEX_FILE" | jq -sc '.' 2>/dev/null
+      tail -"$value" "$index_file" | jq -sc '.' 2>/dev/null
       ;;
     *)
       echo "Usage: proofpack_index_query --since 7d | --last 10" >&2

--- a/lib/signum-ci.sh
+++ b/lib/signum-ci.sh
@@ -1,117 +1,238 @@
 #!/usr/bin/env bash
-# signum-ci.sh — CI wrapper for Signum pipeline
+# signum-ci.sh - CI wrapper for Signum pipeline
 # Runs Signum with a pre-approved contract and maps decision to exit code.
 #
 # Exit codes:
-#   0  — AUTO_OK (safe to merge)
-#   1  — AUTO_BLOCK (issues found, block merge)
-#   78 — HUMAN_REVIEW (needs manual review)
+#   0  - AUTO_OK (safe to merge)
+#   1  - AUTO_BLOCK (issues found, block merge)
+#   78 - HUMAN_REVIEW (needs manual review)
 #
 # Environment variables:
-#   SIGNUM_CONTRACT_PATH — path to pre-approved contract.json (required)
-#   SIGNUM_MAX_TURNS     — max agent turns (default: 30)
-#   SIGNUM_ALLOWED_TOOLS — comma-separated tool allowlist (optional)
-#   SIGNUM_PROJECT_ROOT  — project root (default: current directory)
-#   SIGNUM_AUDIT_MAX_ITERATIONS — max audit fix iterations (default: 20, inherited by pipeline)
-#   SIGNUM_CI_RELAXED    — if "true", HUMAN_REVIEW maps to exit 0 (pass with warning)
+#   SIGNUM_CONTRACT_PATH - path to pre-approved contract.json (required)
+#   SIGNUM_MAX_TURNS     - max agent turns (default: 30)
+#   SIGNUM_ALLOWED_TOOLS - comma-separated tool allowlist (optional)
+#   SIGNUM_PROJECT_ROOT  - project root (default: current directory)
+#   SIGNUM_AUDIT_MAX_ITERATIONS - max audit fix iterations (default: 20, inherited by pipeline)
+#   SIGNUM_CI_RELAXED    - if "true", HUMAN_REVIEW maps to exit 0 (pass with warning)
 
 set -euo pipefail
 
-# --- Validate inputs ---
-CONTRACT="${SIGNUM_CONTRACT_PATH:-}"
-if [ -z "$CONTRACT" ]; then
-  echo "ERROR: SIGNUM_CONTRACT_PATH is required" >&2
-  exit 1
-fi
-if [ ! -f "$CONTRACT" ]; then
-  echo "ERROR: Contract not found: $CONTRACT" >&2
-  exit 1
-fi
+resolve_ci_single_contract_dir() {
+  local project_root="${1:-}"
+  local contracts_root="${project_root}/.signum/contracts"
+  local dir_count=""
+  local only_dir=""
 
-# Validate contract has required fields
-if ! jq -e '.schemaVersion and .goal and .inScope and .acceptanceCriteria and .riskLevel' \
-  "$CONTRACT" > /dev/null 2>&1; then
-  echo "ERROR: Invalid contract (missing required fields)" >&2
-  exit 1
-fi
+  if [ -z "$project_root" ] || [ ! -d "$contracts_root" ]; then
+    return 1
+  fi
 
-PROJECT_ROOT="${SIGNUM_PROJECT_ROOT:-$(pwd)}"
-MAX_TURNS="${SIGNUM_MAX_TURNS:-30}"
+  dir_count=$(find "$contracts_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d '[:space:]')
+  if [ "$dir_count" != "1" ]; then
+    return 1
+  fi
 
-echo "=== Signum CI ==="
-echo "Contract: $CONTRACT"
-echo "Project:  $PROJECT_ROOT"
-echo "Max turns: $MAX_TURNS"
+  only_dir=$(find "$contracts_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -n 1)
+  if [ -n "$only_dir" ] && [ -d "$only_dir" ]; then
+    printf '%s\n' "$only_dir"
+    return 0
+  fi
 
-# --- Setup .signum directory ---
-mkdir -p "$PROJECT_ROOT/.signum/reviews"
-cp "$CONTRACT" "$PROJECT_ROOT/.signum/contract.json"
+  return 1
+}
 
-# --- Build claude invocation ---
-TASK=$(jq -r '.goal' "$CONTRACT")
+resolve_ci_artifact_root() {
+  local project_root="${1:-}"
+  local contract_id="${2:-}"
+  local index_path="${project_root}/.signum/contracts/index.json"
+  local active_id=""
+  local last_dir=""
+  local single_dir=""
 
-CLAUDE_ARGS=(
-  -p "/signum $TASK"
-  --output-format json
-  --max-turns "$MAX_TURNS"
-  --verbose
-)
+  if [ -z "$project_root" ]; then
+    echo "resolve_ci_artifact_root: project_root required" >&2
+    return 1
+  fi
 
-if [ -n "${SIGNUM_ALLOWED_TOOLS:-}" ]; then
-  CLAUDE_ARGS+=(--allowedTools "$SIGNUM_ALLOWED_TOOLS")
-fi
+  if [ -n "$contract_id" ] && [ -d "$project_root/.signum/contracts/$contract_id" ]; then
+    printf '%s\n' "$project_root/.signum/contracts/$contract_id"
+    return 0
+  fi
 
-echo "Starting Signum pipeline..."
-cd "$PROJECT_ROOT"
-claude "${CLAUDE_ARGS[@]}" || true
-
-# --- Extract decision ---
-if [ ! -f .signum/proofpack.json ]; then
-  echo "ERROR: proofpack.json not produced" >&2
-  exit 1
-fi
-
-DECISION=$(jq -r '.decision' .signum/proofpack.json)
-CONFIDENCE=$(jq -r '.confidence.overall // 0' .signum/proofpack.json)
-RUN_ID=$(jq -r '.runId' .signum/proofpack.json)
-
-echo ""
-echo "=== Result ==="
-echo "Decision:   $DECISION"
-echo "Confidence: ${CONFIDENCE}%"
-echo "Run ID:     $RUN_ID"
-
-# --- Compute proofpack hash for artifact integrity ---
-if command -v sha256sum >/dev/null 2>&1; then
-  PP_HASH=$(sha256sum .signum/proofpack.json | awk '{print $1}')
-elif command -v shasum >/dev/null 2>&1; then
-  PP_HASH=$(shasum -a 256 .signum/proofpack.json | awk '{print $1}')
-else
-  PP_HASH="unavailable"
-fi
-echo "Proofpack SHA-256: $PP_HASH"
-
-# --- Map decision to exit code ---
-case "$DECISION" in
-  AUTO_OK)
-    echo "Status: PASS"
-    exit 0
-    ;;
-  AUTO_BLOCK)
-    echo "Status: BLOCKED"
-    exit 1
-    ;;
-  HUMAN_REVIEW)
-    if [ "${SIGNUM_CI_RELAXED:-false}" = "true" ]; then
-      echo "Status: NEEDS REVIEW (relaxed mode — passing)"
-      exit 0
-    else
-      echo "Status: NEEDS REVIEW"
-      exit 78
+  if [ -f "$index_path" ]; then
+    active_id=$(jq -r '.activeContractId // empty' "$index_path" 2>/dev/null || true)
+    if [ -n "$active_id" ] && [ -d "$project_root/.signum/contracts/$active_id" ]; then
+      printf '%s\n' "$project_root/.signum/contracts/$active_id"
+      return 0
     fi
-    ;;
-  *)
-    echo "ERROR: Unknown decision: $DECISION" >&2
+
+    last_dir=$(jq -r '.contracts[-1].directory // empty' "$index_path" 2>/dev/null || true)
+    last_dir="${last_dir%/}"
+    if [ -n "$last_dir" ] && [ -d "$project_root/$last_dir" ]; then
+      printf '%s\n' "$project_root/$last_dir"
+      return 0
+    fi
+  fi
+
+  single_dir=$(resolve_ci_single_contract_dir "$project_root" 2>/dev/null || true)
+  if [ -n "$single_dir" ] && [ -d "$single_dir" ]; then
+    printf '%s\n' "$single_dir"
+    return 0
+  fi
+
+  # Legacy fallback during migration.
+  if [ -d "$project_root/.signum" ]; then
+    printf '%s\n' "$project_root/.signum"
+    return 0
+  fi
+
+  return 1
+}
+
+resolve_ci_proofpack_path() {
+  local project_root="${1:-}"
+  local contract_id="${2:-}"
+  local artifact_root=""
+  local single_dir=""
+
+  if [ -z "$project_root" ]; then
+    echo "resolve_ci_proofpack_path: project_root required" >&2
+    return 1
+  fi
+
+  artifact_root=$(resolve_ci_artifact_root "$project_root" "$contract_id" 2>/dev/null || true)
+  if [ -n "$artifact_root" ] && [ -f "$artifact_root/proofpack.json" ]; then
+    printf '%s\n' "$artifact_root/proofpack.json"
+    return 0
+  fi
+
+  single_dir=$(resolve_ci_single_contract_dir "$project_root" 2>/dev/null || true)
+  if [ -n "$single_dir" ] && [ -f "$single_dir/proofpack.json" ]; then
+    printf '%s\n' "$single_dir/proofpack.json"
+    return 0
+  fi
+
+  # Legacy fallback during migration.
+  if [ -f "$project_root/.signum/proofpack.json" ]; then
+    printf '%s\n' "$project_root/.signum/proofpack.json"
+    return 0
+  fi
+
+  return 1
+}
+
+signum_ci_main() {
+  local contract="${SIGNUM_CONTRACT_PATH:-}"
+  local input_contract_id=""
+  local project_root="${SIGNUM_PROJECT_ROOT:-$(pwd)}"
+  local max_turns="${SIGNUM_MAX_TURNS:-30}"
+  local task=""
+  local artifact_root=""
+  local proofpack_path=""
+  local decision=""
+  local confidence=""
+  local run_id=""
+  local pp_hash=""
+
+  if [ -z "$contract" ]; then
+    echo "ERROR: SIGNUM_CONTRACT_PATH is required" >&2
     exit 1
-    ;;
-esac
+  fi
+  if [ ! -f "$contract" ]; then
+    echo "ERROR: Contract not found: $contract" >&2
+    exit 1
+  fi
+
+  if ! jq -e '.schemaVersion and .goal and .inScope and .acceptanceCriteria and .riskLevel' \
+    "$contract" > /dev/null 2>&1; then
+    echo "ERROR: Invalid contract (missing required fields)" >&2
+    exit 1
+  fi
+
+  input_contract_id=$(jq -r '.contractId // empty' "$contract" 2>/dev/null || true)
+
+  echo "=== Signum CI ==="
+  echo "Contract: $contract"
+  echo "Project:  $project_root"
+  echo "Max turns: $max_turns"
+
+  mkdir -p "$project_root/.signum"
+  echo "Contract mode: file (Phase 1 imports SIGNUM_CONTRACT_PATH into canonical artifact root)"
+
+  task=$(jq -r '.goal' "$contract")
+
+  CLAUDE_ARGS=(
+    -p "/signum $task"
+    --output-format json
+    --max-turns "$max_turns"
+    --verbose
+  )
+
+  if [ -n "${SIGNUM_ALLOWED_TOOLS:-}" ]; then
+    CLAUDE_ARGS+=(--allowedTools "$SIGNUM_ALLOWED_TOOLS")
+  fi
+
+  echo "Starting Signum pipeline..."
+  cd "$project_root"
+  claude "${CLAUDE_ARGS[@]}" || true
+
+  artifact_root=$(resolve_ci_artifact_root "$project_root" "$input_contract_id" 2>/dev/null || true)
+  proofpack_path=$(resolve_ci_proofpack_path "$project_root" "$input_contract_id" 2>/dev/null || true)
+  if [ -z "$artifact_root" ] && [ -n "$proofpack_path" ]; then
+    artifact_root=$(dirname "$proofpack_path")
+  fi
+
+  if [ -z "$proofpack_path" ] || [ ! -f "$proofpack_path" ]; then
+    echo "ERROR: proofpack.json not produced" >&2
+    exit 1
+  fi
+
+  decision=$(jq -r '.decision' "$proofpack_path")
+  confidence=$(jq -r '.confidence.overall // 0' "$proofpack_path")
+  run_id=$(jq -r '.runId' "$proofpack_path")
+
+  echo ""
+  echo "=== Result ==="
+  echo "Artifact root: ${artifact_root:-unresolved}"
+  echo "Proofpack:  $proofpack_path"
+  echo "Decision:   $decision"
+  echo "Confidence: ${confidence}%"
+  echo "Run ID:     $run_id"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    pp_hash=$(sha256sum "$proofpack_path" | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    pp_hash=$(shasum -a 256 "$proofpack_path" | awk '{print $1}')
+  else
+    pp_hash="unavailable"
+  fi
+  echo "Proofpack SHA-256: $pp_hash"
+
+  case "$decision" in
+    AUTO_OK)
+      echo "Status: PASS"
+      exit 0
+      ;;
+    AUTO_BLOCK)
+      echo "Status: BLOCKED"
+      exit 1
+      ;;
+    HUMAN_REVIEW)
+      if [ "${SIGNUM_CI_RELAXED:-false}" = "true" ]; then
+        echo "Status: NEEDS REVIEW (relaxed mode - passing)"
+        exit 0
+      else
+        echo "Status: NEEDS REVIEW"
+        exit 78
+      fi
+      ;;
+    *)
+      echo "ERROR: Unknown decision: $decision" >&2
+      exit 1
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  signum_ci_main "$@"
+fi

--- a/lib/snapshot-tree.sh
+++ b/lib/snapshot-tree.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 # snapshot-tree.sh -- deterministic workspace tree snapshot for Signum receipt chain.
-# Writes a sorted manifest and JSON summary under .signum/snapshots/.
+# Writes a sorted manifest and JSON summary under the active Signum artifact root snapshots/ dir.
 #
 # Usage:
 #   snapshot-tree.sh [label] [--workspace-root PATH] [--signum-dir PATH]
 #
 # Example:
 #   lib/snapshot-tree.sh execute-attempt-01
-#   lib/snapshot-tree.sh lane-A --workspace-root .signum/iterations/01/lanes/A \
-#       --signum-dir .signum/iterations/01/lanes/A/.signum
+#   ARTIFACT_ROOT=".signum/contracts/<contractId>"
+#   lib/snapshot-tree.sh lane-A --workspace-root "$ARTIFACT_ROOT/iterations/01/lanes/A" \
+#       --signum-dir "$ARTIFACT_ROOT"
 set -euo pipefail
 export LC_ALL=C
 
@@ -20,7 +21,7 @@ else
 fi
 
 WORKSPACE_ROOT="${PWD}"
-SIGNUM_DIR=".signum"
+SIGNUM_DIR=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -48,6 +49,36 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "snapshot-tree.sh: jq not found" >&2
   exit 1
 fi
+
+resolve_default_signum_dir() {
+  local workspace_root="$1"
+  local index_path="$workspace_root/.signum/contracts/index.json"
+  local active_id=""
+  local contracts_root="$workspace_root/.signum/contracts"
+  local dir_count=""
+  local only_dir=""
+
+  if [[ -f "$index_path" ]]; then
+    active_id="$(jq -r '.activeContractId // empty' "$index_path" 2>/dev/null || true)"
+    if [[ -n "$active_id" && -d "$workspace_root/.signum/contracts/$active_id" ]]; then
+      printf '%s\n' "$workspace_root/.signum/contracts/$active_id"
+      return 0
+    fi
+  fi
+
+  if [[ -d "$contracts_root" ]]; then
+    dir_count=$(find "$contracts_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d '[:space:]')
+    if [[ "$dir_count" == "1" ]]; then
+      only_dir=$(find "$contracts_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -n 1)
+      if [[ -n "$only_dir" && -d "$only_dir" ]]; then
+        printf '%s\n' "$only_dir"
+        return 0
+      fi
+    fi
+  fi
+
+  printf '%s\n' "$workspace_root/.signum"
+}
 
 hash_file() {
   local path="$1"
@@ -78,6 +109,9 @@ list_files_null() {
 }
 
 ABS_WORKSPACE=$(CDPATH= cd "$WORKSPACE_ROOT" && pwd)
+if [[ -z "$SIGNUM_DIR" ]]; then
+  SIGNUM_DIR="$(resolve_default_signum_dir "$ABS_WORKSPACE")"
+fi
 if [[ "$SIGNUM_DIR" = /* ]]; then
   ABS_SIGNUM_DIR="$SIGNUM_DIR"
 else

--- a/lib/templates/signum-gate.yml
+++ b/lib/templates/signum-gate.yml
@@ -49,11 +49,32 @@ jobs:
           EXIT_CODE=$?
           echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
 
-          # Extract decision for PR comment
-          if [ -f .signum/proofpack.json ]; then
-            DECISION=$(jq -r '.decision' .signum/proofpack.json)
-            CONFIDENCE=$(jq -r '.confidence.overall // 0' .signum/proofpack.json)
-            RUN_ID=$(jq -r '.runId' .signum/proofpack.json)
+          # Extract canonical artifact paths and decision for PR comment
+          source lib/signum-ci.sh
+          INPUT_CONTRACT_ID=$(jq -r '.contractId // empty' "$SIGNUM_CONTRACT_PATH" 2>/dev/null || true)
+          ARTIFACT_ROOT=$(resolve_ci_artifact_root "$SIGNUM_PROJECT_ROOT" "$INPUT_CONTRACT_ID" 2>/dev/null || true)
+          PROOFPACK_PATH=$(resolve_ci_proofpack_path "$SIGNUM_PROJECT_ROOT" "$INPUT_CONTRACT_ID" 2>/dev/null || true)
+          ARTIFACT_UPLOAD_PATH="${ARTIFACT_ROOT:-$SIGNUM_PROJECT_ROOT/.signum/contracts}"
+          if [ ! -d "$ARTIFACT_UPLOAD_PATH" ] && [ -d "$SIGNUM_PROJECT_ROOT/.signum" ]; then
+            ARTIFACT_UPLOAD_PATH="$SIGNUM_PROJECT_ROOT/.signum"
+          fi
+          PROOFPACK_UPLOAD_PATH="${PROOFPACK_PATH:-}"
+          if [ -z "$PROOFPACK_UPLOAD_PATH" ] && [ -n "$ARTIFACT_ROOT" ]; then
+            PROOFPACK_UPLOAD_PATH="$ARTIFACT_ROOT/proofpack.json"
+          fi
+          if [ -z "$PROOFPACK_UPLOAD_PATH" ]; then
+            PROOFPACK_UPLOAD_PATH="$ARTIFACT_UPLOAD_PATH/proofpack.json"
+          fi
+          echo "artifact_upload_path=$ARTIFACT_UPLOAD_PATH" >> "$GITHUB_OUTPUT"
+          echo "proofpack_upload_path=$PROOFPACK_UPLOAD_PATH" >> "$GITHUB_OUTPUT"
+          if [ -n "$ARTIFACT_ROOT" ]; then
+            echo "artifact_root=$ARTIFACT_ROOT" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -n "$PROOFPACK_PATH" ] && [ -f "$PROOFPACK_PATH" ]; then
+            DECISION=$(jq -r '.decision' "$PROOFPACK_PATH")
+            CONFIDENCE=$(jq -r '.confidence.overall // 0' "$PROOFPACK_PATH")
+            RUN_ID=$(jq -r '.runId' "$PROOFPACK_PATH")
+            echo "proofpack_path=$PROOFPACK_PATH" >> "$GITHUB_OUTPUT"
             echo "decision=$DECISION" >> "$GITHUB_OUTPUT"
             echo "confidence=$CONFIDENCE" >> "$GITHUB_OUTPUT"
             echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
@@ -66,7 +87,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: signum-proofpack-${{ steps.signum.outputs.run_id || 'unknown' }}
-          path: .signum/proofpack.json
+          path: ${{ steps.signum.outputs.proofpack_upload_path }}
           retention-days: 90
           if-no-files-found: warn
 
@@ -75,7 +96,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: signum-audit-${{ steps.signum.outputs.run_id || 'unknown' }}
-          path: .signum/
+          path: ${{ steps.signum.outputs.artifact_upload_path }}
           retention-days: 30
           if-no-files-found: warn
 

--- a/lib/transition-verifier.sh
+++ b/lib/transition-verifier.sh
@@ -6,7 +6,7 @@
 #
 # Options:
 #   --workspace-root PATH
-#   --signum-dir PATH
+#   --signum-dir PATH           Signum artifact dir (default: active contract root from .signum/contracts/index.json, else .signum)
 #   --contract PATH
 #   --receipt PATH
 #   --snapshot PATH
@@ -23,7 +23,7 @@ if [[ -z "$FROM_PHASE" || -z "$TO_PHASE" ]]; then
 fi
 
 WORKSPACE_ROOT="$PWD"
-SIGNUM_DIR=".signum"
+SIGNUM_DIR=""
 CONTRACT_ENGINEER=""
 CONTRACT_FULL=""
 RECEIPT_PATH=""
@@ -67,6 +67,22 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+resolve_default_signum_dir() {
+  local workspace_root="$1"
+  local index_path="$workspace_root/.signum/contracts/index.json"
+  local active_id=""
+
+  if [[ -f "$index_path" ]]; then
+    active_id="$(jq -r '.activeContractId // empty' "$index_path" 2>/dev/null || true)"
+    if [[ -n "$active_id" && -d "$workspace_root/.signum/contracts/$active_id" ]]; then
+      printf '%s\n' "$workspace_root/.signum/contracts/$active_id"
+      return 0
+    fi
+  fi
+
+  printf '%s\n' "$workspace_root/.signum"
+}
+
 hash_file() {
   local path="$1"
   if command -v sha256sum >/dev/null 2>&1; then
@@ -80,6 +96,9 @@ hash_file() {
 }
 
 ABS_WORKSPACE=$(CDPATH= cd "$WORKSPACE_ROOT" && pwd)
+if [[ -z "$SIGNUM_DIR" ]]; then
+  SIGNUM_DIR="$(resolve_default_signum_dir "$ABS_WORKSPACE")"
+fi
 if [[ "$SIGNUM_DIR" = /* ]]; then
   ABS_SIGNUM_DIR="$SIGNUM_DIR"
 else

--- a/platforms/claude-code/.claude-plugin/plugin.json
+++ b/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "signum",
   "description": "Evidence-driven development pipeline with multi-model code review",
-  "version": "4.17.1",
+  "version": "4.20.0",
   "author": {
     "name": "heurema"
   },

--- a/platforms/claude-code/CHANGELOG.md
+++ b/platforms/claude-code/CHANGELOG.md
@@ -14,7 +14,7 @@
 - **Context retrieval** (Step 3.2.0) — pre-review step gathers git history (last commit per file), issue refs (ID + title), and project.intent.md. Injected into Claude reviewer only — Codex/Gemini remain adversarially isolated.
   - `{review_context}` variable in `lib/prompts/review-template.md`
 - **Parallel repair lanes** (Step 3.6.2) — 2 parallel Engineers in git worktrees with different strategies (minimal fix vs root-cause). Mechanic+holdout on both, full review on winner only. Runner-up reviewed if winner gets MAJOR+.
-  - Lane artifacts in `.signum/iterations/NN/lanes/A|B/`
+  - Lane artifacts in `iterations/NN/lanes/A|B/` under the active contract artifact root
   - `selected_lane.json` for audit trail
   - Trap-based worktree cleanup, fallback to single-lane on failure
 - **Typed diagnostics** — extracted mechanic logic into `lib/mechanic-parser.sh` with hybrid output format: summary per check always + per-file findings when runner supports structured output.
@@ -74,7 +74,7 @@
 - `SIGNUM_AUDIT_MAX_ITERATIONS` env var for configurable iteration cap
 - `SIGNUM_CI_RELAXED` env var — HUMAN_REVIEW maps to exit 0 in relaxed mode
 - Engineer repair mode: reads `repair_brief.json` to fix specific findings
-- Per-iteration artifact storage in `.signum/iterations/NN/`
+- Per-iteration artifact storage in `iterations/NN/` under the active contract artifact root
 - `audit_iteration_log.json` for cross-iteration tracking
 - Best-of-N with rollback: pipeline keeps best candidate, not last attempt
 - Early stop: halts if no improvement for 2 consecutive iterations

--- a/platforms/claude-code/CHANGELOG.md
+++ b/platforms/claude-code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [4.20.0] - 2026-04-21
+
+### Changed
+- Canonical contract-dir artifact root cleanup and parity hardening for the Claude overlay
+  - overlay command/docs/prompts now consistently describe `.signum/contracts/<contractId>/` as the active artifact root
+  - overlay CI/template surfaces prefer canonical artifact paths before legacy root fallback
+  - overlay changelog/docs/quickstart wording now matches the canonical storage model used by the runtime
+
 ## [4.9.0] - 2026-03-17
 
 ### Added

--- a/platforms/claude-code/QUICKSTART.md
+++ b/platforms/claude-code/QUICKSTART.md
@@ -35,15 +35,16 @@ You approve the contract once. Everything else is autonomous.
 
 ## 3. Read the Proofpack
 
-After a run, check the result:
+After a run, check the result under the active contract artifact root that Signum prints at the end of the run:
 
 ```bash
-jq '.decision, .confidence.overall' .signum/proofpack.json
+ARTIFACT_ROOT=".signum/contracts/<contractId>"
+jq '.decision, .confidence.overall' "$ARTIFACT_ROOT/proofpack.json"
 ```
 
 Decisions:
 - **AUTO_OK** — All checks passed. Review the diff and commit.
-- **AUTO_BLOCK** — Issues found. Check `.signum/audit_summary.json`.
+- **AUTO_BLOCK** — Issues found. Check `audit_summary.json` under the active contract artifact root.
 - **HUMAN_REVIEW** — Inconclusive. Review flagged findings manually.
 
 ## 4. Understand the Phases
@@ -55,7 +56,7 @@ Decisions:
 | AUDIT | Mechanic checks + up to 3 model reviews + holdout validation | 1-3 min |
 | PACK | Bundles all artifacts into signed proofpack | ~5s |
 
-Key artifacts in `.signum/`:
+Key artifacts under the active contract artifact root (`.signum/contracts/<contractId>/`):
 - `contract.json` — The verified spec
 - `combined.patch` — The code diff
 - `mechanic_report.json` — Lint/typecheck/test results vs baseline
@@ -160,12 +161,12 @@ EOF
 2. Create `project.intent.md` (or skip — Signum will ask)
 3. Run: `/signum "describe your first task"`
 4. Review the contract when prompted (5-item checklist)
-5. Check `.signum/proofpack.json` for the result
+5. Check `proofpack.json` under the active contract artifact root for the result
 
 `.signum/` is auto-added to `.gitignore`. No cleanup needed.
 
 ## Next Steps
 
 - Run `/signum` on a real task in your project
-- Check `.signum/audit_summary.json` after a run to understand findings
+- Check `audit_summary.json` under the active contract artifact root after a run to understand findings
 - Add `repo-contract.json` for project-wide invariant enforcement

--- a/platforms/claude-code/agents/contractor.md
+++ b/platforms/claude-code/agents/contractor.md
@@ -166,7 +166,7 @@ You receive:
    - Validate: removal paths must exist (for files/dirs being removed), no overlap with `inScope` paths
    - If `modules.yaml` exists, add obligation to update module status in `modules.yaml`
 4. **Generate contract.json** with:
-   - `contractId`: unique identifier in format `sig-YYYYMMDD-<4char-hash>` where YYYYMMDD is the UTC date and the 4-char hash is the first 4 hex characters of the SHA-1 of the goal string. Example: `sig-20260313-a7f2`
+   - `contractId`: include a provisional unique identifier. Preferred format is `sig-YYYYMMDD-HHMM-<4char-token>`, for example `sig-20260313-1000-a7f2`. The runtime may normalize this to its canonical format before execution.
    - `status`: always set to `"draft"` when generating a new contract
    - `timestamps`: object with `createdAt` set to the current UTC datetime in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ), e.g. `"2026-03-13T10:00:00Z"`
    - `schemaVersion`: always `"3.8"` for new contracts
@@ -217,11 +217,15 @@ You receive:
    - All inScope paths must exist (or be new files to create)
    - All verify blocks must use valid DSL step types
    - At least 1 acceptance criterion
-7. **Write** contract to `.signum/contract.json`
+7. **Write** contract to the canonical artifact root provided by the orchestrator
 
 ## Output
 
-Write `.signum/contract.json` following the schema at `lib/schemas/contract.schema.json`.
+Write `contract.json` under the canonical active contract root provided by the orchestrator, following the schema at `lib/schemas/contract.schema.json`.
+
+If both paths are shown to you:
+- canonical path under `.signum/contracts/<contractId>/` is the source of truth
+- `.signum/contract.json` is only a compatibility view pointing at that canonical file
 
 If you have unresolvable questions (can't determine scope, ambiguous requirement, missing context), set `openQuestions` to a non-empty array and `requiredInputsProvided` to false. The orchestrator will HARD STOP and ask the user.
 
@@ -230,7 +234,7 @@ If you have unresolvable questions (can't determine scope, ambiguous requirement
 You have a limited number of turns. Prioritize writing the contract over exhaustive scanning.
 
 - **Discovery budget**: spend at most 1 structural sweep (Glob/tree) + 3 targeted file reads. Do NOT read every file in scope.
-- **Write deadline**: you MUST call Write for `.signum/contract.json` by turn 10. If uncertain about details, write a blocked contract with `openQuestions` and `requiredInputsProvided: false` rather than continuing to scan.
+- **Write deadline**: you MUST call Write for canonical `contract.json` by turn 10. If uncertain about details, write a blocked contract with `openQuestions` and `requiredInputsProvided: false` rather than continuing to scan.
 - **Never finish without Write**: if you reach your last turn without having written contract.json, immediately write the best contract you have, even if incomplete. An incomplete contract is recoverable; a missing contract is a pipeline failure.
 - **Low-risk shortcut**: for low-risk contracts (< 5 files, 1 language), skip step 3.6 (self-critique) entirely and write immediately after validation.
 

--- a/platforms/claude-code/agents/engineer.md
+++ b/platforms/claude-code/agents/engineer.md
@@ -17,7 +17,9 @@ You operate in one of two modes:
 
 ## Policy
 
-Before implementation, read `.signum/contract-policy.json` if it exists. It defines execution constraints:
+The active contract artifact root is `.signum/contracts/<contractId>/`. Root `.signum/` paths may exist as compatibility views during migration, but the canonical engineer inputs and outputs live under the contract directory.
+
+Before implementation, read `.signum/contracts/<contractId>/contract-policy.json` if it exists. It defines execution constraints:
 
 - **allowed_tools**: only use tools in this list (Read, Write, Edit, Glob, Grep, Bash)
 - **denied_tools**: never use these (WebSearch, WebFetch, Agent, Task)
@@ -25,21 +27,21 @@ Before implementation, read `.signum/contract-policy.json` if it exists. It defi
 - **max_files_changed**: never modify more files than this limit
 - **network_access: false**: no web requests, no external downloads
 
-If `.signum/contract-policy.json` is absent, apply conservative defaults: no web access, no destructive bash.
+If `.signum/contracts/<contractId>/contract-policy.json` is absent, apply conservative defaults: no web access, no destructive bash.
 
 ## Input
 
 You receive:
-- `.signum/contract-engineer.json` -- the implementation contract (holdout scenarios removed by orchestrator for blind validation)
-- `.signum/contract-policy.json` -- execution policy (what you may and may not do)
-- `.signum/baseline.json` -- pre-change check results (written by orchestrator)
+- `.signum/contracts/<contractId>/contract-engineer.json` -- the implementation contract (holdout scenarios removed by orchestrator for blind validation)
+- `.signum/contracts/<contractId>/contract-policy.json` -- execution policy (what you may and may not do)
+- `.signum/contracts/<contractId>/baseline.json` -- pre-change check results (written by orchestrator)
 - Project codebase at the project root
 
 ## Process
 
 ### Step 1: Understand the contract
 
-Read `.signum/contract-engineer.json`. Extract:
+Read `.signum/contracts/<contractId>/contract-engineer.json`. Extract:
 - `goal` -- what to build
 - `inScope` -- which files/directories to touch
 - `acceptanceCriteria` -- what success looks like (with verify commands)
@@ -48,7 +50,7 @@ Read `.signum/contract-engineer.json`. Extract:
 
 ### Step 2: Read baseline
 
-Read `.signum/baseline.json` (written by orchestrator). Note any pre-existing failures -- you are NOT responsible for fixing them, but you MUST NOT introduce new ones.
+Read `.signum/contracts/<contractId>/baseline.json` (written by orchestrator). Note any pre-existing failures -- you are NOT responsible for fixing them, but you MUST NOT introduce new ones.
 
 ### Step 3: Implement changes
 
@@ -80,14 +82,14 @@ If a verify command has `type: "manual"`, skip it during the repair loop. Log it
 ### Step 5: Save artifacts
 
 On success:
-- Generate `.signum/combined.patch` via `git diff`
-- Write `.signum/execute_log.json` with attempt details
+- Generate `.signum/contracts/<contractId>/combined.patch` via `git diff`
+- Write `.signum/contracts/<contractId>/execute_log.json` with attempt details
 
 On failure (any attempt fails after max retries):
-- Write `.signum/execute_log.json` with all attempt errors and `"status": "FAILED"`
+- Write `.signum/contracts/<contractId>/execute_log.json` with all attempt errors and `"status": "FAILED"`
 - Do NOT generate combined.patch (pipeline will stop)
 
-CRITICAL: Always write `.signum/execute_log.json` as your FIRST action after each attempt completes (before generating patch). This ensures the orchestrator can detect progress even if the agent is interrupted mid-step. Write it with current status after EVERY attempt, not only at the end.
+CRITICAL: Always write `.signum/contracts/<contractId>/execute_log.json` as your FIRST action after each attempt completes (before generating patch). This ensures the orchestrator can detect progress even if the agent is interrupted mid-step. Write it with current status after EVERY attempt, not only at the end.
 
 If you cannot complete ANY attempt (crash, timeout, unexpected error), write execute_log.json with `status: "INTERRUPTED"` and `termination_reason` explaining what happened. An interrupted log is always better than no log.
 
@@ -142,9 +144,9 @@ When `.signum/repair_brief.json` exists, you are in **repair mode** — fixing s
 ### Repair input
 
 Read these files:
-- `.signum/contract-engineer.json` — original contract (for scope and AC context)
-- `.signum/baseline.json` — pre-change check state (do not introduce new regressions)
-- `.signum/repair_brief.json` — specific issues to fix
+- `.signum/contracts/<contractId>/contract-engineer.json` — original contract (for scope and AC context)
+- `.signum/contracts/<contractId>/baseline.json` — pre-change check state (do not introduce new regressions)
+- `.signum/contracts/<contractId>/repair_brief.json` — specific issues to fix
 
 ### Repair process
 
@@ -152,7 +154,7 @@ Read these files:
 2. If `mechanicFindings` is present and non-empty, treat each entry as an additional repair target alongside `reviewFindings`. Each mechanic finding identifies the exact file, line, and error code to fix.
 3. Fix ONLY the listed issues. Do not refactor, do not add features, do not touch unrelated code.
 4. After fixing, re-run the visible AC verify commands to confirm existing behavior is preserved.
-5. Generate `.signum/combined.patch` via `git diff` and write `.signum/execute_log.json`.
+5. Generate `.signum/contracts/<contractId>/combined.patch` via `git diff` and write `.signum/contracts/<contractId>/execute_log.json`.
 
 ### Repair constraints
 
@@ -167,11 +169,11 @@ Read these files:
 - NEVER modify files outside inScope
 - NEVER create or modify any receipt-chain artifacts. These are verifier-owned, not engineer-owned.
 - Forbidden paths for engineer writes:
-  - `.signum/receipts/**`
-  - `.signum/runs/**`
-  - `.signum/snapshots/**`
-  - `.signum/*receipt*.json`
-  - `.signum/*hash*.txt`
+  - `.signum/contracts/<contractId>/receipts/**`
+  - `.signum/contracts/<contractId>/runs/**`
+  - `.signum/contracts/<contractId>/snapshots/**`
+  - `.signum/contracts/<contractId>/*receipt*.json`
+  - `.signum/contracts/<contractId>/*hash*.txt`
 - Your job is to change project code and normal execution artifacts only (`combined.patch`, `execute_log.json`, code, tests, configs). Receipt generation is deterministic bash work performed after you return.
 - ALWAYS run verify commands, don't assume your code is correct
 - Keep diffs minimal -- don't refactor, don't add comments, don't "improve" unrelated code

--- a/platforms/claude-code/agents/reviewer-claude.md
+++ b/platforms/claude-code/agents/reviewer-claude.md
@@ -13,28 +13,30 @@ You are the Claude reviewer in Signum v4.18's multi-model audit panel.
 
 ## Input
 
+The active contract artifact root is `.signum/contracts/<contractId>/`. Root `.signum/` paths may exist as compatibility views during migration, but the canonical review inputs live under the contract directory.
+
 Read these files:
-- `.signum/contract.json` -- the contract specification
-- `.signum/combined.patch` -- the generated diff
-- `.signum/mechanic_report.json` -- deterministic check results
-- `.signum/iteration_delta.patch` -- iteration delta (what changed in this fix, only present in iterative passes 2+)
+- `.signum/contracts/<contractId>/contract.json` -- the contract specification
+- `.signum/contracts/<contractId>/combined.patch` -- the generated diff
+- `.signum/contracts/<contractId>/mechanic_report.json` -- deterministic check results
+- `.signum/contracts/<contractId>/iteration_delta.patch` -- iteration delta (what changed in this fix, only present in iterative passes 2+)
 
 ## Task
 
 Review the diff against the contract for bugs, security issues, logic errors, and contract compliance.
 
 Read these inputs directly (do NOT look for a review template file):
-- `{contract_json}` = contents of `.signum/contract.json`
-- `{diff}` = contents of `.signum/combined.patch`
-- `{mechanic_report}` = contents of `.signum/mechanic_report.json`
-- `{iteration_delta}` = contents of `.signum/iteration_delta.patch` if it exists, otherwise empty string
+- `{contract_json}` = contents of `.signum/contracts/<contractId>/contract.json`
+- `{diff}` = contents of `.signum/contracts/<contractId>/combined.patch`
+- `{mechanic_report}` = contents of `.signum/contracts/<contractId>/mechanic_report.json`
+- `{iteration_delta}` = contents of `.signum/contracts/<contractId>/iteration_delta.patch` if it exists, otherwise empty string
 - `{review_context}` = review context JSON passed inline by the orchestrator (git history, issue refs)
 
 When `iteration_delta.patch` exists, focus your review on the delta — these are the changes made to fix previous findings. Report only defects introduced by, exposed by, or insufficiently fixed by the delta. Cite delta lines as primary evidence. Use the full patch for context only.
 
 ## Output
 
-Write your review result to `.signum/reviews/claude.json` as a JSON object with this structure:
+Write your review result to `.signum/contracts/<contractId>/reviews/claude.json` as a JSON object with this structure:
 ```json
 {
   "verdict": "APPROVE | CONDITIONAL | REJECT",

--- a/platforms/claude-code/agents/synthesizer.md
+++ b/platforms/claude-code/agents/synthesizer.md
@@ -14,17 +14,19 @@ You are the Synthesizer agent for Signum v4.18. You combine three independent co
 
 ## Input
 
+The active contract artifact root is `.signum/contracts/<contractId>/`. Root `.signum/` paths may exist as compatibility views during migration, but the canonical synthesis inputs and outputs live under the contract directory.
+
 Read these files:
-- `.signum/contract.json` -- contract (needed for `riskLevel` to apply risk-proportional rules)
-- `.signum/mechanic_report.json` -- deterministic check results (with baseline comparison)
-- `.signum/policy_scan.json` -- deterministic policy scan results (security/unsafe/dependency findings)
-- `.signum/reviews/claude.json` -- Claude opus review
-- `.signum/reviews/codex.json` -- Codex review (may be missing or have parseOk: false)
-- `.signum/reviews/gemini.json` -- Gemini review (may be missing or have parseOk: false)
-- `.signum/holdout_report.json` -- holdout scenario results (if exists)
-- `.signum/execute_log.json` -- execution attempt history
-- `.signum/audit_iteration_log.json` -- previous iteration results (if exists, for iterative AUDIT)
-- `.signum/receipts/execute.json` -- execute boundary receipt (required for AC evidence gating)
+- `.signum/contracts/<contractId>/contract.json` -- contract (needed for `riskLevel` to apply risk-proportional rules)
+- `.signum/contracts/<contractId>/mechanic_report.json` -- deterministic check results (with baseline comparison)
+- `.signum/contracts/<contractId>/policy_scan.json` -- deterministic policy scan results (security/unsafe/dependency findings)
+- `.signum/contracts/<contractId>/reviews/claude.json` -- Claude opus review
+- `.signum/contracts/<contractId>/reviews/codex.json` -- Codex review (may be missing or have parseOk: false)
+- `.signum/contracts/<contractId>/reviews/gemini.json` -- Gemini review (may be missing or have parseOk: false)
+- `.signum/contracts/<contractId>/holdout_report.json` -- holdout scenario results (if exists)
+- `.signum/contracts/<contractId>/execute_log.json` -- execution attempt history
+- `.signum/contracts/<contractId>/audit_iteration_log.json` -- previous iteration results (if exists, for iterative AUDIT)
+- `.signum/contracts/<contractId>/receipts/execute.json` -- execute boundary receipt (required for AC evidence gating)
 
 ## Synthesis Rules (DETERMINISTIC -- follow exactly)
 
@@ -35,9 +37,9 @@ Read these files:
    - ANY reviewer verdict is "REJECT"
    - ANY reviewer found a CRITICAL severity finding
    - Policy scan (`policy_scan.json`) has `summaryCounts.critical` > 0 (CRITICAL policy finding present)
-   - Execute receipt (`.signum/receipts/execute.json`) is missing
+   - Execute receipt (`.signum/contracts/<contractId>/receipts/execute.json`) is missing
    - Execute receipt status is not `PASS`
-   - Any visible AC from `.signum/contract-engineer.json` has no matching entry in `execute.json` `.ac_evidence`
+   - Any visible AC from `.signum/contracts/<contractId>/contract-engineer.json` has no matching entry in `execute.json` `.ac_evidence`
    - Any visible AC has `verify_exit_code != 0`
    - Any visible AC has `verify_format != "dsl"`
    - Any visible AC is marked `vacuous: true` on medium/high risk
@@ -85,10 +87,10 @@ list each failed/errored holdout ID, description, and error message from the `re
 After determining the decision, compute confidence metrics:
 
 - `execution_health` = (ACs_passed / ACs_total) * 100 - (repair_attempts * 5)
-  Read from `.signum/execute_log.json`
+  Read from `.signum/contracts/<contractId>/execute_log.json`
 - `baseline_stability` = 100 if no regressions, else 100 * (checks_stable / checks_total)
-  Read from `.signum/mechanic_report.json`
-- `behavioral_evidence` = holdout pass rate (from `.signum/holdout_report.json`):
+  Read from `.signum/contracts/<contractId>/mechanic_report.json`
+- `behavioral_evidence` = holdout pass rate (from `.signum/contracts/<contractId>/holdout_report.json`):
   - If total holdouts > 0: (passed / total) * 100
   - If total holdouts == 0: 75 (neutral — no evidence, no penalty)
 - `review_alignment`:
@@ -103,7 +105,7 @@ Round all values to integers.
 
 ## Output
 
-Write `.signum/audit_summary.json`:
+Write `.signum/contracts/<contractId>/audit_summary.json`:
 
 ```json
 {
@@ -182,7 +184,7 @@ The **orchestrator** owns the early stop counter, not the synthesizer. The synth
 
 ## Execute Receipt Coverage Gate
 
-For every visible acceptance criterion, verify that `.signum/receipts/execute.json` `.ac_evidence` contains an entry with the same AC id.
+For every visible acceptance criterion, verify that `.signum/contracts/<contractId>/receipts/execute.json` `.ac_evidence` contains an entry with the same AC id.
 If any visible AC is missing evidence, AUTO_BLOCK.
 If any AC evidence has `verify_exit_code != 0`, AUTO_BLOCK.
 If the receipt itself is absent or has `status != "PASS"`, AUTO_BLOCK.

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -27,7 +27,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.19.1",
+  "version": "4.20.0",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -3559,7 +3559,7 @@ fi
 # Final assembly
 jq -n \
   --arg schemaVersion "4.6" \
-  --arg signumVersion "4.19.1" \
+  --arg signumVersion "4.20.0" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -62,7 +62,9 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
     "medium": {"reviews": "Claude + externals", "holdouts": "≥2", "cost": "~$0.50", "duration": "3-5 min"},
     "high": {"reviews": "Full 3-model panel", "holdouts": "≥5", "cost": "~$1.00", "duration": "5-10 min"}
   },
-  "artifacts": [".signum/contract.json", ".signum/combined.patch", ".signum/proofpack.json", ".signum/audit_summary.json", ".signum/anti_entropy_report.json"]
+  "artifactRoot": ".signum/contracts/<contractId>/",
+  "compatibilityRoot": ".signum/",
+  "artifacts": ["contract.json", "combined.patch", "proofpack.json", "audit_summary.json", "anti_entropy_report.json"]
 }
 ```
 
@@ -72,7 +74,7 @@ Do not proceed to Setup or any phase.
 
 If the user's task starts with `archive` (case-insensitive), do NOT run the pipeline. Instead, archive a completed contract.
 
-If a contract ID is provided (e.g., `archive sig-20260314-a1b2`), extract it from the user input. Otherwise, the active contract will be used.
+If a contract ID is provided (e.g., `archive sig-20260314-1030-a1b2`), extract it from the user input. Otherwise, the active contract will be used.
 
 Before running the Bash tool, parse the contract ID from the user's arguments (everything after `archive `). Pass it as `CONTRACT_ID_FROM_ARGS` environment variable. Use the Bash tool:
 
@@ -86,6 +88,11 @@ if [ -z "$CONTRACT_ID" ]; then
   exit 1
 fi
 
+WAS_ACTIVE=false
+if [ "$(get_active_contract 2>/dev/null || true)" = "$CONTRACT_ID" ]; then
+  WAS_ACTIVE=true
+fi
+
 DIR=$(contract_dir "$CONTRACT_ID")
 if [ ! -d "$DIR" ]; then
   echo "ERROR: Contract directory not found: $DIR" >&2
@@ -97,19 +104,7 @@ ARCHIVE_DIR=".signum/archive/${CONTRACT_ID}/"
 mkdir -p "$ARCHIVE_DIR"
 
 # Copy durable artifacts from the per-contract snapshot/history
-cp "${DIR}contract.json" "$ARCHIVE_DIR" 2>/dev/null || true
-cp "${DIR}proofpack.json" "$ARCHIVE_DIR" 2>/dev/null || true
-cp "${DIR}approval.json" "$ARCHIVE_DIR" 2>/dev/null || true
-
-# Copy audit summary if present
-cp "${DIR}audit_summary.json" "$ARCHIVE_DIR" 2>/dev/null || true
-cp "${DIR}anti_entropy_report.json" "$ARCHIVE_DIR" 2>/dev/null || true
-cp "${DIR}execution_context.json" "$ARCHIVE_DIR" 2>/dev/null || true
-
-# Copy receipt-chain artifacts needed for replay/verification
-cp -R "${DIR}receipts" "$ARCHIVE_DIR" 2>/dev/null || true
-cp -R "${DIR}runs" "$ARCHIVE_DIR" 2>/dev/null || true
-cp -R "${DIR}snapshots" "$ARCHIVE_DIR" 2>/dev/null || true
+archive_contract_artifacts "$CONTRACT_ID" "$ARCHIVE_DIR"
 
 # Purge intermediate artifacts (reviews, baseline, holdout, execute_log, prompts)
 rm -rf "${DIR}reviews/" 2>/dev/null || true
@@ -120,8 +115,10 @@ rm -f "${DIR}baseline.json" "${DIR}execute_log.json" "${DIR}holdout_report.json"
       "${DIR}contract-engineer.json" "${DIR}contract-policy.json" \
       "${DIR}policy_violations.json" "${DIR}spec_quality.json" \
       "${DIR}spec_validation.json" "${DIR}clover_report.json" \
+      "${DIR}repo_contract_baseline.json" "${DIR}repo_contract_violations.json" \
       "${DIR}contract-hash.txt" "${DIR}execution_context.json" \
       "${DIR}review_prompt_codex.txt" "${DIR}review_prompt_gemini.txt" \
+      "${DIR}review_context.json" \
       "${DIR}intent_check.json" \
       "${DIR}audit_iteration_log.json" "${DIR}repair_brief.json" "${DIR}flaky_tests.json" \
       "${DIR}policy_scan.json" 2>/dev/null || true
@@ -137,8 +134,12 @@ jq --arg id "$CONTRACT_ID" --arg ts "$ARCHIVED_AT" \
   .signum/contracts/index.json > .signum/contracts/index.json.tmp \
   && mv .signum/contracts/index.json.tmp .signum/contracts/index.json
 
+if [ "$WAS_ACTIVE" = "true" ]; then
+  purge_root_working_set_views >/dev/null 2>&1 || true
+fi
+
 echo "Archived: $CONTRACT_ID → $ARCHIVE_DIR"
-echo "Kept: contract.json, proofpack.json, approval.json, audit_summary.json, anti_entropy_report.json, execution_context.json, receipts/, runs/, snapshots/"
+echo "Kept: contract.json, proofpack.json, approval.json, audit_summary.json, anti_entropy_report.json, execution_context.json, optional reconcile_report.json + retro.json, receipts/, runs/, snapshots/"
 echo "Purged: intermediates (reviews, baseline, patches, prompts)"
 ```
 
@@ -148,7 +149,7 @@ Do not proceed to Setup or any phase.
 
 If the user's task starts with `close` (case-insensitive), do NOT run the pipeline. Instead, mark a contract as closed (abandoned, no proofpack).
 
-If a contract ID is provided (e.g., `close sig-20260314-a1b2`), extract it from user input. Otherwise, the active contract will be used.
+If a contract ID is provided (e.g., `close sig-20260314-1030-a1b2`), extract it from user input. Otherwise, the active contract will be used.
 
 Before running the Bash tool, parse the contract ID from the user's arguments (everything after `close `). Pass it as `CONTRACT_ID_FROM_ARGS` environment variable. Use the Bash tool:
 
@@ -162,6 +163,12 @@ if [ -z "$CONTRACT_ID" ]; then
   exit 1
 fi
 
+# Record whether this contract was the active one before closing.
+WAS_ACTIVE=false
+if [ "$(get_active_contract 2>/dev/null || true)" = "$CONTRACT_ID" ]; then
+  WAS_ACTIVE=true
+fi
+
 # Update status
 update_contract_status "$CONTRACT_ID" "closed"
 
@@ -173,11 +180,9 @@ jq --arg id "$CONTRACT_ID" --arg ts "$CLOSED_AT" \
   .signum/contracts/index.json > .signum/contracts/index.json.tmp \
   && mv .signum/contracts/index.json.tmp .signum/contracts/index.json
 
-# Clear active contract if this was the active one
-ACTIVE=$(get_active_contract)
-if [ "$ACTIVE" = "$CONTRACT_ID" ]; then
-  jq '.activeContractId = null' .signum/contracts/index.json > .signum/contracts/index.json.tmp \
-    && mv .signum/contracts/index.json.tmp .signum/contracts/index.json
+# update_contract_status() already clears activeContractId for terminal statuses.
+if [ "$WAS_ACTIVE" = "true" ]; then
+  purge_root_working_set_views >/dev/null 2>&1 || true
   echo "Cleared active contract (was $CONTRACT_ID)"
 fi
 
@@ -350,17 +355,85 @@ If either is empty, do NOT pass `--model` — let the CLI use its built-in defau
 
 Use the `PROJECT_ROOT` determined during Project Resolution. Verify we are in the correct directory:
 
-Check for an existing contract:
+Check for a resumable working set using `contracts/index.json` first. Root `.signum/contract.json` is only a legacy fallback during the migration:
 
 ```bash
-test -f .signum/contract.json && echo "EXISTS" || echo "NONE"
+source lib/contract-dir.sh
+
+RESUME_INFO=$(describe_active_contract_state)
+RESUME_STATE=$(printf '%s' "$RESUME_INFO" | jq -r '.state')
+RESUME_CONTRACT_ID=$(printf '%s' "$RESUME_INFO" | jq -r '.contractId // empty')
+RESUME_STATUS=$(printf '%s' "$RESUME_INFO" | jq -r '.status // empty')
+
+if [ "$RESUME_STATE" = "NONE" ] && [ -f .signum/contract.json ] && [ ! -L .signum/contract.json ]; then
+  if [ -f .signum/execution_context.json ] && [ ! -L .signum/execution_context.json ]; then
+    RESUME_STATE="LEGACY_RESUMABLE"
+  else
+    RESUME_STATE="LEGACY_CONTRACT_ONLY"
+  fi
+fi
+
+jq -n \
+  --arg state "$RESUME_STATE" \
+  --arg contractId "$RESUME_CONTRACT_ID" \
+  --arg status "$RESUME_STATUS" \
+  '{
+    state: $state,
+    contractId: (if $contractId == "" then null else $contractId end),
+    status: (if $status == "" then null else $status end)
+  }'
 ```
 
-If contract.json exists, ask the user: "A previous contract exists in .signum/contract.json. Resume from Phase 2, or restart from Phase 1 (discards existing contract)?"
+- If `.state == "RESUMABLE"`: an active contract exists in `contracts/index.json`. Ask the user: "Active contract `<contractId>` is in progress. Resume from Phase 2, or restart from Phase 1 (discards the active working set)?"
+- If `.state == "CONTRACT_ONLY"`: an active contract exists but execution has not started. Ask: "Active contract `<contractId>` exists but execution has not started. Resume from Phase 2, or restart from Phase 1 (new contract)?"
+- If `.state == "LEGACY_RESUMABLE"` or `.state == "LEGACY_CONTRACT_ONLY"`: a legacy root-based working set exists outside the contract registry. Ask: "A legacy `.signum/` working set was found. Resume by migrating it into `.signum/contracts/`, or restart from Phase 1?"
+- If `.state == "NONE"`: proceed to Phase 1.
+
+If the user chooses to resume a legacy root-based working set, migrate it into the canonical active contract directory before continuing:
+
+```bash
+source lib/contract-dir.sh
+
+LEGACY_CONTRACT_ID=$(jq -r '.contractId // empty' .signum/contract.json 2>/dev/null || true)
+if [ -z "$LEGACY_CONTRACT_ID" ] || [ "$LEGACY_CONTRACT_ID" = "null" ]; then
+  LEGACY_CONTRACT_ID="$(new_contract_id)"
+  jq --arg id "$LEGACY_CONTRACT_ID" '.contractId = $id' .signum/contract.json > .signum/contract.json.tmp \
+    && mv .signum/contract.json.tmp .signum/contract.json
+fi
+
+init_contract_dir "$LEGACY_CONTRACT_ID"
+register_contract "$LEGACY_CONTRACT_ID" "draft"
+set_active_contract "$LEGACY_CONTRACT_ID"
+
+for rel in \
+  contract.json \
+  spec_quality.json spec_validation.json clover_report.json intent_check.json approval.json \
+  contract-hash.txt contract-engineer.json contract-policy.json execution_context.json \
+  baseline.json combined.patch execute_log.json iteration_delta.patch mechanic_report.json \
+  holdout_report.json policy_violations.json policy_scan.json audit_iteration_log.json \
+  repair_brief.json flaky_tests.json audit_summary.json proofpack.json anti_entropy_report.json; do
+  if [ -e ".signum/$rel" ] || [ -L ".signum/$rel" ]; then
+    promote_root_artifact_to_active "$rel"
+  else
+    link_active_artifact "$rel"
+  fi
+done
+
+for rel in reviews iterations receipts runs snapshots; do
+  if [ -e ".signum/$rel" ] || [ -L ".signum/$rel" ]; then
+    promote_root_artifact_to_active "$rel"
+  else
+    ensure_active_artifact_dir "$rel"
+  fi
+done
+
+describe_active_contract_state
+```
 
 Wait for the user's answer before continuing. If restart, delete the existing artifacts:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
 rm -f .signum/contract.json .signum/execute_log.json .signum/combined.patch .signum/iteration_delta.patch \
        .signum/baseline.json .signum/mechanic_report.json \
        .signum/audit_summary.json .signum/proofpack.json \
@@ -370,13 +443,14 @@ rm -f .signum/contract.json .signum/execute_log.json .signum/combined.patch .sig
        .signum/spec_quality.json .signum/spec_validation.json \
        .signum/repo_contract_baseline.json .signum/repo_contract_violations.json \
        .signum/contract-hash.txt .signum/execution_context.json \
-       .signum/reviews/claude.json .signum/reviews/codex.json .signum/reviews/gemini.json \
        .signum/review_prompt_codex.txt .signum/review_prompt_gemini.txt \
-       .signum/reviews/codex_raw.txt .signum/reviews/gemini_raw.txt \
        .signum/clover_report.json .signum/approval.json \
        .signum/intent_check.json \
        .signum/audit_iteration_log.json .signum/flaky_tests.json .signum/repair_brief.json
-rm -rf .signum/iterations/
+for rel in reviews iterations receipts runs snapshots; do
+  remove_root_artifact_view "$rel" >/dev/null 2>&1 || true
+done
+clear_active_contract >/dev/null 2>&1 || true
 ```
 
 ---
@@ -387,13 +461,50 @@ rm -rf .signum/iterations/
 
 ### Step 1.1: Launch Contractor
 
-Use the Agent tool to launch the "contractor" agent with this prompt:
+Use the Bash tool once to pre-allocate the canonical active contract root for this run. If `SIGNUM_CONTRACT_PATH` is set, treat that file as the authoritative pre-approved contract and import it into the canonical root instead of launching the contractor:
+
+```bash
+source lib/contract-dir.sh
+
+FILE_CONTRACT_ID=""
+if [ -n "${SIGNUM_CONTRACT_PATH:-}" ] && [ -f "$SIGNUM_CONTRACT_PATH" ]; then
+  FILE_CONTRACT_ID="$(jq -r '.contractId // empty' "$SIGNUM_CONTRACT_PATH" 2>/dev/null || true)"
+fi
+
+CONTRACT_ID="${FILE_CONTRACT_ID:-$(new_contract_id)}"
+init_contract_dir "$CONTRACT_ID"
+register_contract "$CONTRACT_ID" "draft"
+set_active_contract "$CONTRACT_ID"
+
+ARTIFACT_ROOT="$(active_artifact_root)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+link_active_artifact "contract.json"
+
+if [ -n "${SIGNUM_CONTRACT_PATH:-}" ]; then
+  test -f "$SIGNUM_CONTRACT_PATH" || { echo "ERROR: SIGNUM_CONTRACT_PATH not found: $SIGNUM_CONTRACT_PATH"; exit 1; }
+  cp "$SIGNUM_CONTRACT_PATH" "$CONTRACT_PATH"
+  echo "CONTRACT_SOURCE=file"
+else
+  echo "CONTRACT_SOURCE=interactive"
+fi
+
+echo "CONTRACT_ID=$CONTRACT_ID"
+echo "ARTIFACT_ROOT=$ARTIFACT_ROOT"
+echo "CONTRACT_PATH=$CONTRACT_PATH"
+```
+
+If `SIGNUM_CONTRACT_PATH` is set, skip contractor launch and continue to Step 1.2 using the imported canonical contract above.
+
+Otherwise use the Agent tool to launch the "contractor" agent with this prompt:
 
 ```
 FEATURE_REQUEST: <the user's task from $ARGUMENTS>
 PROJECT_ROOT: <output of pwd>
+CONTRACT_ID: <value emitted above>
+CANONICAL_ARTIFACT_ROOT: <value emitted above>
 
-Scan the codebase, assess risk, and write .signum/contract.json.
+Scan the codebase, assess risk, and write `contract.json` to the canonical artifact root above.
+The `.signum/contract.json` compatibility path points there, but the canonical file is the one under the contract directory.
 ```
 
 ### Step 1.2: Validate contract
@@ -401,10 +512,15 @@ Scan the codebase, assess risk, and write .signum/contract.json.
 Use the Bash tool to verify the contract was written and has required fields:
 
 ```bash
-test -f .signum/contract.json || { echo "ERROR: contract.json not found"; exit 1; }
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+test -f "$CONTRACT_PATH" || { echo "ERROR: contract.json not found"; exit 1; }
 jq -e '.schemaVersion and .goal and .inScope and .acceptanceCriteria and .riskLevel' \
-  .signum/contract.json > /dev/null && echo "VALID" || echo "INVALID"
+  "$CONTRACT_PATH" > /dev/null && echo "VALID" || echo "INVALID"
 ```
+
+If `SIGNUM_CONTRACT_PATH` is set and the imported contract is missing or INVALID, stop immediately and report: "Pre-approved contract file is missing or invalid. Fix the file passed through SIGNUM_CONTRACT_PATH."
 
 If the file is missing, retry ONCE before failing:
 
@@ -412,9 +528,11 @@ If the file is missing, retry ONCE before failing:
 ```
 FEATURE_REQUEST: <same task from $ARGUMENTS>
 PROJECT_ROOT: <output of pwd>
+CONTRACT_ID: <value emitted above>
+CANONICAL_ARTIFACT_ROOT: <value emitted above>
 
 CRITICAL: The previous contractor run failed to produce contract.json.
-Stop scanning. Write .signum/contract.json NOW with whatever information you have.
+Stop scanning. Write `contract.json` to the canonical artifact root NOW with whatever information you have.
 If uncertain, use openQuestions array and set requiredInputsProvided: false.
 You MUST call the Write tool before finishing.
 ```
@@ -423,32 +541,64 @@ You MUST call the Write tool before finishing.
 
 If the file is STILL missing or INVALID after retry, stop and report: "Contractor agent failed to produce a valid contract.json after 2 attempts (haiku + sonnet). Check agent output for errors."
 
-### Step 1.2.5: Initialize per-contract durable directory
+### Step 1.2.5: Finalize canonical contract bootstrap
 
-After contractor creates `contract.json`, extract the `contractId` and set up a per-contract durable directory. This directory is **not** the live workspace for the current run. The live working set remains under `.signum/`; the per-contract directory is a mirrored snapshot/history surface for this contract.
+After contractor creates `contract.json` in the active contract root, persist the preallocated `contractId` into the file, refresh index metadata, and expose the remaining Phase 1 compatibility views. Contract-owned artifacts, selected downstream file artifacts, and active run directories stay canonical under that active contract root.
 
 Use the Bash tool:
 
 ```bash
-# Source the contract-dir module
 source lib/contract-dir.sh
 
-# Extract contractId from contract.json
-CONTRACT_ID=$(jq -r '.contractId' .signum/contract.json)
-if [ -z "$CONTRACT_ID" ] || [ "$CONTRACT_ID" = "null" ]; then
-  echo "ERROR: contractId not found in contract.json"
-  exit 1
-fi
+CONTRACT_ID="$(get_active_contract)"
+ARTIFACT_ROOT="$(active_artifact_root)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+
+[ -n "$CONTRACT_ID" ] || { echo "ERROR: active contractId missing"; exit 1; }
+test -f "$CONTRACT_PATH" || { echo "ERROR: canonical contract.json not found"; exit 1; }
+
+jq --arg id "$CONTRACT_ID" '.contractId = $id' "$CONTRACT_PATH" > "${CONTRACT_PATH}.tmp" \
+  && mv "${CONTRACT_PATH}.tmp" "$CONTRACT_PATH"
 echo "contractId: $CONTRACT_ID"
 
-# Create per-contract durable directory
-init_contract_dir "$CONTRACT_ID"
-
-# Mirror the initial contract snapshot
-sync_contract_artifacts "$CONTRACT_ID" "contract.json"
-
-# Register contract in index.json
 register_contract "$CONTRACT_ID" "draft"
+
+# Expose Phase 1 artifact ownership through compatibility views.
+link_active_artifact "contract.json"
+link_active_artifact "spec_quality.json"
+link_active_artifact "spec_validation.json"
+link_active_artifact "clover_report.json"
+link_active_artifact "intent_check.json"
+link_active_artifact "approval.json"
+link_active_artifact "contract-hash.txt"
+link_active_artifact "contract-engineer.json"
+link_active_artifact "contract-policy.json"
+link_active_artifact "execution_context.json"
+link_active_artifact "baseline.json"
+link_active_artifact "combined.patch"
+link_active_artifact "execute_log.json"
+link_active_artifact "iteration_delta.patch"
+link_active_artifact "mechanic_report.json"
+link_active_artifact "holdout_report.json"
+link_active_artifact "policy_violations.json"
+link_active_artifact "policy_scan.json"
+link_active_artifact "repo_contract_baseline.json"
+link_active_artifact "repo_contract_violations.json"
+link_active_artifact "audit_iteration_log.json"
+link_active_artifact "repair_brief.json"
+link_active_artifact "flaky_tests.json"
+link_active_artifact "audit_summary.json"
+link_active_artifact "proofpack.json"
+link_active_artifact "anti_entropy_report.json"
+link_active_artifact "review_context.json"
+link_active_artifact "review_prompt_codex.txt"
+link_active_artifact "review_prompt_gemini.txt"
+ensure_active_artifact_dir "reviews"
+ensure_active_artifact_dir "iterations"
+ensure_active_artifact_dir "receipts"
+ensure_active_artifact_dir "runs"
+ensure_active_artifact_dir "snapshots"
+echo "ARTIFACT_ROOT=$ARTIFACT_ROOT"
 ```
 
 ### Step 1.2.7: Module lifecycle check (informational, non-blocking)
@@ -484,16 +634,20 @@ Module lifecycle warnings are informational — they do not block the pipeline. 
 Use the Bash tool:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+
 # Check 1: requiredInputsProvided (contractor cannot resolve ambiguity from codebase alone)
-REQ_OK=$(jq -r '.requiredInputsProvided // true' .signum/contract.json)
+REQ_OK=$(jq -r '.requiredInputsProvided // true' "$CONTRACT_PATH")
 if [ "$REQ_OK" = "false" ]; then
   echo "HARD STOP: requiredInputsProvided=false"
-  jq -r '"Contractor needs additional input:\n  - " + ((.openQuestions // []) | join("\n  - "))' .signum/contract.json
+  jq -r '"Contractor needs additional input:\n  - " + ((.openQuestions // []) | join("\n  - "))' "$CONTRACT_PATH"
 fi
 
 # Check 2: open questions (ambiguities requiring user clarification)
 jq -r 'if (.openQuestions | length) > 0 then "BLOCKED: " + (.openQuestions | join("\n  - ")) else "OK" end' \
-  .signum/contract.json
+  "$CONTRACT_PATH"
 ```
 
 If output contains `HARD STOP:` or starts with `BLOCKED:`, display the questions to the user and **STOP**. Do not proceed to Phase 2 until the user provides answers.
@@ -505,15 +659,20 @@ Do not proceed to Phase 2 until the user provides answers to every open question
 Use the Bash tool to score the contract on 7 dimensions. A score below 69 (grade D) means the contract is too vague for reliable autonomous execution.
 
 ```bash
-GOAL=$(jq -r '.goal' .signum/contract.json)
-AC_COUNT=$(jq '.acceptanceCriteria | length' .signum/contract.json)
-AC_WITH_VERIFY=$(jq '[.acceptanceCriteria[] | select((.verify.type and .verify.value) or .verify.steps)] | length' .signum/contract.json)
-INSCOPE_COUNT=$(jq '.inScope | length' .signum/contract.json)
-HAS_OUTOFSCOPE=$(jq 'if (.outOfScope | length) > 0 then 1 else 0 end' .signum/contract.json)
-HAS_ASSUMPTIONS=$(jq 'if (.assumptions | length) > 0 then 1 else 0 end' .signum/contract.json)
-HAS_HOLDOUTS=$(jq 'if ((.holdoutScenarios // []) | length) > 0 then 1 else 0 end' .signum/contract.json)
-REQ_OK=$(jq -r '.requiredInputsProvided // true' .signum/contract.json)
-OPEN_Q=$(jq '(.openQuestions | length)' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+
+GOAL=$(jq -r '.goal' "$CONTRACT_PATH")
+AC_COUNT=$(jq '.acceptanceCriteria | length' "$CONTRACT_PATH")
+AC_WITH_VERIFY=$(jq '[.acceptanceCriteria[] | select((.verify.type and .verify.value) or .verify.steps)] | length' "$CONTRACT_PATH")
+INSCOPE_COUNT=$(jq '.inScope | length' "$CONTRACT_PATH")
+HAS_OUTOFSCOPE=$(jq 'if (.outOfScope | length) > 0 then 1 else 0 end' "$CONTRACT_PATH")
+HAS_ASSUMPTIONS=$(jq 'if (.assumptions | length) > 0 then 1 else 0 end' "$CONTRACT_PATH")
+HAS_HOLDOUTS=$(jq 'if ((.holdoutScenarios // []) | length) > 0 then 1 else 0 end' "$CONTRACT_PATH")
+REQ_OK=$(jq -r '.requiredInputsProvided // true' "$CONTRACT_PATH")
+OPEN_Q=$(jq '(.openQuestions | length)' "$CONTRACT_PATH")
 
 # Testability (0-25): fraction of ACs with verify commands
 if [ "$AC_COUNT" -gt 0 ]; then
@@ -541,7 +700,7 @@ fi
 # Negative coverage (0-20): holdouts + negative-language ACs
 NEG_SCORE=0
 [ "$HAS_HOLDOUTS" -eq 1 ] && NEG_SCORE=$((NEG_SCORE + 10))
-NEG_ACS=$(jq '[.acceptanceCriteria[] | select(.description | test("must not|should not|\\bnever\\b|\\bprevent|reject|fail|invalid"; "i"))] | length' .signum/contract.json)
+NEG_ACS=$(jq '[.acceptanceCriteria[] | select(.description | test("must not|should not|\\bnever\\b|\\bprevent|reject|fail|invalid"; "i"))] | length' "$CONTRACT_PATH")
 [ "$NEG_ACS" -gt 0 ] && NEG_SCORE=$((NEG_SCORE + 10))
 
 # Clarity (0-20): goal length + absence of vague phrases
@@ -561,7 +720,7 @@ BOUNDARY=0
 # Sub-check 1: Vague verb detection (0-5)
 # Synonym map for terminology consistency (endpoint/route, function/method, test/spec,
 #   error/exception, config/configuration/settings, user/client, file/document)
-ALL_AC_TEXT=$(jq -r '[.acceptanceCriteria[].description] | join(" ")' .signum/contract.json)
+ALL_AC_TEXT=$(jq -r '[.acceptanceCriteria[].description] | join(" ")' "$CONTRACT_PATH")
 VAGUE_VERBS_PATTERN="handle|process|manage|support|ensure|implement|perform|utilize|leverage|facilitate"
 VAGUE_VERBS_FOUND=$(echo "$ALL_AC_TEXT $GOAL" | grep -ciE "\b($VAGUE_VERBS_PATTERN)\b" 2>/dev/null || echo 0)
 if [ "$VAGUE_VERBS_FOUND" -eq 0 ]; then VAGUE_VERB_PTS=5; else VAGUE_VERB_PTS=0; fi
@@ -592,7 +751,7 @@ if [ "$SYNONYM_INCONSISTENT" -eq 0 ]; then TERM_PTS=5; else TERM_PTS=0; fi
 
 # Sub-check 3: AC contradiction detection (0-5)
 # Check pairs of AC descriptions for negation contradictions (must X vs must not X, allow Y vs prevent Y)
-AC_TEXTS=$(jq -r '.acceptanceCriteria[].description' .signum/contract.json 2>/dev/null || echo "")
+AC_TEXTS=$(jq -r '.acceptanceCriteria[].description' "$CONTRACT_PATH" 2>/dev/null || echo "")
 CONTRADICTION_FOUND=0
 while IFS= read -r ac_line; do
   pos=$(echo "$ac_line" | grep -oi "must [a-z]*\|allow [a-z]*\|enable [a-z]*" 2>/dev/null | grep -vi "must not" | head -5)
@@ -652,7 +811,7 @@ jq -n --argjson total "$TOTAL" --arg grade "$GRADE" \
                    clarity: $clarity, scope_boundedness: $scope,
                    completeness: $completeness, boundary_system: $boundary,
                    nl_consistency: $nl_consistency } }' \
-  > .signum/spec_quality.json
+  > "$SPEC_QUALITY_PATH"
 ```
 
 #### Prose quality check (informational, non-blocking)
@@ -661,17 +820,21 @@ Use the Bash tool to run the prose quality gate on the contract. This check is *
 
 ```bash
 PROSE_REPORT=""
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
 if [ -f lib/prose-check.sh ]; then
-  PROSE_REPORT=$(lib/prose-check.sh .signum/contract.json 2>/dev/null || echo '{}')
+  PROSE_REPORT=$(lib/prose-check.sh "$CONTRACT_PATH" 2>/dev/null || echo '{}')
   PROSE_TOTAL=$(echo "$PROSE_REPORT" | jq '.total_findings // 0')
   PROSE_PASS=$(echo "$PROSE_REPORT" | jq -r '.pass // "true"')
   echo "Prose quality: $PROSE_TOTAL finding(s), pass=$PROSE_PASS"
 
   # Merge prose_warnings into spec_quality.json (non-blocking)
-  if [ -f .signum/spec_quality.json ]; then
+  if [ -f "$SPEC_QUALITY_PATH" ]; then
     jq --argjson prose "$PROSE_REPORT" '. + {prose_warnings: $prose}' \
-      .signum/spec_quality.json > .signum/spec_quality_tmp.json \
-      && mv .signum/spec_quality_tmp.json .signum/spec_quality.json
+      "$SPEC_QUALITY_PATH" > "${SPEC_QUALITY_PATH}.tmp" \
+      && mv "${SPEC_QUALITY_PATH}.tmp" "$SPEC_QUALITY_PATH"
   fi
 fi
 ```
@@ -681,12 +844,16 @@ fi
 Run the glossary_check: scan goal, inScope items, and AC descriptions for forbidden synonyms from `project.glossary.json` aliases. This check is **non-blocking** — it never fails the pipeline or reduces the numeric spec quality score. Warnings are written only to `glossary_warnings` in `spec_quality.json`.
 
 ```bash
-GLOSSARY_RESULT=$(lib/glossary-check.sh .signum/contract.json \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+GLOSSARY_RESULT=$(lib/glossary-check.sh "$CONTRACT_PATH" \
   --glossary "${PROJECT_ROOT:-$PWD}/project.glossary.json" 2>/dev/null || echo '{}')
 jq --argjson r "$GLOSSARY_RESULT" \
   '. + {glossary_warnings: ($r.findings // []), glossary_version: ($r.glossary_version // ""), glossary_terms: ($r.glossary_terms // 0)}' \
-  .signum/spec_quality.json > .signum/spec_quality_tmp.json \
-  && mv .signum/spec_quality_tmp.json .signum/spec_quality.json
+  "$SPEC_QUALITY_PATH" > "${SPEC_QUALITY_PATH}.tmp" \
+  && mv "${SPEC_QUALITY_PATH}.tmp" "$SPEC_QUALITY_PATH"
 ```
 
 #### Terminology consistency check (terminology_consistency_check — informational, non-blocking)
@@ -694,13 +861,17 @@ jq --argjson r "$GLOSSARY_RESULT" \
 Run the terminology_consistency_check: read `.signum/contracts/index.json`, extract goal text from active contracts, and emit WARN on synonym proliferation (same concept appearing under two different terms across contracts). This check is **non-blocking**.
 
 ```bash
-TERMINOLOGY_RESULT=$(lib/terminology-check.sh .signum/contract.json \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+TERMINOLOGY_RESULT=$(lib/terminology-check.sh "$CONTRACT_PATH" \
   --index .signum/contracts/index.json \
   --glossary "${PROJECT_ROOT:-$PWD}/project.glossary.json" 2>/dev/null || echo '{}')
 jq --argjson r "$TERMINOLOGY_RESULT" \
   '. + {terminology_warnings: ($r.findings // [])}' \
-  .signum/spec_quality.json > .signum/spec_quality_tmp.json \
-  && mv .signum/spec_quality_tmp.json .signum/spec_quality.json
+  "$SPEC_QUALITY_PATH" > "${SPEC_QUALITY_PATH}.tmp" \
+  && mv "${SPEC_QUALITY_PATH}.tmp" "$SPEC_QUALITY_PATH"
 ```
 
 #### Cross-contract overlap check (cross_contract_overlap_check — informational, non-blocking)
@@ -708,12 +879,16 @@ jq --argjson r "$TERMINOLOGY_RESULT" \
 Run the cross_contract_overlap_check: read `.signum/contracts/index.json`, compare inScope arrays of active contracts against the new contract's inScope, and emit overlap warnings. This check is **non-blocking** — it never fails the pipeline or reduces the numeric spec quality score. Warnings are written only to `overlap_warnings` in `spec_quality.json`.
 
 ```bash
-OVERLAP_RESULT=$(lib/overlap-check.sh .signum/contract.json \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+OVERLAP_RESULT=$(lib/overlap-check.sh "$CONTRACT_PATH" \
   --index .signum/contracts/index.json 2>/dev/null || echo '{}')
 jq --argjson r "$OVERLAP_RESULT" \
   '. + {overlap_warnings: ($r.findings // [])}' \
-  .signum/spec_quality.json > .signum/spec_quality_tmp.json \
-  && mv .signum/spec_quality_tmp.json .signum/spec_quality.json
+  "$SPEC_QUALITY_PATH" > "${SPEC_QUALITY_PATH}.tmp" \
+  && mv "${SPEC_QUALITY_PATH}.tmp" "$SPEC_QUALITY_PATH"
 ```
 
 #### Assumption contradiction check (assumption_contradiction_check — informational, non-blocking)
@@ -721,12 +896,16 @@ jq --argjson r "$OVERLAP_RESULT" \
 Run the assumption_contradiction_check: read assumptions from each related contract in index.json (parentContractId, relatedContractIds), compare assumption text pairs for direct contradiction keywords, and emit contradiction warnings. This check is **non-blocking** — it does not block the pipeline.
 
 ```bash
-ASSUMPTION_RESULT=$(lib/assumption-check.sh .signum/contract.json \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+ASSUMPTION_RESULT=$(lib/assumption-check.sh "$CONTRACT_PATH" \
   --index .signum/contracts/index.json 2>/dev/null || echo '{}')
 jq --argjson r "$ASSUMPTION_RESULT" \
   '. + {assumption_warnings: ($r.findings // [])}' \
-  .signum/spec_quality.json > .signum/spec_quality_tmp.json \
-  && mv .signum/spec_quality_tmp.json .signum/spec_quality.json
+  "$SPEC_QUALITY_PATH" > "${SPEC_QUALITY_PATH}.tmp" \
+  && mv "${SPEC_QUALITY_PATH}.tmp" "$SPEC_QUALITY_PATH"
 ```
 
 #### ADR relevance check (adr_relevance_check — informational, non-blocking)
@@ -734,12 +913,16 @@ jq --argjson r "$ASSUMPTION_RESULT" \
 Run the adr_relevance_check: scan `docs/adr/` and `docs/decisions/` for `*.md` files, match their filenames against inScope paths using glob-style prefix matching, and emit a WARN when relevant ADRs exist but the contract's `adrRefs` field is absent or empty. This check is **non-blocking** and degrades gracefully to a no-op when neither directory exists.
 
 ```bash
-ADR_RESULT=$(lib/adr-check.sh .signum/contract.json \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+ADR_RESULT=$(lib/adr-check.sh "$CONTRACT_PATH" \
   --project-root "${PROJECT_ROOT:-$PWD}" 2>/dev/null || echo '{}')
 jq --argjson r "$ADR_RESULT" \
   '. + {adr_warnings: ($r.findings // [])}' \
-  .signum/spec_quality.json > .signum/spec_quality_tmp.json \
-  && mv .signum/spec_quality_tmp.json .signum/spec_quality.json
+  "$SPEC_QUALITY_PATH" > "${SPEC_QUALITY_PATH}.tmp" \
+  && mv "${SPEC_QUALITY_PATH}.tmp" "$SPEC_QUALITY_PATH"
 ```
 
 #### Upstream staleness check (upstream_staleness_check — blocking when stalenessPolicy is "block")
@@ -747,19 +930,22 @@ jq --argjson r "$ADR_RESULT" \
 Run the upstream_staleness_check: recompute SHA-256 over all files listed in `contextInheritance.staleIfChanged`, compare to `contextInheritance.contextSnapshotHash`, and emit BLOCK or WARN when the hash differs. This check is **skipped** when `staleIfChanged` is absent or empty.
 
 ```bash
-STALENESS_RESULT=$(lib/staleness-check.sh .signum/contract.json \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+STALENESS_RESULT=$(lib/staleness-check.sh "$CONTRACT_PATH" \
   --project-root "${PROJECT_ROOT:-$PWD}" 2>/dev/null || echo '{"check":"staleness","status":"error"}')
 STALENESS_STATUS=$(echo "$STALENESS_RESULT" | jq -r '.status // "error"')
 # Apply stalenessStatus mutation to contract.json based on check result
 if [ "$STALENESS_STATUS" = "fresh" ]; then
-  jq '.contextInheritance.stalenessStatus = "fresh"' .signum/contract.json > .signum/contract.json.tmp \
-    && mv .signum/contract.json.tmp .signum/contract.json
+  jq '.contextInheritance.stalenessStatus = "fresh"' "$CONTRACT_PATH" > "${CONTRACT_PATH}.tmp" \
+    && mv "${CONTRACT_PATH}.tmp" "$CONTRACT_PATH"
 elif [ "$STALENESS_STATUS" = "warn" ]; then
-  jq '.contextInheritance.stalenessStatus = "warning"' .signum/contract.json > .signum/contract.json.tmp \
-    && mv .signum/contract.json.tmp .signum/contract.json
+  jq '.contextInheritance.stalenessStatus = "warning"' "$CONTRACT_PATH" > "${CONTRACT_PATH}.tmp" \
+    && mv "${CONTRACT_PATH}.tmp" "$CONTRACT_PATH"
 elif [ "$STALENESS_STATUS" = "block" ]; then
-  jq '.contextInheritance.stalenessStatus = "stale"' .signum/contract.json > .signum/contract.json.tmp \
-    && mv .signum/contract.json.tmp .signum/contract.json
+  jq '.contextInheritance.stalenessStatus = "stale"' "$CONTRACT_PATH" > "${CONTRACT_PATH}.tmp" \
+    && mv "${CONTRACT_PATH}.tmp" "$CONTRACT_PATH"
   echo "BLOCK: upstream artifacts changed (stalenessPolicy=block). Re-run Contractor agent to refresh."
   exit 1
 fi
@@ -772,8 +958,11 @@ fi
 Check if contract has a project intent reference:
 
 ```bash
-PROJECT_REF=$(jq -r '.contextInheritance.projectRef // "absent"' .signum/contract.json)
-RISK=$(jq -r '.riskLevel' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+PROJECT_REF=$(jq -r '.contextInheritance.projectRef // "absent"' "$CONTRACT_PATH")
+RISK=$(jq -r '.riskLevel' "$CONTRACT_PATH")
 if [ "$RISK" = "low" ] || [ "$PROJECT_REF" = "absent" ] || [ "$PROJECT_REF" = "null" ] || [ "$PROJECT_REF" = "not_found" ]; then
   echo "Intent alignment check: skipped (risk=$RISK, projectRef=$PROJECT_REF)"
 else
@@ -810,7 +999,7 @@ Output JSON only:
 Parse the subagent response as JSON. If parsing fails, write safe default:
 `{"aligned": null, "concerns": [], "glossary_violations": [], "parse_error": true}`
 
-Write result to `.signum/intent_check.json`.
+Write result to `intent_check.json` under the canonical artifact root.
 
 ### Step 1.3.7: Multi-model spec validation (optional, if providers available)
 
@@ -829,9 +1018,13 @@ If both are UNAVAILABLE, skip to Step 1.4.
 If at least one is available: read the contract to build validation context:
 
 ```bash
-SPEC_CONTEXT=$(python3 -c "
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_CONTEXT=$(python3 - "$CONTRACT_PATH" <<'PY'
 import json
-c = json.load(open('.signum/contract.json'))
+import sys
+c = json.load(open(sys.argv[1]))
 acs = '\n'.join(f'  - [{a[\"id\"]}] {a[\"description\"]}' for a in c.get('acceptanceCriteria', []))
 inscope = ', '.join(c.get('inScope', []))
 print(f'''Goal: {c[\"goal\"]}
@@ -842,7 +1035,8 @@ Acceptance criteria:
 Assumptions: {', '.join(c.get('assumptions', ['none']))}
 Out of scope: {', '.join(c.get('outOfScope', ['not specified']))}
 ''')
-")
+PY
+)
 echo "$SPEC_CONTEXT"
 ```
 
@@ -911,9 +1105,12 @@ Save the task ID as GEMINI_SPEC_TASK_ID.
 
 Use the TaskOutput tool with `block: true` to wait for CODEX_SPEC_TASK_ID (if launched). Then use the TaskOutput tool with `block: true` to wait for GEMINI_SPEC_TASK_ID (if launched).
 
-Write collected findings to `.signum/spec_validation.json`:
+Write collected findings to `spec_validation.json` under the canonical artifact root:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+SPEC_VALIDATION_PATH="${ARTIFACT_ROOT}spec_validation.json"
 jq -n \
   --arg codex_out "$CODEX_SPEC_OUT" \
   --arg gemini_out "$GEMINI_SPEC_OUT" \
@@ -922,8 +1119,8 @@ jq -n \
   '{
     codex: { available: ($codex_avail == "yes"), findings: $codex_out },
     gemini: { available: ($gemini_avail == "yes"), findings: $gemini_out }
-  }' > .signum/spec_validation.json
-echo "Spec validation written to .signum/spec_validation.json"
+  }' > "$SPEC_VALIDATION_PATH"
+echo "Spec validation written to $SPEC_VALIDATION_PATH"
 ```
 
 ### Step 1.3.8: Clover reconstruction test
@@ -937,7 +1134,7 @@ You are given ONLY the acceptance criteria below. You have NOT seen the original
 Reconstruct what the goal/task likely was based solely on these ACs.
 
 Acceptance criteria:
-<ACs from .signum/contract.json — list each AC id + description, but do NOT include the goal>
+<ACs from contract.json under the canonical artifact root - list each AC id + description, but do NOT include the goal>
 
 Write your reconstructed goal as a single paragraph (2-3 sentences max).
 Then write a JSON object:
@@ -952,7 +1149,11 @@ Output ONLY the JSON object, no other text.
 After the agent returns, use the Bash tool to compare:
 
 ```bash
-ORIGINAL_GOAL=$(jq -r '.goal' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+CLOVER_REPORT_PATH="${ARTIFACT_ROOT}clover_report.json"
+ORIGINAL_GOAL=$(jq -r '.goal' "$CONTRACT_PATH")
 RECONSTRUCTED=$(echo '<agent output>' | jq -r '.reconstructed_goal // empty')
 CONFIDENCE=$(echo '<agent output>' | jq -r '.confidence // 0')
 GAPS=$(echo '<agent output>' | jq -r '.coverage_gaps | length')
@@ -966,11 +1167,11 @@ jq -n \
   --argjson gaps "$(echo '<agent output>' | jq '.coverage_gaps')" \
   '{original_goal: $original, reconstructed_goal: $reconstructed,
     confidence: $confidence, coverage_gaps: $gaps, gap_count: $gap_count,
-    pass: ($confidence >= 0.7 and $gap_count <= 2)}' > .signum/clover_report.json
+    pass: ($confidence >= 0.7 and $gap_count <= 2)}' > "$CLOVER_REPORT_PATH"
 
-if [ "$(jq '.pass' .signum/clover_report.json)" = "false" ]; then
+if [ "$(jq '.pass' "$CLOVER_REPORT_PATH")" = "false" ]; then
   echo "CLOVER WARNING: ACs may not fully capture the goal (confidence=$CONFIDENCE, gaps=$GAPS)"
-  jq -r '.coverage_gaps[]' .signum/clover_report.json | sed 's/^/  - /'
+  jq -r '.coverage_gaps[]' "$CLOVER_REPORT_PATH" | sed 's/^/  - /'
   echo "Consider adding ACs to cover the gaps above."
 else
   echo "Clover test: PASS (confidence=$CONFIDENCE)"
@@ -984,29 +1185,36 @@ Clover failure is informational — it does not block the pipeline. Display warn
 **Data collection:** Use a single Bash call to extract all values into shell variables:
 
 ```bash
-CONTRACT_ID=$(jq -r '.contractId' .signum/contract.json)
-GOAL=$(jq -r '.goal' .signum/contract.json)
-RISK=$(jq -r '.riskLevel' .signum/contract.json)
-INSCOPE=$(jq -r '.inScope | join(", ")' .signum/contract.json)
-AC_COUNT=$(jq '.acceptanceCriteria | length' .signum/contract.json)
-HOLDOUT_COUNT=$(jq '((.holdoutScenarios // []) | length) + ([.acceptanceCriteria[] | select(.visibility == "holdout")] | length)' .signum/contract.json)
-VISIBLE_AC=$((AC_COUNT - $(jq '[.acceptanceCriteria[] | select(.visibility == "holdout")] | length' .signum/contract.json)))
-SPEC_TOTAL=$(jq -r '.total // "?"' .signum/spec_quality.json 2>/dev/null || echo "?")
-SPEC_GRADE=$(jq -r '.grade // "?"' .signum/spec_quality.json 2>/dev/null || echo "?")
-CLOVER=$(jq -r 'if .pass then "PASS (" + (.confidence | tostring) + ")" else "WARN (" + (.confidence | tostring) + ")" end' .signum/clover_report.json 2>/dev/null || echo "skipped")
-INTENT=$(jq -r 'if .aligned then "aligned" elif .aligned == false then "MISALIGNED" else "skipped" end' .signum/intent_check.json 2>/dev/null || echo "skipped")
-RISK_SIGNALS=$(jq -r 'if .riskLevel == "high" then (.riskSignals // [] | join(", ")) else "" end' .signum/contract.json)
-READINESS=$(jq -r '.readinessForPlanning.verdict // "absent"' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"
+CLOVER_REPORT_PATH="${ARTIFACT_ROOT}clover_report.json"
+INTENT_CHECK_PATH="${ARTIFACT_ROOT}intent_check.json"
+
+CONTRACT_ID=$(jq -r '.contractId' "$CONTRACT_PATH")
+GOAL=$(jq -r '.goal' "$CONTRACT_PATH")
+RISK=$(jq -r '.riskLevel' "$CONTRACT_PATH")
+INSCOPE=$(jq -r '.inScope | join(", ")' "$CONTRACT_PATH")
+AC_COUNT=$(jq '.acceptanceCriteria | length' "$CONTRACT_PATH")
+HOLDOUT_COUNT=$(jq '((.holdoutScenarios // []) | length) + ([.acceptanceCriteria[] | select(.visibility == "holdout")] | length)' "$CONTRACT_PATH")
+VISIBLE_AC=$((AC_COUNT - $(jq '[.acceptanceCriteria[] | select(.visibility == "holdout")] | length' "$CONTRACT_PATH")))
+SPEC_TOTAL=$(jq -r '.total // "?"' "$SPEC_QUALITY_PATH" 2>/dev/null || echo "?")
+SPEC_GRADE=$(jq -r '.grade // "?"' "$SPEC_QUALITY_PATH" 2>/dev/null || echo "?")
+CLOVER=$(jq -r 'if .pass then "PASS (" + (.confidence | tostring) + ")" else "WARN (" + (.confidence | tostring) + ")" end' "$CLOVER_REPORT_PATH" 2>/dev/null || echo "skipped")
+INTENT=$(jq -r 'if .aligned then "aligned" elif .aligned == false then "MISALIGNED" else "skipped" end' "$INTENT_CHECK_PATH" 2>/dev/null || echo "skipped")
+RISK_SIGNALS=$(jq -r 'if .riskLevel == "high" then (.riskSignals // [] | join(", ")) else "" end' "$CONTRACT_PATH")
+READINESS=$(jq -r '.readinessForPlanning.verdict // "absent"' "$CONTRACT_PATH")
 
 # Warnings (collect into array for display)
 WARNINGS=""
-if [ -f .signum/clover_report.json ] && [ "$(jq '.pass' .signum/clover_report.json)" = "false" ]; then
+if [ -f "$CLOVER_REPORT_PATH" ] && [ "$(jq '.pass' "$CLOVER_REPORT_PATH")" = "false" ]; then
   WARNINGS="${WARNINGS}\n- Clover: ACs may not fully capture the goal"
-  WARNINGS="${WARNINGS}\n$(jq -r '.coverage_gaps[] | "  - " + .' .signum/clover_report.json)"
+  WARNINGS="${WARNINGS}\n$(jq -r '.coverage_gaps[] | "  - " + .' "$CLOVER_REPORT_PATH")"
 fi
-if [ -f .signum/intent_check.json ] && [ "$(jq '.concerns | length' .signum/intent_check.json)" -gt 0 ]; then
+if [ -f "$INTENT_CHECK_PATH" ] && [ "$(jq '.concerns | length' "$INTENT_CHECK_PATH")" -gt 0 ]; then
   WARNINGS="${WARNINGS}\n- Intent alignment concerns:"
-  WARNINGS="${WARNINGS}\n$(jq -r '.concerns[] | "  - " + .' .signum/intent_check.json)"
+  WARNINGS="${WARNINGS}\n$(jq -r '.concerns[] | "  - " + .' "$INTENT_CHECK_PATH")"
 fi
 if [ "$READINESS" = "no-go" ]; then
   WARNINGS="${WARNINGS}\n- Contractor self-critique returned no-go"
@@ -1082,9 +1290,12 @@ Phase 2 will NOT be entered until all checklist items are approved.
 
 **STOP. Do not proceed to Phase 2.**
 
-If ALL items are answered "yes", write `.signum/approval.json`:
+If ALL items are answered "yes", write `approval.json` under the canonical artifact root:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+APPROVAL_PATH="${ARTIFACT_ROOT}approval.json"
 APPROVAL_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 jq -n --arg ts "$APPROVAL_TS" \
   '{
@@ -1097,18 +1308,21 @@ jq -n --arg ts "$APPROVAL_TS" \
       assumptions_valid: true,
       risk_appropriate: true
     }
-  }' > .signum/approval.json
+  }' > "$APPROVAL_PATH"
 echo "approval.json written at $APPROVAL_TS"
 ```
 
 After writing approval.json, transition the contract status from `draft` to `active` and record the `activatedAt` timestamp:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
 ACTIVATED_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 jq --arg ts "$ACTIVATED_TS" \
   '.status = "active" | .timestamps.activatedAt = $ts' \
-  .signum/contract.json > .signum/contract-tmp.json && \
-  mv .signum/contract-tmp.json .signum/contract.json
+  "$CONTRACT_PATH" > "${CONTRACT_PATH}.tmp" && \
+  mv "${CONTRACT_PATH}.tmp" "$CONTRACT_PATH"
 echo "Contract status: draft → active at $ACTIVATED_TS"
 ```
 
@@ -1119,20 +1333,25 @@ After the user confirms, anchor the approved contract with a SHA-256 hash and ti
 Use the Bash tool:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+CONTRACT_HASH_PATH="${ARTIFACT_ROOT}contract-hash.txt"
+
 if command -v sha256sum >/dev/null 2>&1; then
-  CONTRACT_HASH=$(sha256sum .signum/contract.json | awk '{print $1}')
+  CONTRACT_HASH=$(sha256sum "$CONTRACT_PATH" | awk '{print $1}')
 elif command -v shasum >/dev/null 2>&1; then
-  CONTRACT_HASH=$(shasum -a 256 .signum/contract.json | awk '{print $1}')
+  CONTRACT_HASH=$(shasum -a 256 "$CONTRACT_PATH" | awk '{print $1}')
 else
   CONTRACT_HASH="unavailable"
 fi
 
 APPROVAL_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-cat > .signum/contract-hash.txt <<EOF
+cat > "$CONTRACT_HASH_PATH" <<EOF
 contract_sha256: $CONTRACT_HASH
 approved_at: $APPROVAL_TS
-contract_file: .signum/contract.json
+contract_file: $CONTRACT_PATH
 EOF
 
 echo "Audit chain anchored: $CONTRACT_HASH at $APPROVAL_TS"
@@ -1143,32 +1362,40 @@ echo "Audit chain anchored: $CONTRACT_HASH at $APPROVAL_TS"
 Use the Bash tool to create a contract stripped of holdout scenarios and holdout ACs (data-level isolation):
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+CONTRACT_ENGINEER_PATH="${ARTIFACT_ROOT}contract-engineer.json"
+
 # Create engineer contract: remove holdouts + holdoutScenarios
 jq '{
   schemaVersion, contractId, status, timestamps, goal, inScope, allowNewFilesUnder, outOfScope,
   acceptanceCriteria: [.acceptanceCriteria[] | select(.visibility != "holdout")],
   assumptions, openQuestions, riskLevel, riskSignals, requiredInputsProvided,
   contextInheritance
-} | with_entries(select(.value != null))' .signum/contract.json > .signum/contract-engineer.json
+} | with_entries(select(.value != null))' "$CONTRACT_PATH" > "$CONTRACT_ENGINEER_PATH"
 
 # Generate holdout manifest for committed spec
-HOLDOUT_COUNT=$(jq '[.acceptanceCriteria[] | select(.visibility == "holdout")] | length' .signum/contract.json)
+HOLDOUT_COUNT=$(jq '[.acceptanceCriteria[] | select(.visibility == "holdout")] | length' "$CONTRACT_PATH")
 if [ "$HOLDOUT_COUNT" -gt 0 ]; then
-  HOLDOUT_HASH=$(jq -c '[.acceptanceCriteria[] | select(.visibility == "holdout")]' .signum/contract.json | shasum -a 256 | cut -c1-16)
+  HOLDOUT_HASH=$(jq -c '[.acceptanceCriteria[] | select(.visibility == "holdout")]' "$CONTRACT_PATH" | shasum -a 256 | cut -c1-16)
   jq --argjson count "$HOLDOUT_COUNT" --arg hash "sha256:$HOLDOUT_HASH" \
-    '. + {holdoutManifest: {count: $count, hash: $hash}}' .signum/contract-engineer.json > .signum/contract-engineer-tmp.json
-  mv .signum/contract-engineer-tmp.json .signum/contract-engineer.json
+    '. + {holdoutManifest: {count: $count, hash: $hash}}' "$CONTRACT_ENGINEER_PATH" > "${CONTRACT_ENGINEER_PATH}.tmp"
+  mv "${CONTRACT_ENGINEER_PATH}.tmp" "$CONTRACT_ENGINEER_PATH"
 fi
 
-AC_VISIBLE=$(jq '[.acceptanceCriteria[] | select(.visibility != "holdout")] | length' .signum/contract.json)
+AC_VISIBLE=$(jq '[.acceptanceCriteria[] | select(.visibility != "holdout")] | length' "$CONTRACT_PATH")
 echo "contract-engineer.json written ($AC_VISIBLE visible ACs, $HOLDOUT_COUNT holdouts redacted)"
 ```
 
 After writing `contract-engineer.json`, validate holdout count against risk level:
 
 ```bash
-RISK=$(jq -r '.riskLevel' .signum/contract.json)
-HOLDOUT_COUNT=$(jq '([.acceptanceCriteria[] | select(.visibility == "holdout")] | length) + ((.holdoutScenarios // []) | length)' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+RISK=$(jq -r '.riskLevel' "$CONTRACT_PATH")
+HOLDOUT_COUNT=$(jq '([.acceptanceCriteria[] | select(.visibility == "holdout")] | length) + ((.holdoutScenarios // []) | length)' "$CONTRACT_PATH")
 
 # Minimum holdout requirements by risk level
 MIN_HOLDOUTS=0
@@ -1204,9 +1431,16 @@ Derive `contract-policy.json` from the contract. This file defines what the Engi
 Use the Bash tool:
 
 ```bash
-python3 -c "
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+CONTRACT_POLICY_PATH="${ARTIFACT_ROOT}contract-policy.json"
+python3 - "$CONTRACT_PATH" "$CONTRACT_POLICY_PATH" <<'PY'
 import json
-with open('.signum/contract.json') as f:
+import sys
+contract_path = sys.argv[1]
+policy_path = sys.argv[2]
+with open(contract_path) as f:
     c = json.load(f)
 risk = c.get('riskLevel', 'low')
 in_scope = c.get('inScope', [])
@@ -1230,10 +1464,10 @@ policy = {
     'max_files_changed': max_files,
     'network_access': False,
 }
-with open('.signum/contract-policy.json', 'w') as f:
+with open(policy_path, 'w') as f:
     json.dump(policy, f, indent=2)
 print(f'contract-policy.json written (risk={risk}, allowed_paths={len(in_scope)}, max_files={max_files})')
-"
+PY
 ```
 
 ---
@@ -1247,16 +1481,22 @@ print(f'contract-policy.json written (risk={risk}, allowed_paths={len(in_scope)}
 Use the Bash tool to record the current commit SHA (audit chain: this is where the Engineer starts from) and run project checks BEFORE the engineer touches anything:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+BASELINE_PATH="${ARTIFACT_ROOT}baseline.json"
+
 # Record base commit for audit chain
 BASE_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "no-git")
 EXECUTE_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-echo "{\"base_commit\":\"$BASE_COMMIT\",\"started_at\":\"$EXECUTE_START\"}" > .signum/execution_context.json
+echo "{\"base_commit\":\"$BASE_COMMIT\",\"started_at\":\"$EXECUTE_START\"}" > "$EXECUTION_CONTEXT_PATH"
 echo "Execution context: base_commit=$BASE_COMMIT"
 
 # Set run_id for receipt chain and capture pre-execute snapshot
-RUN_ID=$(jq -r '.contractId // "signum-run"' .signum/contract.json)
-jq --arg rid "$RUN_ID" '. + {run_id:$rid}' .signum/execution_context.json > .signum/execution_context.json.tmp \
-  && mv .signum/execution_context.json.tmp .signum/execution_context.json
+RUN_ID=$(jq -r '.contractId // "signum-run"' "$CONTRACT_PATH")
+jq --arg rid "$RUN_ID" '. + {run_id:$rid}' "$EXECUTION_CONTEXT_PATH" > "${EXECUTION_CONTEXT_PATH}.tmp" \
+  && mv "${EXECUTION_CONTEXT_PATH}.tmp" "$EXECUTION_CONTEXT_PATH"
 
 # Lint
 if [ -f "pyproject.toml" ] && grep -q "ruff" pyproject.toml 2>/dev/null; then
@@ -1298,17 +1538,25 @@ jq -n \
   --argjson type "$BL_TYPE_EXIT" \
   --argjson test "$BL_TEST_EXIT" \
   --argjson failing "$BL_TEST_FAILING" \
-  '{ lint: $lint, typecheck: $type, tests: { exit_code: $test, failing: $failing } }' > .signum/baseline.json
+  '{ lint: $lint, typecheck: $type, tests: { exit_code: $test, failing: $failing } }' > "$BASELINE_PATH"
 
 echo "Baseline captured: lint=$BL_LINT_EXIT type=$BL_TYPE_EXIT test=$BL_TEST_EXIT"
 ```
 
-If `repo-contract.json` exists in the project root, also capture invariant baseline:
+If `repo-contract.json` exists in the project root, also capture invariant baseline to `repo_contract_baseline.json` under the canonical artifact root:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REPO_CONTRACT_BASELINE_PATH="${ARTIFACT_ROOT}repo_contract_baseline.json"
+
 if [ -f "repo-contract.json" ]; then
-  python3 -c "
-import json, subprocess
+  python3 - "$REPO_CONTRACT_BASELINE_PATH" <<'PY'
+import json
+import subprocess
+import sys
+
+output_path = sys.argv[1]
 with open('repo-contract.json') as f:
     rc = json.load(f)
 results = {}
@@ -1321,20 +1569,24 @@ for inv in rc.get('invariants', []):
         'exit_code': r.returncode,
         'passed': r.returncode == 0,
     }
-with open('.signum/repo_contract_baseline.json', 'w') as f:
+with open(output_path, 'w') as f:
     json.dump(results, f, indent=2)
 total = len(results)
 passed = sum(1 for v in results.values() if v['passed'])
 print(f'Repo-contract baseline: {passed}/{total} invariants passing')
-"
+PY
 fi
 ```
 
 ### Step 2.0.5: Capture pre-execute snapshot (receipt chain)
 
-Use the Bash tool to capture a deterministic workspace snapshot before the engineer runs. This snapshot anchors the receipt chain — `base_tree_hash` in the execute receipt will reference this snapshot.
+Use the Bash tool to capture a deterministic workspace snapshot before the engineer runs. This snapshot anchors the receipt chain, and it is written under the canonical artifact root so `base_tree_hash` in the execute receipt references the active contract's snapshot.
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+SNAPSHOT_PATH="${ARTIFACT_ROOT}snapshots/execute-attempt-01.json"
+
 # Resolve snapshot-tree.sh from known trusted Signum install roots only.
 _SIGNUM_SNAPSHOT=""
 for _d in \
@@ -1349,7 +1601,7 @@ if [ -z "$_SIGNUM_SNAPSHOT" ]; then
   echo "ERROR: snapshot-tree.sh not found in Signum plugin directories — receipt chain cannot be disabled" >&2
   exit 1
 fi
-bash "$_SIGNUM_SNAPSHOT" execute-attempt-01
+bash "$_SIGNUM_SNAPSHOT" execute-attempt-01 --workspace-root "$PWD" --signum-dir "$ARTIFACT_ROOT"
 echo "Pre-execute snapshot captured"
 ```
 
@@ -1358,10 +1610,10 @@ echo "Pre-execute snapshot captured"
 Use the Agent tool to launch the "engineer" agent with this prompt:
 
 ```
-Read .signum/contract-engineer.json and implement the required changes.
-Read .signum/baseline.json for pre-existing check state.
+The canonical artifact root for this execute phase is `.signum/contracts/<activeContractId>/`.
+Read `contract-engineer.json` and `baseline.json` from that canonical artifact root.
 Implement, run the repair loop (max 3 attempts), save artifacts.
-Write .signum/combined.patch and .signum/execute_log.json.
+Write `combined.patch` and `execute_log.json` to that same canonical artifact root.
 ```
 
 ### Step 2.2: Check result
@@ -1369,15 +1621,18 @@ Write .signum/combined.patch and .signum/execute_log.json.
 Use the Bash tool:
 
 ```bash
-test -f .signum/execute_log.json || { echo "ERROR: execute_log.json not found"; exit 1; }
-STATUS=$(jq -r '.status' .signum/execute_log.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+test -f "$EXECUTE_LOG_PATH" || { echo "ERROR: execute_log.json not found"; exit 1; }
+STATUS=$(jq -r '.status' "$EXECUTE_LOG_PATH")
 if [ "$STATUS" != "SUCCESS" ]; then
   echo "ERROR: Execute status is '$STATUS' (expected SUCCESS)"
   jq -r '"Attempt failures:",
          (.attempts[] | "  Attempt " + (.number | tostring) + ": " +
            (.checks | to_entries[] | select(.value.passed == false) |
              "  " + .key + " failed: " + (.value.error // "no error message")))' \
-    .signum/execute_log.json 2>/dev/null || jq . .signum/execute_log.json
+    "$EXECUTE_LOG_PATH" 2>/dev/null || jq . "$EXECUTE_LOG_PATH"
   exit 1
 fi
 ```
@@ -1387,7 +1642,10 @@ If exit code is non-zero, report: "Engineer agent failed after all attempts. Fix
 Verify the patch exists:
 
 ```bash
-test -f .signum/combined.patch && wc -l .signum/combined.patch || echo "WARNING: combined.patch missing"
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+test -f "$COMBINED_PATCH_PATH" && wc -l "$COMBINED_PATCH_PATH" || echo "WARNING: combined.patch missing"
 ```
 
 ### Step 2.3: Display execution summary
@@ -1395,10 +1653,13 @@ test -f .signum/combined.patch && wc -l .signum/combined.patch || echo "WARNING:
 Use the Bash tool:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
 jq -r '"Attempts used: " + (.totalAttempts | tostring) + "/" + (.maxAttempts | tostring),
        "Acceptance criteria passed: " +
          ([.attempts[-1].checks | to_entries[] | select(.value.passed == true)] | length | tostring)' \
-  .signum/execute_log.json
+  "$EXECUTE_LOG_PATH"
 ```
 
 ### Step 2.4: Scope gate
@@ -1406,11 +1667,18 @@ jq -r '"Attempts used: " + (.totalAttempts | tostring) + "/" + (.maxAttempts | t
 Use the Bash tool to verify no out-of-scope files were modified:
 
 ```bash
-python3 -c "
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+
+python3 - "$CONTRACT_PATH" <<'PY'
 import json, subprocess
+import sys
+
+contract_path = sys.argv[1]
 changed = subprocess.run(['git', 'diff', '--name-only'], capture_output=True, text=True).stdout.strip().split('\n')
 changed = [f for f in changed if f]
-with open('.signum/contract.json') as f:
+with open(contract_path) as f:
     contract = json.load(f)
 in_scope = contract.get('inScope', [])
 allow_new = contract.get('allowNewFilesUnder', [])
@@ -1438,7 +1706,7 @@ if violations:
     exit(1)
 else:
     print(f'Scope check: PASS ({len(changed)} files, all within inScope)')
-"
+PY
 ```
 
 If scope violation, **STOP**. Do not proceed to Phase 3.
@@ -1448,12 +1716,17 @@ If scope violation, **STOP**. Do not proceed to Phase 3.
 Use the Bash tool to verify the Engineer's changes comply with `contract-policy.json`:
 
 ```bash
-if [ ! -f ".signum/contract-policy.json" ]; then
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_POLICY_PATH="${ARTIFACT_ROOT}contract-policy.json"
+POLICY_VIOLATIONS_PATH="${ARTIFACT_ROOT}policy_violations.json"
+
+if [ ! -f "$CONTRACT_POLICY_PATH" ]; then
   echo "contract-policy.json not found, skipping policy check"
-  echo '{"violations":[]}' > .signum/policy_violations.json
+  echo '{"violations":[]}' > "$POLICY_VIOLATIONS_PATH"
 else
   FILE_COUNT=$(git diff --name-only | wc -l | tr -d '[:space:]')
-  MAX_FILES=$(jq '.max_files_changed' .signum/contract-policy.json)
+  MAX_FILES=$(jq '.max_files_changed' "$CONTRACT_POLICY_PATH")
 
   VIOLS='[]'
 
@@ -1469,9 +1742,9 @@ else
     if printf '%s' "$DIFF" | grep -qE "$pat" 2>/dev/null; then
       VIOLS=$(printf '%s' "$VIOLS" | jq --arg v "DENIED_PATTERN in diff: $pat" '. + [$v]')
     fi
-  done < <(jq -r '.bash_deny_patterns[]' .signum/contract-policy.json)
+  done < <(jq -r '.bash_deny_patterns[]' "$CONTRACT_POLICY_PATH")
 
-  printf '%s' "$VIOLS" | jq '{violations: .}' > .signum/policy_violations.json
+  printf '%s' "$VIOLS" | jq '{violations: .}' > "$POLICY_VIOLATIONS_PATH"
   VIOL_COUNT=$(printf '%s' "$VIOLS" | jq 'length')
 
   if [ "$VIOL_COUNT" -gt 0 ]; then
@@ -1491,6 +1764,10 @@ If output contains `AUTO_BLOCK`, **STOP**. Do not proceed to Phase 3.
 Use the Bash tool to verify all non-glob `inScope` paths exist after the engineer ran. This catches the class of failure where files were promised but never created:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+
 MISSING_SCOPE=""
 while IFS= read -r scoped; do
   scoped=$(printf '%s' "$scoped" | sed 's/ (.*$//')
@@ -1501,7 +1778,7 @@ while IFS= read -r scoped; do
   if [ ! -e "$scoped" ]; then
     MISSING_SCOPE="$MISSING_SCOPE\n  $scoped"
   fi
-done < <(jq -r '.inScope[]' .signum/contract.json)
+done < <(jq -r '.inScope[]' "$CONTRACT_PATH")
 if [ -n "$MISSING_SCOPE" ]; then
   echo "SCOPE MISSING: expected inScope paths do not exist:$MISSING_SCOPE"
   exit 1
@@ -1517,6 +1794,12 @@ If scope existence fails, **STOP**. Do not proceed to Phase 3.
 Use the Bash tool to run deterministic boundary verification. This runs AFTER the engineer completes and verifies AC evidence, scope integrity, and artifact hashes. The boundary verifier generates the execute receipt — the engineer does NOT write its own receipt.
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_ENGINEER_PATH="${ARTIFACT_ROOT}contract-engineer.json"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+SNAPSHOT_PATH="${ARTIFACT_ROOT}snapshots/execute-attempt-01.json"
 _SIGNUM_BOUNDARY=""
 for _d in \
   "${_REAL_HOME:=$HOME}/.claude/plugins/signum/platforms/claude-code" \
@@ -1531,7 +1814,12 @@ if [ -z "$_SIGNUM_BOUNDARY" ]; then
   exit 1
 fi
 bash "$_SIGNUM_BOUNDARY" execute \
-  --snapshot .signum/snapshots/execute-attempt-01.json
+  --workspace-root "$PWD" \
+  --signum-dir "$ARTIFACT_ROOT" \
+  --contract "$CONTRACT_ENGINEER_PATH" \
+  --contract-full "$CONTRACT_PATH" \
+  --execution-context "$EXECUTION_CONTEXT_PATH" \
+  --snapshot "$SNAPSHOT_PATH"
 ```
 
 If boundary verifier exits non-zero, **STOP**. Do not proceed to Phase 3.
@@ -1541,6 +1829,11 @@ If boundary verifier exits non-zero, **STOP**. Do not proceed to Phase 3.
 Use the Bash tool to verify the execute → audit transition gate. This checks receipt integrity, contract hash chain, artifact hashes, and AC evidence completeness.
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_ENGINEER_PATH="${ARTIFACT_ROOT}contract-engineer.json"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+SNAPSHOT_PATH="${ARTIFACT_ROOT}snapshots/execute-attempt-01.json"
 _SIGNUM_TRANSITION=""
 for _d in \
   "${_REAL_HOME:=$HOME}/.claude/plugins/signum/platforms/claude-code" \
@@ -1555,7 +1848,11 @@ if [ -z "$_SIGNUM_TRANSITION" ]; then
   exit 1
 fi
 bash "$_SIGNUM_TRANSITION" execute audit \
-  --snapshot .signum/snapshots/execute-attempt-01.json
+  --workspace-root "$PWD" \
+  --signum-dir "$ARTIFACT_ROOT" \
+  --contract "$CONTRACT_ENGINEER_PATH" \
+  --contract-full "$CONTRACT_PATH" \
+  --snapshot "$SNAPSHOT_PATH"
 ```
 
 If transition verifier exits non-zero, **STOP**. Do not proceed to Phase 3.
@@ -1587,7 +1884,10 @@ Read the contract's `riskLevel` and apply the matching ceremony profile. Steps m
 Use the Bash tool to read the risk level and save it for conditional checks:
 
 ```bash
-RISK_LEVEL=$(jq -r '.riskLevel' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+RISK_LEVEL=$(jq -r '.riskLevel' "$CONTRACT_PATH")
 echo "RISK_LEVEL=$RISK_LEVEL"
 ```
 
@@ -1595,15 +1895,25 @@ Save `RISK_LEVEL` for use in all subsequent steps.
 
 ### Step 3.0.5: Repo-contract invariant check
 
-If `repo-contract.json` and `.signum/repo_contract_baseline.json` both exist, re-run invariants and detect regressions:
+If `repo-contract.json` and `repo_contract_baseline.json` under the canonical artifact root both exist, re-run invariants and detect regressions:
 
 ```bash
-if [ -f "repo-contract.json" ] && [ -f ".signum/repo_contract_baseline.json" ]; then
-  python3 -c "
-import json, subprocess
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REPO_CONTRACT_BASELINE_PATH="${ARTIFACT_ROOT}repo_contract_baseline.json"
+REPO_CONTRACT_VIOLATIONS_PATH="${ARTIFACT_ROOT}repo_contract_violations.json"
+
+if [ -f "repo-contract.json" ] && [ -f "$REPO_CONTRACT_BASELINE_PATH" ]; then
+  python3 - "$REPO_CONTRACT_BASELINE_PATH" "$REPO_CONTRACT_VIOLATIONS_PATH" <<'PY'
+import json
+import subprocess
+import sys
+
+baseline_path = sys.argv[1]
+violations_path = sys.argv[2]
 with open('repo-contract.json') as f:
     rc = json.load(f)
-with open('.signum/repo_contract_baseline.json') as f:
+with open(baseline_path) as f:
     baseline = json.load(f)
 regressions = []
 results = {}
@@ -1623,8 +1933,8 @@ for inv in rc.get('invariants', []):
         'regressed': regressed,
     }
     if regressed:
-        regressions.append(f'{iid} ({inv[\"severity\"]}): {inv[\"description\"]}')
-with open('.signum/repo_contract_violations.json', 'w') as f:
+        regressions.append(f'{iid} ({inv["severity"]}): {inv["description"]}')
+with open(violations_path, 'w') as f:
     json.dump({'invariants': results, 'regressions': regressions}, f, indent=2)
 if regressions:
     print('INVARIANT REGRESSIONS:')
@@ -1635,7 +1945,7 @@ else:
     total = len(results)
     passed = sum(1 for v in results.values() if v['passed'])
     print(f'Repo-contract: PASS ({passed}/{total} invariants holding)')
-"
+PY
 fi
 ```
 
@@ -1665,16 +1975,23 @@ if [ -z "$_SIGNUM_MECHANIC" ]; then
   echo "ERROR: mechanic-parser.sh not found in Signum plugin directories" >&2
   exit 1
 fi
-bash "$_SIGNUM_MECHANIC" .signum/baseline.json
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+BASELINE_PATH="${ARTIFACT_ROOT}baseline.json"
+bash "$_SIGNUM_MECHANIC" "$BASELINE_PATH"
 ```
 
 If any check has a NEW regression, continue to reviews — mechanic regression influences the final decision but does not block the audit.
 
 ### Step 3.1.3: Policy scanner (bash, zero LLM cost)
 
-Run the deterministic policy scanner on `.signum/combined.patch`. This step scans addition lines only for security, unsafe, and dependency patterns. Use the Bash tool:
+Run the deterministic policy scanner on `combined.patch` under the canonical artifact root. This step scans addition lines only for security, unsafe, and dependency patterns. Use the Bash tool:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+
 # Resolve policy-scanner.sh from known trusted Signum install roots only.
 # SIGNUM_PLUGIN_DIR env var is intentionally excluded to prevent environment
 # hijacking — only fixed install paths derived from $HOME are trusted.
@@ -1691,34 +2008,42 @@ if [ -z "$_SIGNUM_SCANNER" ]; then
   echo "ERROR: policy-scanner.sh not found in Signum plugin directories" >&2
   exit 1
 fi
-bash "$_SIGNUM_SCANNER" .signum/combined.patch
+bash "$_SIGNUM_SCANNER" "$COMBINED_PATCH_PATH"
 ```
 
-This writes `.signum/policy_scan.json` with fields: `scannedAt`, `patchFile`, `findings` (array), and `summaryCounts` ({critical, major, minor, total}).
+This writes `policy_scan.json` under the canonical artifact root with fields: `scannedAt`, `patchFile`, `findings` (array), and `summaryCounts` ({critical, major, minor, total}).
 
 Check for CRITICAL findings:
 
 ```bash
-POLICY_CRITICAL=$(jq -r '.summaryCounts.critical // 0' .signum/policy_scan.json)
-echo "Policy scan: critical=$POLICY_CRITICAL findings total=$(jq -r '.summaryCounts.total' .signum/policy_scan.json)"
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+POLICY_SCAN_PATH="${ARTIFACT_ROOT}policy_scan.json"
+POLICY_CRITICAL=$(jq -r '.summaryCounts.critical // 0' "$POLICY_SCAN_PATH")
+echo "Policy scan: critical=$POLICY_CRITICAL findings total=$(jq -r '.summaryCounts.total' "$POLICY_SCAN_PATH")"
 ```
 
 If `POLICY_CRITICAL` is greater than 0, the synthesizer will AUTO_BLOCK. Continue to reviews — the synthesizer reads `policy_scan.json` and applies the block rule deterministically.
 
 ### Step 3.1.5: Holdout validation
 
-**Skip if `RISK_LEVEL` is `low`.** Write an empty holdout report and proceed to Step 3.2.
+**Skip if `RISK_LEVEL` is `low`.** Write an empty holdout report under the canonical artifact root and proceed to Step 3.2.
 
 Otherwise, run holdout verification using the typed DSL runner. Supports both new format (`acceptanceCriteria` with `visibility: "holdout"`) and legacy `holdoutScenarios`:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+
 if [ "$RISK_LEVEL" = "low" ]; then
-  echo '{"total":0,"passed":0,"failed":0,"errors":0,"results":[]}' > .signum/holdout_report.json
+  echo '{"total":0,"passed":0,"failed":0,"errors":0,"results":[]}' > "$HOLDOUT_REPORT_PATH"
   echo "Holdout validation skipped (low risk)"
 else
 # Count holdouts: new format (visibility=holdout) + legacy (holdoutScenarios)
-HOLDOUT_ACS=$(jq '[.acceptanceCriteria[] | select(.visibility == "holdout")] | length' .signum/contract.json)
-LEGACY_HOLDOUTS=$(jq '.holdoutScenarios // [] | length' .signum/contract.json)
+HOLDOUT_ACS=$(jq '[.acceptanceCriteria[] | select(.visibility == "holdout")] | length' "$CONTRACT_PATH")
+LEGACY_HOLDOUTS=$(jq '.holdoutScenarios // [] | length' "$CONTRACT_PATH")
 TOTAL_HOLDOUTS=$((HOLDOUT_ACS + LEGACY_HOLDOUTS))
 
 if [ "$TOTAL_HOLDOUTS" -gt 0 ]; then
@@ -1727,11 +2052,11 @@ if [ "$TOTAL_HOLDOUTS" -gt 0 ]; then
 
   # New format: AC with visibility=holdout
   for i in $(seq 0 $((HOLDOUT_ACS - 1))); do
-    ID=$(jq -r "[.acceptanceCriteria[] | select(.visibility == \"holdout\")][$i].id" .signum/contract.json)
-    DESC=$(jq -r "[.acceptanceCriteria[] | select(.visibility == \"holdout\")][$i].description" .signum/contract.json)
+    ID=$(jq -r "[.acceptanceCriteria[] | select(.visibility == \"holdout\")][$i].id" "$CONTRACT_PATH")
+    DESC=$(jq -r "[.acceptanceCriteria[] | select(.visibility == \"holdout\")][$i].description" "$CONTRACT_PATH")
 
     VERIFY_FILE=$(mktemp)
-    jq "[.acceptanceCriteria[] | select(.visibility == \"holdout\")][$i].verify" .signum/contract.json > "$VERIFY_FILE"
+    jq "[.acceptanceCriteria[] | select(.visibility == \"holdout\")][$i].verify" "$CONTRACT_PATH" > "$VERIFY_FILE"
 
     if ! bash lib/dsl-runner.sh validate "$VERIFY_FILE" > /dev/null 2>&1; then
       ERRORS=$((ERRORS + 1))
@@ -1757,12 +2082,12 @@ if [ "$TOTAL_HOLDOUTS" -gt 0 ]; then
 
   # Legacy format: holdoutScenarios (backward compat)
   for i in $(seq 0 $((LEGACY_HOLDOUTS - 1))); do
-    ID=$(jq -r ".holdoutScenarios[$i].id // \"HO$((i+1))\"" .signum/contract.json)
-    DESC=$(jq -r ".holdoutScenarios[$i].description" .signum/contract.json)
-    HAS_STEPS=$(jq ".holdoutScenarios[$i].verify | has(\"steps\")" .signum/contract.json)
+    ID=$(jq -r ".holdoutScenarios[$i].id // \"HO$((i+1))\"" "$CONTRACT_PATH")
+    DESC=$(jq -r ".holdoutScenarios[$i].description" "$CONTRACT_PATH")
+    HAS_STEPS=$(jq ".holdoutScenarios[$i].verify | has(\"steps\")" "$CONTRACT_PATH")
     if [ "$HAS_STEPS" = "true" ]; then
       VERIFY_FILE=$(mktemp)
-      jq ".holdoutScenarios[$i].verify" .signum/contract.json > "$VERIFY_FILE"
+      jq ".holdoutScenarios[$i].verify" "$CONTRACT_PATH" > "$VERIFY_FILE"
       if bash lib/dsl-runner.sh validate "$VERIFY_FILE" > /dev/null 2>&1; then
         REPORT=$(bash lib/dsl-runner.sh run "$VERIFY_FILE" 2>&1) || true
         STATUS=$(echo "$REPORT" | jq -r '.status // "ERROR"')
@@ -1782,10 +2107,10 @@ if [ "$TOTAL_HOLDOUTS" -gt 0 ]; then
 
   echo "$RESULTS" | jq --argjson pass "$PASS" --argjson fail "$FAIL" --argjson err "$ERRORS" \
     '{total: ($pass + $fail + $err), passed: $pass, failed: $fail, errors: $err, results: .}' \
-    > .signum/holdout_report.json
+    > "$HOLDOUT_REPORT_PATH"
   echo "Holdout: $PASS passed, $FAIL failed, $ERRORS errors"
 else
-  echo '{"total":0,"passed":0,"failed":0,"errors":0,"results":[]}' > .signum/holdout_report.json
+  echo '{"total":0,"passed":0,"failed":0,"errors":0,"results":[]}' > "$HOLDOUT_REPORT_PATH"
   echo "No holdout scenarios"
 fi
 fi
@@ -1795,15 +2120,22 @@ If any holdout fails, continue to reviews but synthesizer treats it as regressio
 
 ### Step 3.2.0: Gather review context
 
-Run a single Bash block to build `.signum/review_context.json`. This file provides git history for changed files and issue references extracted from commit messages — used later to enrich the Claude reviewer prompt.
+Run a single Bash block to build `review_context.json` under the canonical artifact root. This file provides git history for changed files and issue references extracted from commit messages and is used later to enrich the Claude reviewer prompt.
 
 ```bash
-python3 - << 'PYEOF'
-import json, os, subprocess, re
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+REVIEW_CONTEXT_PATH="${ARTIFACT_ROOT}review_context.json"
+
+python3 - "$PATCH_PATH" "$REVIEW_CONTEXT_PATH" << 'PYEOF'
+import json, os, re, subprocess, sys
+
+patch_path = sys.argv[1]
+review_context_path = sys.argv[2]
 
 # --- git_history: one entry per file changed in combined.patch ---
 git_history = []
-patch_path = '.signum/combined.patch'
 if os.path.exists(patch_path):
     with open(patch_path) as f:
         patch = f.read()
@@ -1879,7 +2211,7 @@ result = {
     'issue_refs': issue_refs,
     'project_intent': project_intent,
 }
-with open('.signum/review_context.json', 'w') as f:
+with open(review_context_path, 'w') as f:
     json.dump(result, f, indent=2)
 print(f"review_context.json written: {len(git_history)} file(s), {len(issue_refs)} issue ref(s), intent={'yes' if project_intent else 'null'}")
 PYEOF
@@ -1891,37 +2223,51 @@ If the patch does not exist or contains no file paths, `git_history` and `issue_
 
 **If `RISK_LEVEL` is `low`:** skip this step entirely (no external prompts needed). Set `CODEX_AVAILABLE=false` and `GEMINI_AVAILABLE=false`, then proceed directly to Step 3.2.5 (Claude-only).
 
-Otherwise, in a single Bash block, check both codex and gemini availability, build both prompts (security-focused for codex, performance-focused for gemini), and save as `.signum/review_prompt_codex.txt` and `.signum/review_prompt_gemini.txt`:
+Otherwise, in a single Bash block, check both codex and gemini availability, build both prompts (security-focused for codex, performance-focused for gemini), and save them under the canonical artifact root as `review_prompt_codex.txt` and `review_prompt_gemini.txt`:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+DELTA_PATCH_PATH="${ARTIFACT_ROOT}iteration_delta.patch"
+REVIEW_PROMPT_CODEX_PATH="${ARTIFACT_ROOT}review_prompt_codex.txt"
+REVIEW_PROMPT_GEMINI_PATH="${ARTIFACT_ROOT}review_prompt_gemini.txt"
+
 which codex > /dev/null 2>&1 && CODEX_AVAILABLE=true || CODEX_AVAILABLE=false
 which gemini > /dev/null 2>&1 && GEMINI_AVAILABLE=true || GEMINI_AVAILABLE=false
 
 if [ "$CODEX_AVAILABLE" = "true" ]; then
-  python3 -c "
-import json, sys, os
-goal = json.load(open('.signum/contract.json'))['goal']
-diff = open('.signum/combined.patch').read()
-delta_path = '.signum/iteration_delta.patch'
+  python3 - "$CONTRACT_PATH" "$PATCH_PATH" "$DELTA_PATCH_PATH" "lib/prompts/review-template-security.md" <<'PY' > "$REVIEW_PROMPT_CODEX_PATH"
+import json
+import os
+import sys
+
+contract_path, patch_path, delta_path, template_path = sys.argv[1:]
+goal = json.load(open(contract_path))['goal']
+diff = open(patch_path).read()
 delta = open(delta_path).read() if os.path.exists(delta_path) else ''
-tmpl = open('lib/prompts/review-template-security.md').read()
+tmpl = open(template_path).read()
 print(tmpl.replace('{goal}', goal).replace('{diff}', diff).replace('{iteration_delta}', delta))
-" > .signum/review_prompt_codex.txt
+PY
   echo "codex: AVAILABLE, prompt written"
 else
   echo "codex: UNAVAILABLE"
 fi
 
 if [ "$GEMINI_AVAILABLE" = "true" ]; then
-  python3 -c "
-import json, sys, os
-goal = json.load(open('.signum/contract.json'))['goal']
-diff = open('.signum/combined.patch').read()
-delta_path = '.signum/iteration_delta.patch'
+  python3 - "$CONTRACT_PATH" "$PATCH_PATH" "$DELTA_PATCH_PATH" "lib/prompts/review-template-performance.md" <<'PY' > "$REVIEW_PROMPT_GEMINI_PATH"
+import json
+import os
+import sys
+
+contract_path, patch_path, delta_path, template_path = sys.argv[1:]
+goal = json.load(open(contract_path))['goal']
+diff = open(patch_path).read()
 delta = open(delta_path).read() if os.path.exists(delta_path) else ''
-tmpl = open('lib/prompts/review-template-performance.md').read()
+tmpl = open(template_path).read()
 print(tmpl.replace('{goal}', goal).replace('{diff}', diff).replace('{iteration_delta}', delta))
-" > .signum/review_prompt_gemini.txt
+PY
   echo "gemini: AVAILABLE, prompt written"
 else
   echo "gemini: UNAVAILABLE"
@@ -1942,33 +2288,42 @@ For medium/high risk, launch the reviewer-claude Agent with `run_in_background: 
 
 **Claude (Agent tool, `run_in_background: true`):**
 
-Before launching the Claude reviewer Agent, read `.signum/review_context.json` and serialize it to a string. Then construct the agent prompt as follows (inject the review_context JSON content inline, not as a file path):
+Before launching the Claude reviewer Agent, read `review_context.json` under the canonical artifact root and serialize it to a string. Then construct the agent prompt as follows (inject the review_context JSON content inline, not as a file path):
 
 ```
-Read .signum/contract.json, .signum/combined.patch, and .signum/mechanic_report.json.
-Also read .signum/iteration_delta.patch if it exists.
+The canonical artifact root for this review is `.signum/contracts/<activeContractId>/`.
+Read `contract.json`, `combined.patch`, and `mechanic_report.json` from that canonical artifact root.
+Also read `iteration_delta.patch` from that same root if it exists.
 The review_context for this review is: <REVIEW_CONTEXT_JSON>
-Follow lib/prompts/review-template.md and write your review to .signum/reviews/claude.json.
+Follow lib/prompts/review-template.md and write your review to `reviews/claude.json` under that same canonical artifact root.
 Use the review_context above to fill in the {review_context} placeholder in the template.
 Write ONLY the JSON object, no markers, no markdown.
 ```
 
-Replace `<REVIEW_CONTEXT_JSON>` with the full JSON content of `.signum/review_context.json` read in the previous step.
+Replace `<REVIEW_CONTEXT_JSON>` with the full JSON content of `review_context.json` from the canonical artifact root read in the previous step.
 
 **Codex (Bash tool, `run_in_background: true`, only if CODEX_AVAILABLE):**
 
 ```bash
-PROMPT=$(cat .signum/review_prompt_codex.txt)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+REVIEW_PROMPT_CODEX_PATH="${ARTIFACT_ROOT}review_prompt_codex.txt"
+CODEX_STDOUT_PATH="${REVIEWS_DIR}/codex_stdout.txt"
+CODEX_EXIT_PATH="${REVIEWS_DIR}/codex_exit_code.txt"
+CODEX_RAW_PATH="${REVIEWS_DIR}/codex_raw.txt"
+PROMPT=$(cat "$REVIEW_PROMPT_CODEX_PATH")
 OUT=$(mktemp)
 CODEX_MODEL_FLAG=""
 [ -n "$SIGNUM_CODEX_MODEL" ] && CODEX_MODEL_FLAG="--model $SIGNUM_CODEX_MODEL"
 CODEX_PROFILE_FLAG=""
 [ -n "$SIGNUM_CODEX_PROFILE" ] && CODEX_PROFILE_FLAG="-p $SIGNUM_CODEX_PROFILE"
+mkdir -p "$REVIEWS_DIR"
 codex exec --ephemeral -C "$PWD" $CODEX_PROFILE_FLAG $CODEX_MODEL_FLAG --output-last-message "$OUT" "$PROMPT" \
-  > .signum/reviews/codex_stdout.txt 2>&1
-echo $? > .signum/reviews/codex_exit_code.txt
-cp "$OUT" .signum/reviews/codex_raw.txt 2>/dev/null || \
-  cp .signum/reviews/codex_stdout.txt .signum/reviews/codex_raw.txt
+  > "$CODEX_STDOUT_PATH" 2>&1
+echo $? > "$CODEX_EXIT_PATH"
+cp "$OUT" "$CODEX_RAW_PATH" 2>/dev/null || \
+  cp "$CODEX_STDOUT_PATH" "$CODEX_RAW_PATH"
 rm -f "$OUT"
 echo "CODEX_DONE"
 ```
@@ -1976,11 +2331,18 @@ echo "CODEX_DONE"
 **Gemini (Bash tool, `run_in_background: true`, only if GEMINI_AVAILABLE):**
 
 ```bash
-PROMPT=$(cat .signum/review_prompt_gemini.txt)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+REVIEW_PROMPT_GEMINI_PATH="${ARTIFACT_ROOT}review_prompt_gemini.txt"
+GEMINI_RAW_PATH="${REVIEWS_DIR}/gemini_raw.txt"
+GEMINI_EXIT_PATH="${REVIEWS_DIR}/gemini_exit_code.txt"
+PROMPT=$(cat "$REVIEW_PROMPT_GEMINI_PATH")
 GEMINI_MODEL_FLAG=""
 [ -n "$SIGNUM_GEMINI_MODEL" ] && GEMINI_MODEL_FLAG="--model $SIGNUM_GEMINI_MODEL"
-gemini $GEMINI_MODEL_FLAG -p "$PROMPT" > .signum/reviews/gemini_raw.txt 2>&1
-echo $? > .signum/reviews/gemini_exit_code.txt
+mkdir -p "$REVIEWS_DIR"
+gemini $GEMINI_MODEL_FLAG -p "$PROMPT" > "$GEMINI_RAW_PATH" 2>&1
+echo $? > "$GEMINI_EXIT_PATH"
 echo "GEMINI_DONE"
 ```
 
@@ -1993,7 +2355,11 @@ Use the TaskOutput tool with `block: true` to wait for CLAUDE_TASK_ID. Then use 
 After all complete (or if they were never launched), verify the claude output:
 
 ```bash
-test -f .signum/reviews/claude.json && jq -e '.verdict' .signum/reviews/claude.json > /dev/null \
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+CLAUDE_REVIEW_PATH="${REVIEWS_DIR}/claude.json"
+test -f "$CLAUDE_REVIEW_PATH" && jq -e '.verdict' "$CLAUDE_REVIEW_PATH" > /dev/null \
   && echo "claude review OK" || echo "WARNING: claude.json missing or invalid"
 ```
 
@@ -2001,44 +2367,52 @@ test -f .signum/reviews/claude.json && jq -e '.verdict' .signum/reviews/claude.j
 
 After collection, parse codex output and parse gemini output.
 
-If CODEX_AVAILABLE: check exit code first, then attempt 3-level parsing of `.signum/reviews/codex_raw.txt`:
+If CODEX_AVAILABLE: check exit code first, then attempt 3-level parsing of `reviews/codex_raw.txt` under the canonical artifact root:
 
 ```bash
-CODEX_EXIT=$(cat .signum/reviews/codex_exit_code.txt 2>/dev/null || echo "1")
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+CODEX_EXIT_PATH="${REVIEWS_DIR}/codex_exit_code.txt"
+CODEX_STDOUT_PATH="${REVIEWS_DIR}/codex_stdout.txt"
+CODEX_RAW_PATH="${REVIEWS_DIR}/codex_raw.txt"
+CODEX_JSON_PATH="${REVIEWS_DIR}/codex.json"
+CODEX_EXTRACTED_PATH="${ARTIFACT_ROOT}codex_extracted.json"
+CODEX_EXIT=$(cat "$CODEX_EXIT_PATH" 2>/dev/null || echo "1")
 if [ "$CODEX_EXIT" != "0" ]; then
   # Crash → UNAVAILABLE (not CONDITIONAL)
-  RAW=$(head -c 2000 .signum/reviews/codex_stdout.txt 2>/dev/null)
+  RAW=$(head -c 2000 "$CODEX_STDOUT_PATH" 2>/dev/null)
   jq -n --arg raw "$RAW" --arg code "$CODEX_EXIT" \
     '{"verdict":"UNAVAILABLE","findings":[],"summary":("Codex invocation failed (exit " + $code + ")"),"available":false,"raw":$raw}' \
-    > .signum/reviews/codex.json
+    > "$CODEX_JSON_PATH"
   echo "codex: invocation failed (exit $CODEX_EXIT), marked UNAVAILABLE"
 
 # Level 1: valid JSON directly
-elif jq -e '.verdict' .signum/reviews/codex_raw.txt > /dev/null 2>&1; then
-  cp .signum/reviews/codex_raw.txt .signum/reviews/codex.json
+elif jq -e '.verdict' "$CODEX_RAW_PATH" > /dev/null 2>&1; then
+  cp "$CODEX_RAW_PATH" "$CODEX_JSON_PATH"
   echo "codex: parsed as direct JSON"
 
 # Level 2: extract between markers
-elif grep -q '###SIGNUM_REVIEW_START###' .signum/reviews/codex_raw.txt; then
-  sed -n '/###SIGNUM_REVIEW_START###/,/###SIGNUM_REVIEW_END###/p' .signum/reviews/codex_raw.txt \
-    | grep -v '###SIGNUM_REVIEW' > .signum/codex_extracted.json
-  if jq -e '.verdict' .signum/codex_extracted.json > /dev/null 2>&1; then
-    cp .signum/codex_extracted.json .signum/reviews/codex.json
+elif grep -q '###SIGNUM_REVIEW_START###' "$CODEX_RAW_PATH"; then
+  sed -n '/###SIGNUM_REVIEW_START###/,/###SIGNUM_REVIEW_END###/p' "$CODEX_RAW_PATH" \
+    | grep -v '###SIGNUM_REVIEW' > "$CODEX_EXTRACTED_PATH"
+  if jq -e '.verdict' "$CODEX_EXTRACTED_PATH" > /dev/null 2>&1; then
+    cp "$CODEX_EXTRACTED_PATH" "$CODEX_JSON_PATH"
     echo "codex: parsed via markers"
   else
-    RAW=$(cat .signum/reviews/codex_raw.txt | head -c 2000)
+    RAW=$(head -c 2000 "$CODEX_RAW_PATH")
     jq -n --arg raw "$RAW" \
       '{"verdict":"CONDITIONAL","findings":[],"summary":"Could not parse codex output","parseOk":false,"raw":$raw}' \
-      > .signum/reviews/codex.json
+      > "$CODEX_JSON_PATH"
     echo "codex: marker extraction failed, saved raw"
   fi
 
 # Level 3: save raw, mark unparseable
 else
-  RAW=$(cat .signum/reviews/codex_raw.txt | head -c 2000)
+  RAW=$(head -c 2000 "$CODEX_RAW_PATH")
   jq -n --arg raw "$RAW" \
     '{"verdict":"CONDITIONAL","findings":[],"summary":"Could not parse codex output","parseOk":false,"raw":$raw}' \
-    > .signum/reviews/codex.json
+    > "$CODEX_JSON_PATH"
   echo "codex: no markers found, saved raw"
 fi
 ```
@@ -2046,55 +2420,67 @@ fi
 If CODEX_UNAVAILABLE:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+CODEX_JSON_PATH="${REVIEWS_DIR}/codex.json"
 echo '{"verdict":"UNAVAILABLE","findings":[],"summary":"Codex CLI not installed","available":false}' \
-  > .signum/reviews/codex.json
+  > "$CODEX_JSON_PATH"
 ```
 
 Parse gemini output:
 
-If GEMINI_AVAILABLE: check exit code first, then attempt 3-level parsing of `.signum/reviews/gemini_raw.txt`:
+If GEMINI_AVAILABLE: check exit code first, then attempt 3-level parsing of `reviews/gemini_raw.txt` under the canonical artifact root:
 
 ```bash
-GEMINI_EXIT=$(cat .signum/reviews/gemini_exit_code.txt 2>/dev/null || echo "1")
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+GEMINI_EXIT_PATH="${REVIEWS_DIR}/gemini_exit_code.txt"
+GEMINI_RAW_PATH="${REVIEWS_DIR}/gemini_raw.txt"
+GEMINI_JSON_PATH="${REVIEWS_DIR}/gemini.json"
+GEMINI_STRIPPED_PATH="${ARTIFACT_ROOT}gemini_stripped.txt"
+GEMINI_EXTRACTED_PATH="${ARTIFACT_ROOT}gemini_extracted.json"
+GEMINI_EXIT=$(cat "$GEMINI_EXIT_PATH" 2>/dev/null || echo "1")
 if [ "$GEMINI_EXIT" != "0" ]; then
   # Crash → UNAVAILABLE (not CONDITIONAL)
-  RAW=$(head -c 2000 .signum/reviews/gemini_raw.txt 2>/dev/null)
+  RAW=$(head -c 2000 "$GEMINI_RAW_PATH" 2>/dev/null)
   jq -n --arg raw "$RAW" --arg code "$GEMINI_EXIT" \
     '{"verdict":"UNAVAILABLE","findings":[],"summary":("Gemini invocation failed (exit " + $code + ")"),"available":false,"raw":$raw}' \
-    > .signum/reviews/gemini.json
+    > "$GEMINI_JSON_PATH"
   echo "gemini: invocation failed (exit $GEMINI_EXIT), marked UNAVAILABLE"
 
 # Level 0.5: strip markdown code fences (```json ... ```) if present
-elif sed -n '1{/^```/d}; ${/^```/d}; p' .signum/reviews/gemini_raw.txt | sed 's/^```json$//' | sed 's/^```$//' > .signum/reviews/gemini_stripped.txt \
-  && jq -e '.verdict' .signum/reviews/gemini_stripped.txt > /dev/null 2>&1; then
-  cp .signum/reviews/gemini_stripped.txt .signum/reviews/gemini.json
-  rm -f .signum/reviews/gemini_stripped.txt
+elif sed -n '1{/^```/d}; ${/^```/d}; p' "$GEMINI_RAW_PATH" | sed 's/^```json$//' | sed 's/^```$//' > "$GEMINI_STRIPPED_PATH" \
+  && jq -e '.verdict' "$GEMINI_STRIPPED_PATH" > /dev/null 2>&1; then
+  cp "$GEMINI_STRIPPED_PATH" "$GEMINI_JSON_PATH"
+  rm -f "$GEMINI_STRIPPED_PATH"
   echo "gemini: parsed after stripping markdown fences"
 
 # Level 1: valid JSON directly
-elif jq -e '.verdict' .signum/reviews/gemini_raw.txt > /dev/null 2>&1; then
-  cp .signum/reviews/gemini_raw.txt .signum/reviews/gemini.json
+elif jq -e '.verdict' "$GEMINI_RAW_PATH" > /dev/null 2>&1; then
+  cp "$GEMINI_RAW_PATH" "$GEMINI_JSON_PATH"
   echo "gemini: parsed as direct JSON"
 
-elif grep -q '###SIGNUM_REVIEW_START###' .signum/reviews/gemini_raw.txt; then
-  sed -n '/###SIGNUM_REVIEW_START###/,/###SIGNUM_REVIEW_END###/p' .signum/reviews/gemini_raw.txt \
-    | grep -v '###SIGNUM_REVIEW' > .signum/gemini_extracted.json
-  if jq -e '.verdict' .signum/gemini_extracted.json > /dev/null 2>&1; then
-    cp .signum/gemini_extracted.json .signum/reviews/gemini.json
+elif grep -q '###SIGNUM_REVIEW_START###' "$GEMINI_RAW_PATH"; then
+  sed -n '/###SIGNUM_REVIEW_START###/,/###SIGNUM_REVIEW_END###/p' "$GEMINI_RAW_PATH" \
+    | grep -v '###SIGNUM_REVIEW' > "$GEMINI_EXTRACTED_PATH"
+  if jq -e '.verdict' "$GEMINI_EXTRACTED_PATH" > /dev/null 2>&1; then
+    cp "$GEMINI_EXTRACTED_PATH" "$GEMINI_JSON_PATH"
     echo "gemini: parsed via markers"
   else
-    RAW=$(cat .signum/reviews/gemini_raw.txt | head -c 2000)
+    RAW=$(head -c 2000 "$GEMINI_RAW_PATH")
     jq -n --arg raw "$RAW" \
       '{"verdict":"CONDITIONAL","findings":[],"summary":"Could not parse gemini output","parseOk":false,"raw":$raw}' \
-      > .signum/reviews/gemini.json
+      > "$GEMINI_JSON_PATH"
     echo "gemini: marker extraction failed, saved raw"
   fi
 
 else
-  RAW=$(cat .signum/reviews/gemini_raw.txt | head -c 2000)
+  RAW=$(head -c 2000 "$GEMINI_RAW_PATH")
   jq -n --arg raw "$RAW" \
     '{"verdict":"CONDITIONAL","findings":[],"summary":"Could not parse gemini output","parseOk":false,"raw":$raw}' \
-    > .signum/reviews/gemini.json
+    > "$GEMINI_JSON_PATH"
   echo "gemini: no markers found, saved raw"
 fi
 ```
@@ -2102,8 +2488,12 @@ fi
 If GEMINI_UNAVAILABLE:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+GEMINI_JSON_PATH="${REVIEWS_DIR}/gemini.json"
 echo '{"verdict":"UNAVAILABLE","findings":[],"summary":"Gemini CLI not installed","available":false}' \
-  > .signum/reviews/gemini.json
+  > "$GEMINI_JSON_PATH"
 ```
 
 ### Step 3.5: Synthesizer (agent)
@@ -2111,17 +2501,18 @@ echo '{"verdict":"UNAVAILABLE","findings":[],"summary":"Gemini CLI not installed
 Use the Agent tool to launch the "synthesizer" agent with this prompt:
 
 ```
-Read .signum/mechanic_report.json, .signum/reviews/claude.json,
-.signum/reviews/codex.json, .signum/reviews/gemini.json,
-.signum/holdout_report.json, and .signum/execute_log.json.
-Apply deterministic synthesis rules, compute confidence scores,
-and write .signum/audit_summary.json.
+The canonical artifact root for this synthesis is `.signum/contracts/<activeContractId>/`.
+Read `mechanic_report.json`, `reviews/claude.json`, `reviews/codex.json`, `reviews/gemini.json`, `holdout_report.json`, and `execute_log.json` from that canonical artifact root.
+Apply deterministic synthesis rules, compute confidence scores, and write `audit_summary.json` to that same canonical artifact root.
 ```
 
 After it finishes, read and display the audit summary:
 
 ```bash
-test -f .signum/audit_summary.json || { echo "ERROR: audit_summary.json not found"; exit 1; }
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+test -f "$AUDIT_SUMMARY_PATH" || { echo "ERROR: audit_summary.json not found"; exit 1; }
 
 jq -r '"=== AUDIT SUMMARY ===",
        "Mechanic: " + (.mechanic // "unknown"),
@@ -2134,8 +2525,7 @@ jq -r '"=== AUDIT SUMMARY ===",
        "Consensus: " + .consensus,
        "Confidence: " + ((.confidence.overall // 0) | tostring) + "%",
        "DECISION: " + .decision,
-       "Reasoning: " + .reasoning' \
-  .signum/audit_summary.json
+       "Reasoning: " + .reasoning'   "$AUDIT_SUMMARY_PATH"
 ```
 
 ### Step 3.6: Iterative AUDIT Loop
@@ -2156,17 +2546,22 @@ echo "Iterative AUDIT config: max_iterations=$MAX_ITERATIONS"
 Check the audit summary decision and findings:
 
 ```bash
-AUDIT_DECISION=$(jq -r '.decision' .signum/audit_summary.json)
-HAS_MAJOR=$(jq '[.reviews[].findings[]? | select(.severity == "MAJOR" or .severity == "CRITICAL")] | length' .signum/audit_summary.json)
-HAS_REGRESSIONS=$(jq -r '.mechanic' .signum/audit_summary.json | grep -q "regression" && echo "true" || echo "false")
-HOLDOUT_FAILURES=$(jq -r '.holdout.failed // 0' .signum/audit_summary.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+AUDIT_DECISION=$(jq -r '.decision' "$AUDIT_SUMMARY_PATH")
+HAS_MAJOR=$(jq '[.reviews[].findings[]? | select(.severity == "MAJOR" or .severity == "CRITICAL")] | length' "$AUDIT_SUMMARY_PATH")
+HAS_REGRESSIONS=$(jq -r '.mechanic' "$AUDIT_SUMMARY_PATH" | grep -q "regression" && echo "true" || echo "false")
+HOLDOUT_FAILURES=$(jq -r '.holdout.failed // 0' "$AUDIT_SUMMARY_PATH")
 
 # Compute iteration score from audit_summary findings (synthesizer emits the score field in iterative mode)
-_CRITICALS=$(jq '[.reviews[].findings[]? | select(.severity == "CRITICAL")] | length' .signum/audit_summary.json)
-_MAJORS=$(jq '[.reviews[].findings[]? | select(.severity == "MAJOR")] | length' .signum/audit_summary.json)
-_MINORS=$(jq '[.reviews[].findings[]? | select(.severity == "MINOR")] | length' .signum/audit_summary.json)
-_MECH_REGRESSIONS=$(jq 'if .hasRegressions then 1 else 0 end' .signum/mechanic_report.json)
-_HOLDOUT_FAILURES=$(jq '.failed // 0' .signum/holdout_report.json 2>/dev/null || echo 0)
+_CRITICALS=$(jq '[.reviews[].findings[]? | select(.severity == "CRITICAL")] | length' "$AUDIT_SUMMARY_PATH")
+_MAJORS=$(jq '[.reviews[].findings[]? | select(.severity == "MAJOR")] | length' "$AUDIT_SUMMARY_PATH")
+_MINORS=$(jq '[.reviews[].findings[]? | select(.severity == "MINOR")] | length' "$AUDIT_SUMMARY_PATH")
+_MECH_REGRESSIONS=$(jq 'if .hasRegressions then 1 else 0 end' "$MECHANIC_REPORT_PATH")
+_HOLDOUT_FAILURES=$(jq '.failed // 0' "$HOLDOUT_REPORT_PATH" 2>/dev/null || echo 0)
 ITERATION_SCORE=$(( -(_CRITICALS * 1000) - (_MECH_REGRESSIONS * 500) - (_HOLDOUT_FAILURES * 200) - (_MAJORS * 50) - (_MINORS * 1) ))
 
 echo "Pass 1: decision=$AUDIT_DECISION major_findings=$HAS_MAJOR regressions=$HAS_REGRESSIONS holdout_failures=$HOLDOUT_FAILURES score=$ITERATION_SCORE"
@@ -2179,30 +2574,39 @@ Otherwise, enter the iterative repair loop:
 #### Step 3.6.1: Initialize iteration tracking
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+PASS1_DIR="${ARTIFACT_ROOT}iterations/01"
+PASS1_REVIEWS_DIR="${PASS1_DIR}/reviews"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+AUDIT_ITERATION_LOG_PATH="${ARTIFACT_ROOT}audit_iteration_log.json"
+
 # Store pass 1 artifacts
-mkdir -p .signum/iterations/01/reviews
-cp .signum/combined.patch .signum/iterations/01/
-cp .signum/mechanic_report.json .signum/iterations/01/
-cp .signum/holdout_report.json .signum/iterations/01/ 2>/dev/null || true
-cp .signum/execute_log.json .signum/iterations/01/ 2>/dev/null || true
-cp .signum/reviews/*.json .signum/iterations/01/reviews/ 2>/dev/null || true
-cp .signum/audit_summary.json .signum/iterations/01/
+mkdir -p "$PASS1_REVIEWS_DIR"
+cp "$COMBINED_PATCH_PATH" "$PASS1_DIR/"
+cp "$MECHANIC_REPORT_PATH" "$PASS1_DIR/"
+cp "$HOLDOUT_REPORT_PATH" "$PASS1_DIR/" 2>/dev/null || true
+cp "$EXECUTE_LOG_PATH" "$PASS1_DIR/" 2>/dev/null || true
+cp "$REVIEWS_DIR/"*.json "$PASS1_REVIEWS_DIR/" 2>/dev/null || true
+cp "$AUDIT_SUMMARY_PATH" "$PASS1_DIR/"
 
 # Initialize iteration log
 BEST_SCORE=$ITERATION_SCORE
 BEST_ITERATION=1
-PASS1_FINDINGS=$(jq '[.reviews[].findings[]? | {fingerprint: .fingerprint, severity: .severity, category: .category, file: .file, line: .line}] | unique_by(.fingerprint // (.file + ":" + (.line | tostring) + ":" + .category))' .signum/audit_summary.json)
+PASS1_FINDINGS=$(jq '[.reviews[].findings[]? | {fingerprint: .fingerprint, severity: .severity, category: .category, file: .file, line: .line}] | unique_by(.fingerprint // (.file + ":" + (.line | tostring) + ":" + .category))' "$AUDIT_SUMMARY_PATH")
 PASS1_FINDINGS_COUNT=$(jq '{
   critical: [.reviews[].findings[]? | select(.severity == "CRITICAL")] | length,
   major: [.reviews[].findings[]? | select(.severity == "MAJOR")] | length,
   minor: [.reviews[].findings[]? | select(.severity == "MINOR")] | length
-}' .signum/audit_summary.json)
-MECH_REG=$(jq -r '.hasRegressions' .signum/mechanic_report.json 2>/dev/null || echo "false")
-HOLDOUT_FAIL=$(jq '.failed // 0' .signum/holdout_report.json 2>/dev/null || echo 0)
-jq -n --argjson score "$ITERATION_SCORE" --argjson findings "$PASS1_FINDINGS" --argjson findingsCount "$PASS1_FINDINGS_COUNT" \
-  --arg mechReg "$MECH_REG" --argjson holdoutFail "$HOLDOUT_FAIL" \
-  '[{"pass": 1, "score": $score, "decision": "'"$AUDIT_DECISION"'", "findingsCount": $findingsCount, "canonicalFindings": $findings, "mechanicRegressions": ($mechReg == "true"), "holdoutFailures": $holdoutFail}]' \
-  > .signum/audit_iteration_log.json
+}' "$AUDIT_SUMMARY_PATH")
+MECH_REG=$(jq -r '.hasRegressions' "$MECHANIC_REPORT_PATH" 2>/dev/null || echo "false")
+HOLDOUT_FAIL=$(jq '.failed // 0' "$HOLDOUT_REPORT_PATH" 2>/dev/null || echo 0)
+jq -n --argjson score "$ITERATION_SCORE" --argjson findings "$PASS1_FINDINGS" --argjson findingsCount "$PASS1_FINDINGS_COUNT"   --arg mechReg "$MECH_REG" --argjson holdoutFail "$HOLDOUT_FAIL"   '[{"pass": 1, "score": $score, "decision": "'"$AUDIT_DECISION"'", "findingsCount": $findingsCount, "canonicalFindings": $findings, "mechanicRegressions": ($mechReg == "true"), "holdoutFailures": $holdoutFail}]'   > "$AUDIT_ITERATION_LOG_PATH"
 
 echo "Iteration 1 stored. Best score: $BEST_SCORE"
 ```
@@ -2233,32 +2637,42 @@ fi
 SKIP_ITERATION=false
 if [ "$ITERATION_SCORE" -lt "$BEST_SCORE" ] && [ "$CURRENT_ITERATION" -gt 1 ]; then
   echo "Current score ($ITERATION_SCORE) worse than best ($BEST_SCORE at iteration $BEST_ITERATION). Rolling back."
+  source lib/contract-dir.sh 2>/dev/null || true
+  ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+  REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+  EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+  COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+  ITERATION_DELTA_PATH="${ARTIFACT_ROOT}iteration_delta.patch"
+  MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+  HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+  EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+  AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
   # Rollback: revert files from current patch (if exists) or best iteration's stored patch
-  BASE=$(jq -r '.base_commit' .signum/execution_context.json)
-  ROLLBACK_PATCH=".signum/combined.patch"
-  [ ! -f "$ROLLBACK_PATCH" ] && ROLLBACK_PATCH=".signum/iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch"
+  BASE=$(jq -r '.base_commit' "$EXECUTION_CONTEXT_PATH")
+  ROLLBACK_PATCH="$COMBINED_PATCH_PATH"
+  [ ! -f "$ROLLBACK_PATCH" ] && ROLLBACK_PATCH="${ARTIFACT_ROOT}iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch"
   PATCH_FILES=$(grep '^diff --git' "$ROLLBACK_PATCH" 2>/dev/null | sed 's|^diff --git a/||; s| b/.*||' | sort -u)
   for f in $PATCH_FILES; do
     git checkout "$BASE" -- "$f" 2>/dev/null || rm -f "$f" 2>/dev/null || true
   done
-  if git apply .signum/iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch; then
-    # Sync .signum/ working copies from best iteration
-    BEST_DIR=".signum/iterations/$(printf '%02d' $BEST_ITERATION)"
-    cp "${BEST_DIR}/combined.patch" .signum/ 2>/dev/null || true
-    cp "${BEST_DIR}/iteration_delta.patch" .signum/ 2>/dev/null || rm -f .signum/iteration_delta.patch
-    cp "${BEST_DIR}/mechanic_report.json" .signum/ 2>/dev/null || true
-    cp "${BEST_DIR}/holdout_report.json" .signum/ 2>/dev/null || true
-    cp "${BEST_DIR}/execute_log.json" .signum/ 2>/dev/null || true
-    rm -f .signum/reviews/*.json
-    cp "${BEST_DIR}/reviews/"*.json .signum/reviews/ 2>/dev/null || true
-    cp "${BEST_DIR}/audit_summary.json" .signum/ 2>/dev/null || true
+  if git apply "${ARTIFACT_ROOT}iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch"; then
+    # Sync canonical working copies from best iteration
+    BEST_DIR="${ARTIFACT_ROOT}iterations/$(printf '%02d' $BEST_ITERATION)"
+    cp "${BEST_DIR}/combined.patch" "$COMBINED_PATCH_PATH" 2>/dev/null || true
+    cp "${BEST_DIR}/iteration_delta.patch" "$ITERATION_DELTA_PATH" 2>/dev/null || reset_active_artifact "iteration_delta.patch"
+    cp "${BEST_DIR}/mechanic_report.json" "$MECHANIC_REPORT_PATH" 2>/dev/null || true
+    cp "${BEST_DIR}/holdout_report.json" "$HOLDOUT_REPORT_PATH" 2>/dev/null || true
+    cp "${BEST_DIR}/execute_log.json" "$EXECUTE_LOG_PATH" 2>/dev/null || true
+    rm -f "$REVIEWS_DIR/"*.json
+    cp "${BEST_DIR}/reviews/"*.json "$REVIEWS_DIR/" 2>/dev/null || true
+    cp "${BEST_DIR}/audit_summary.json" "$AUDIT_SUMMARY_PATH" 2>/dev/null || true
   else
-    echo "ROLLBACK_FAILED: git apply failed for iteration $BEST_ITERATION — forcing early stop"
+    echo "ROLLBACK_FAILED: git apply failed for iteration $BEST_ITERATION - forcing early stop"
     NO_IMPROVE_COUNT=99
     SKIP_ITERATION=true
   fi
 fi
-# If rollback failed, skip repair engineer and audit re-run — the early stop condition
+# If rollback failed, skip repair engineer and audit re-run. The early stop condition
 # (NO_IMPROVE_COUNT=99) will terminate the loop on the next entry condition check.
 ```
 
@@ -2266,18 +2680,24 @@ fi
 
 **Build repair brief:**
 
-Use the Bash tool to construct `.signum/repair_brief.json` from the current audit summary (which now reflects the best candidate after any rollback):
+Use the Bash tool to construct `repair_brief.json` under the canonical artifact root from the current audit summary (which now reflects the best candidate after any rollback):
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+REPAIR_BRIEF_PATH="${ARTIFACT_ROOT}repair_brief.json"
 ITER_NUM=$((CURRENT_ITERATION + 1))
 
 # Extract MAJOR+ findings from all reviewers
-FINDINGS=$(jq '[.reviews | to_entries[] | .value.findings[]? | select(.severity == "MAJOR" or .severity == "CRITICAL") | {fingerprint: .fingerprint, severity: .severity, category: .category, file: .file, line: .line, comment: .comment, evidence: .evidence}]' .signum/audit_summary.json)
+FINDINGS=$(jq '[.reviews | to_entries[] | .value.findings[]? | select(.severity == "MAJOR" or .severity == "CRITICAL") | {fingerprint: .fingerprint, severity: .severity, category: .category, file: .file, line: .line, comment: .comment, evidence: .evidence}]' "$AUDIT_SUMMARY_PATH")
 
 # Sanitize holdout summary (category only, no details)
 HOLDOUT_SUMMARY=""
-if [ -f .signum/holdout_report.json ]; then
-  HOLDOUT_FAILED=$(jq '.failed // 0' .signum/holdout_report.json)
+if [ -f "$HOLDOUT_REPORT_PATH" ]; then
+  HOLDOUT_FAILED=$(jq '.failed // 0' "$HOLDOUT_REPORT_PATH")
   if [ "$HOLDOUT_FAILED" -gt 0 ]; then
     # Extract categories via keyword matching on descriptions
     HOLDOUT_CATS=$(jq -r '[.results[] | select(.status != "PASS") | .description | ascii_downcase |
@@ -2285,7 +2705,7 @@ if [ -f .signum/holdout_report.json ]; then
       elif test("error|exception|fail") then "error handling"
       elif test("concurrent|race|parallel") then "concurrency"
       elif test("empty|null|missing") then "null/empty input"
-      else "unspecified" end] | unique | join(", ")' .signum/holdout_report.json)
+      else "unspecified" end] | unique | join(", ")' "$HOLDOUT_REPORT_PATH")
     HOLDOUT_SUMMARY="${HOLDOUT_FAILED} holdout(s) failed (categories: ${HOLDOUT_CATS})"
   fi
 fi
@@ -2293,13 +2713,13 @@ fi
 # Build mechanic regression summary and typed findings
 MECH_SUMMARY=""
 MECH_FINDINGS='[]'
-MECH_REG=$(jq -r '.hasRegressions' .signum/mechanic_report.json)
+MECH_REG=$(jq -r '.hasRegressions' "$MECHANIC_REPORT_PATH")
 if [ "$MECH_REG" = "true" ]; then
   MECH_SUMMARY=$(jq -r '
     [if .lint.regression then "lint regression" else empty end,
      if .typecheck.regression then "typecheck regression" else empty end,
      if .tests.regression then "test regression (" + (.tests.newFailures | length | tostring) + " new failures)" else empty end
-    ] | join(", ")' .signum/mechanic_report.json)
+    ] | join(", ")' "$MECHANIC_REPORT_PATH")
   # Extract typed per-file findings from regression checks only
   MECH_FINDINGS=$(jq '[
     .findings[]? |
@@ -2308,9 +2728,9 @@ if [ "$MECH_REG" = "true" ]; then
     # Find the check entry to get category and regression flag
     ([ (if . then . else null end) ] | first) as $_ |
     $f
-  ] | if length == 0 then [] else . end' .signum/mechanic_report.json 2>/dev/null || echo '[]')
+  ] | if length == 0 then [] else . end' "$MECHANIC_REPORT_PATH" 2>/dev/null || echo '[]')
   # Filter to only regression checks
-  REGRESSION_IDS=$(jq -r '[.checks[]? | select(.regression == true) | .id] | join(" ")' .signum/mechanic_report.json 2>/dev/null || echo "")
+  REGRESSION_IDS=$(jq -r '[.checks[]? | select(.regression == true) | .id] | join(" ")' "$MECHANIC_REPORT_PATH" 2>/dev/null || echo "")
   if [ -n "$REGRESSION_IDS" ]; then
     MECH_FINDINGS=$(jq '
       (.checks // [] | map({(.id): .category}) | add // {}) as $cat_map |
@@ -2319,23 +2739,16 @@ if [ "$MECH_REG" = "true" ]; then
         # Normalize file path: reject absolute paths and path traversal attempts
         . as $entry |
         ($entry.file // "") as $raw_file |
-        (if ($raw_file | startswith("/")) or ($raw_file | test("(^|/)\\.\\.(/|$)"))
+        (if ($raw_file | startswith("/")) or ($raw_file | test("(^|/)\.\.(/|$)"))
          then ""
          else $raw_file end) as $safe_file |
-        {check_id: $entry.check_id, category: ($cat_map[$entry.check_id] // "unknown"), file: $safe_file, line: $entry.line, column: $entry.column, code: $entry.code, message: $entry.message, origin: $entry.origin}]' \
-      .signum/mechanic_report.json 2>/dev/null || echo '[]')
+        {check_id: $entry.check_id, category: ($cat_map[$entry.check_id] // "unknown"), file: $safe_file, line: $entry.line, column: $entry.column, code: $entry.code, message: $entry.message, origin: $entry.origin}]'       "$MECHANIC_REPORT_PATH" 2>/dev/null || echo '[]')
   else
     MECH_FINDINGS='[]'
   fi
 fi
 
-jq -n \
-  --argjson iteration "$ITER_NUM" \
-  --argjson findings "$FINDINGS" \
-  --arg holdout_summary "$HOLDOUT_SUMMARY" \
-  --arg mechanic_summary "$MECH_SUMMARY" \
-  --argjson mechanic_findings "$MECH_FINDINGS" \
-  '{
+jq -n   --argjson iteration "$ITER_NUM"   --argjson findings "$FINDINGS"   --arg holdout_summary "$HOLDOUT_SUMMARY"   --arg mechanic_summary "$MECH_SUMMARY"   --argjson mechanic_findings "$MECH_FINDINGS"   '{
     iteration: $iteration,
     deterministicFailures: {
       mechanic: (if $mechanic_summary != "" then $mechanic_summary else null end),
@@ -2345,27 +2758,34 @@ jq -n \
     mechanicFindings: (if ($mechanic_findings | length) > 0 then $mechanic_findings else [] end),
     constraints: [
       "Fix ONLY the listed findings",
-      "Minimal diff — no unrelated refactors",
+      "Minimal diff - no unrelated refactors",
       "Do not break already-passing acceptance criteria",
       "Re-run visible AC verifies after fix"
     ]
-  }' > .signum/repair_brief.json
+  }' > "$REPAIR_BRIEF_PATH"
 
-echo "Repair brief built: $(jq '.reviewFindings | length' .signum/repair_brief.json) findings, $(jq '.mechanicFindings | length' .signum/repair_brief.json) mechanic findings"
+echo "Repair brief built: $(jq '.reviewFindings | length' "$REPAIR_BRIEF_PATH") findings, $(jq '.mechanicFindings | length' "$REPAIR_BRIEF_PATH") mechanic findings"
 ```
 
 **Clear stale engineer artifacts before launching repair:**
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+
 # Save current best combined.patch for worktree seeding BEFORE deleting stale artifacts
 _SEED_PATCH=""
-if [ -f .signum/combined.patch ]; then
+if [ -f "$COMBINED_PATCH_PATH" ]; then
   _SEED_PATCH=$(mktemp /tmp/signum_seed_XXXXXX.patch)
-  cp .signum/combined.patch "$_SEED_PATCH"
+  cp "$COMBINED_PATCH_PATH" "$_SEED_PATCH"
 fi
 
-# Remove stale artifacts so the success gate cannot accept leftovers from prior iterations
-rm -f .signum/execute_log.json .signum/combined.patch .signum/iteration_delta.patch
+# Remove stale artifacts from both the root view and canonical active root.
+source lib/contract-dir.sh
+reset_active_artifact "combined.patch"
+reset_active_artifact "execute_log.json"
+reset_active_artifact "iteration_delta.patch"
 ```
 
 **Launch repair engineer (parallel lanes):**
@@ -2377,12 +2797,16 @@ Set up two isolated git worktrees and run both engineers in parallel. The two st
 
 If worktree creation fails for either lane, fall back to single-lane behavior (the original single-engineer dispatch) without aborting the iteration.
 
-Each lane works in an isolated git worktree seeded from `base_commit` + current best `combined.patch`. Worktree paths live under `.signum/iterations/NN/lanes/` (one subdirectory per lane).
+Each lane works in an isolated git worktree seeded from `base_commit` + current best `combined.patch`. Worktree paths live under `iterations/NN/lanes/` inside the active contract artifact root.
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+ITERATIONS_DIR="${ARTIFACT_ROOT}iterations"
 ITER_PAD=$(printf '%02d' $ITER_NUM)
-BASE_COMMIT=$(jq -r '.base_commit' .signum/execution_context.json)
-LANE_PATHS=( ".signum/iterations/$ITER_PAD/lanes/A" ".signum/iterations/$ITER_PAD/lanes/B" )
+BASE_COMMIT=$(jq -r '.base_commit' "$EXECUTION_CONTEXT_PATH")
+LANE_PATHS=( "${ITERATIONS_DIR}/${ITER_PAD}/lanes/A" "${ITERATIONS_DIR}/${ITER_PAD}/lanes/B" )
 mkdir -p "${LANE_PATHS[0]}" "${LANE_PATHS[1]}"
 
 # _prune_lanes: remove both worktrees; safe to call multiple times
@@ -2418,6 +2842,9 @@ fi
 Before launching repair engineers, capture a fresh workspace snapshot for this attempt. Each attempt needs its own snapshot because `base_tree_hash` must bind to the actual starting state of this repair.
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+
 # Single-lane snapshot
 if [ -z "$_SIGNUM_SNAPSHOT" ] || [ ! -f "$_SIGNUM_SNAPSHOT" ]; then
   _SIGNUM_SNAPSHOT=""
@@ -2432,12 +2859,12 @@ if [ -z "$_SIGNUM_SNAPSHOT" ] || [ ! -f "$_SIGNUM_SNAPSHOT" ]; then
 fi
 ATTEMPT_PAD=$(printf '%02d' "$ITER_NUM")
 if [ -n "$_SIGNUM_SNAPSHOT" ]; then
-  bash "$_SIGNUM_SNAPSHOT" "execute-attempt-${ATTEMPT_PAD}"
+  bash "$_SIGNUM_SNAPSHOT" "execute-attempt-${ATTEMPT_PAD}" --workspace-root "$PWD" --signum-dir "$ARTIFACT_ROOT"
   echo "Pre-repair snapshot captured: execute-attempt-${ATTEMPT_PAD}"
 fi
 ```
 
-If `WORKTREE_OK` is `false`, fall back to single-lane: use the Agent tool to launch the "engineer" agent with the original prompt (no strategy hint), writing `.signum/combined.patch` and `.signum/execute_log.json` as before — then skip ahead to "After engineer completes, validate execute success".
+If `WORKTREE_OK` is `false`, fall back to single-lane: use the Agent tool to launch the "engineer" agent with the original prompt (no strategy hint), writing `combined.patch` and `execute_log.json` under the active contract artifact root, then skip ahead to "After engineer completes, validate execute success".
 
 If `WORKTREE_OK` is `true`, launch both lane engineers in parallel using the Agent tool.
 
@@ -2445,9 +2872,8 @@ For the engineer working in `${LANE_PATHS[0]}`, use this prompt (strategy: minim
 
 ```
 STRATEGY HINT: Fix with minimal targeted changes. Patch only the specific lines flagged in findings.
-Read .signum/contract-engineer.json for scope and acceptance criteria.
-Read .signum/baseline.json for pre-existing check state.
-Read .signum/repair_brief.json for the specific issues to fix.
+The canonical artifact root in this lane is `.signum/contracts/<activeContractId>/`.
+Read `contract-engineer.json`, `baseline.json`, and `repair_brief.json` from that canonical artifact root.
 Fix ONLY the issues listed in the repair brief. Do not refactor, do not add features.
 After fixing, run the visible AC verifies to confirm you didn't break them.
 Write ${LANE_PATHS[0]}/combined.patch and ${LANE_PATHS[0]}/execute_log.json.
@@ -2458,9 +2884,8 @@ For the engineer working in `${LANE_PATHS[1]}`, use this prompt (strategy: root 
 
 ```
 STRATEGY HINT: Fix by addressing the root cause. May touch more files if the findings share a common underlying issue.
-Read .signum/contract-engineer.json for scope and acceptance criteria.
-Read .signum/baseline.json for pre-existing check state.
-Read .signum/repair_brief.json for the specific issues to fix.
+The canonical artifact root in this lane is `.signum/contracts/<activeContractId>/`.
+Read `contract-engineer.json`, `baseline.json`, and `repair_brief.json` from that canonical artifact root.
 Fix ONLY the issues listed in the repair brief. Do not refactor, do not add features.
 After fixing, run the visible AC verifies to confirm you didn't break them.
 Write ${LANE_PATHS[1]}/combined.patch and ${LANE_PATHS[1]}/execute_log.json.
@@ -2484,7 +2909,7 @@ _lane_score() {
 
 SCORE_A=$(_lane_score "${LANE_PATHS[0]}")
 SCORE_B=$(_lane_score "${LANE_PATHS[1]}")
-LANE_SELECTED_DIR=".signum/iterations/$ITER_PAD/lanes"
+LANE_SELECTED_DIR="${ITERATIONS_DIR}/${ITER_PAD}/lanes"
 
 if [ "$SCORE_A" -ge "$SCORE_B" ]; then
   WINNER_LANE="A"; RUNNER_UP_LANE="B"
@@ -2515,14 +2940,22 @@ If the winner receives a MAJOR or CRITICAL finding after the panel, also send th
 **Copy winner artifacts to iteration root:**
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
 if [ "$WINNER_LANE" = "A" ]; then WINNER_DIR="${LANE_PATHS[0]}"; else WINNER_DIR="${LANE_PATHS[1]}"; fi
-cp "$WINNER_DIR/combined.patch" .signum/combined.patch
-cp "$WINNER_DIR/execute_log.json" .signum/execute_log.json 2>/dev/null || true
-cp "$WINNER_DIR/mechanic_report.json" .signum/mechanic_report.json 2>/dev/null || true
-cp "$WINNER_DIR/holdout_report.json" .signum/holdout_report.json 2>/dev/null || true
-mkdir -p .signum/reviews
-cp "$WINNER_DIR/reviews/"*.json .signum/reviews/ 2>/dev/null || true
-cp "$WINNER_DIR/audit_summary.json" .signum/audit_summary.json 2>/dev/null || true
+cp "$WINNER_DIR/combined.patch" "$COMBINED_PATCH_PATH"
+cp "$WINNER_DIR/execute_log.json" "$EXECUTE_LOG_PATH" 2>/dev/null || true
+cp "$WINNER_DIR/mechanic_report.json" "$MECHANIC_REPORT_PATH" 2>/dev/null || true
+cp "$WINNER_DIR/holdout_report.json" "$HOLDOUT_REPORT_PATH" 2>/dev/null || true
+mkdir -p "$REVIEWS_DIR"
+cp "$WINNER_DIR/reviews/"*.json "$REVIEWS_DIR/" 2>/dev/null || true
+cp "$WINNER_DIR/audit_summary.json" "$AUDIT_SUMMARY_PATH" 2>/dev/null || true
 ```
 
 **Run boundary verification on winner BEFORE pruning worktrees (receipt chain):**
@@ -2530,6 +2963,23 @@ cp "$WINNER_DIR/audit_summary.json" .signum/audit_summary.json 2>/dev/null || tr
 Boundary verification must run while the winner worktree still exists — it needs the live workspace to verify file hashes, scope integrity, and AC evidence. Pruning worktrees before verification would cause the verifier to run against stale main checkout.
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+SNAPSHOTS_DIR="${ARTIFACT_ROOT}snapshots"
+RECEIPTS_DIR="${ARTIFACT_ROOT}receipts"
+RUNS_DIR="${ARTIFACT_ROOT}runs"
+WINNER_SIGNUM_DIR="${WINNER_DIR}/.signum"
+WINNER_ACTIVE_CONTRACT_ID=$(jq -r '.activeContractId // empty' "${WINNER_SIGNUM_DIR}/contracts/index.json" 2>/dev/null || true)
+if [ -z "$WINNER_ACTIVE_CONTRACT_ID" ]; then
+  WINNER_ACTIVE_CONTRACT_ID="$(get_active_contract 2>/dev/null || true)"
+fi
+if [ -n "$WINNER_ACTIVE_CONTRACT_ID" ]; then
+  WINNER_ARTIFACT_ROOT="${WINNER_SIGNUM_DIR}/contracts/${WINNER_ACTIVE_CONTRACT_ID}/"
+else
+  WINNER_ARTIFACT_ROOT="${WINNER_SIGNUM_DIR}/"
+fi
+
 # Re-resolve receipt chain scripts (variables may not persist across Bash tool calls)
 if [ -z "${_SIGNUM_BOUNDARY:-}" ]; then
   for _d in \
@@ -2559,26 +3009,26 @@ if [ -n "${_SIGNUM_BOUNDARY:-}" ]; then
   ATTEMPT_PAD=$(printf '%02d' "$ITER_NUM")
   if ! bash "$_SIGNUM_BOUNDARY" execute \
     --workspace-root "$WINNER_DIR" \
-    --signum-dir "$WINNER_DIR/.signum" \
-    --contract "$WINNER_DIR/.signum/contract-engineer.json" \
-    --contract-full "$WINNER_DIR/.signum/contract.json" \
-    --snapshot ".signum/snapshots/execute-attempt-${ATTEMPT_PAD}.json"; then
+    --signum-dir "$WINNER_SIGNUM_DIR" \
+    --contract "${WINNER_ARTIFACT_ROOT}contract-engineer.json" \
+    --contract-full "${WINNER_ARTIFACT_ROOT}contract.json" \
+    --snapshot "${SNAPSHOTS_DIR}/execute-attempt-${ATTEMPT_PAD}.json"; then
     echo "BOUNDARY_BLOCK: repair attempt $ITER_NUM failed boundary verification"
     RECEIPT_CHAIN_OK=false
   fi
-  # Copy receipt from winner worktree to root .signum (specific run_id only)
-  _CURRENT_RUN_ID=$(jq -r '.run_id // empty' .signum/execution_context.json)
-  mkdir -p ".signum/receipts" ".signum/runs/$_CURRENT_RUN_ID"
-  cp "$WINNER_DIR/.signum/receipts/execute.json" .signum/receipts/execute.json 2>/dev/null || true
-  if [ -d "$WINNER_DIR/.signum/runs/$_CURRENT_RUN_ID" ]; then
-    cp "$WINNER_DIR/.signum/runs/$_CURRENT_RUN_ID/execute-"*.json \
-      ".signum/runs/$_CURRENT_RUN_ID/" 2>/dev/null || true
+  # Copy receipt from winner worktree into the canonical artifact root.
+  _CURRENT_RUN_ID=$(jq -r '.run_id // empty' "$EXECUTION_CONTEXT_PATH")
+  mkdir -p "$RECEIPTS_DIR" "$RUNS_DIR/$_CURRENT_RUN_ID"
+  cp "${WINNER_ARTIFACT_ROOT}receipts/execute.json" "$RECEIPTS_DIR/execute.json" 2>/dev/null || true
+  if [ -d "${WINNER_ARTIFACT_ROOT}runs/$_CURRENT_RUN_ID" ]; then
+    cp "${WINNER_ARTIFACT_ROOT}runs/$_CURRENT_RUN_ID/execute-"*.json \
+      "$RUNS_DIR/$_CURRENT_RUN_ID/" 2>/dev/null || true
   fi
 fi
 if [ "$RECEIPT_CHAIN_OK" = "true" ] && [ -n "${_SIGNUM_TRANSITION:-}" ]; then
   ATTEMPT_PAD=$(printf '%02d' "$ITER_NUM")
   if ! bash "$_SIGNUM_TRANSITION" execute audit \
-    --snapshot ".signum/snapshots/execute-attempt-${ATTEMPT_PAD}.json"; then
+    --snapshot "${SNAPSHOTS_DIR}/execute-attempt-${ATTEMPT_PAD}.json"; then
     echo "TRANSITION_BLOCK: repair attempt $ITER_NUM failed transition gate"
     RECEIPT_CHAIN_OK=false
   fi
@@ -2597,51 +3047,57 @@ If `RECEIPT_CHAIN_OK` is `false`, **STOP** the repair iteration. Do not proceed 
 **After engineer completes, validate execute success before re-running audit:**
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+ITERATION_DELTA_PATH="${ARTIFACT_ROOT}iteration_delta.patch"
+
 # Execute success gate: verify engineer produced NEW artifacts (stale ones were cleared above)
-if [ ! -f .signum/execute_log.json ]; then
-  echo "REPAIR_SKIP: execute_log.json missing after repair engineer — skipping iteration $ITER_NUM"
+if [ ! -f "$EXECUTE_LOG_PATH" ]; then
+  echo "REPAIR_SKIP: execute_log.json missing after repair engineer - skipping iteration $ITER_NUM"
   CURRENT_ITERATION=$ITER_NUM
   continue
 fi
-REPAIR_STATUS=$(jq -r '.status // "unknown"' .signum/execute_log.json)
+REPAIR_STATUS=$(jq -r '.status // "unknown"' "$EXECUTE_LOG_PATH")
 if [ "$REPAIR_STATUS" != "SUCCESS" ]; then
-  echo "REPAIR_SKIP: execute_log.json status=$REPAIR_STATUS (not SUCCESS) — skipping iteration $ITER_NUM"
+  echo "REPAIR_SKIP: execute_log.json status=$REPAIR_STATUS (not SUCCESS) - skipping iteration $ITER_NUM"
   CURRENT_ITERATION=$ITER_NUM
   continue
 fi
-if [ ! -f .signum/combined.patch ]; then
-  echo "REPAIR_SKIP: combined.patch missing after repair engineer — skipping iteration $ITER_NUM"
+if [ ! -f "$COMBINED_PATCH_PATH" ]; then
+  echo "REPAIR_SKIP: combined.patch missing after repair engineer - skipping iteration $ITER_NUM"
   CURRENT_ITERATION=$ITER_NUM
   continue
 fi
-echo "Repair engineer succeeded for iteration $ITER_NUM — proceeding to audit"
+echo "Repair engineer succeeded for iteration $ITER_NUM - proceeding to audit"
 
 # Compute iteration delta by diffing the two stored patches (best candidate vs current)
 # The engineer already wrote combined.patch; we diff it against the best iteration's patch
-BEST_PATCH=".signum/iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch"
+BEST_PATCH="${ARTIFACT_ROOT}iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch"
 if [ -f "$BEST_PATCH" ]; then
   # Delta = lines in current patch that differ from best candidate's patch
   # Use diff on the applied file states, not on patch text
   # Simpler: extract file lists from both patches and diff only changed files
-  diff -u "$BEST_PATCH" .signum/combined.patch > .signum/iteration_delta.patch 2>/dev/null || true
+  diff -u "$BEST_PATCH" "$COMBINED_PATCH_PATH" > "$ITERATION_DELTA_PATH" 2>/dev/null || true
 else
   # No best patch to compare against (shouldn't happen after pass 1)
-  cp .signum/combined.patch .signum/iteration_delta.patch 2>/dev/null || true
+  cp "$COMBINED_PATCH_PATH" "$ITERATION_DELTA_PATH" 2>/dev/null || true
 fi
-DELTA_SIZE=$(wc -c < .signum/iteration_delta.patch 2>/dev/null || echo 0)
-FULL_SIZE=$(wc -c < .signum/combined.patch 2>/dev/null || echo 0)
+DELTA_SIZE=$(wc -c < "$ITERATION_DELTA_PATH" 2>/dev/null || echo 0)
+FULL_SIZE=$(wc -c < "$COMBINED_PATCH_PATH" 2>/dev/null || echo 0)
 echo "Delta: $DELTA_SIZE bytes, Full: $FULL_SIZE bytes"
 
 if [ "$DELTA_SIZE" -eq 0 ]; then
-  echo "Delta empty — marking as non-improving"
+  echo "Delta empty - marking as non-improving"
   NO_IMPROVE_COUNT=$((NO_IMPROVE_COUNT + 1))
   CURRENT_ITERATION=$ITER_NUM
   continue
 fi
 
 if [ "$FULL_SIZE" -gt 0 ] && [ $((DELTA_SIZE * 100 / FULL_SIZE)) -gt 80 ]; then
-  echo "Delta >80% of full patch — full-diff-only review for this iteration"
-  rm -f .signum/iteration_delta.patch
+  echo "Delta >80% of full patch - full-diff-only review for this iteration"
+  reset_active_artifact "iteration_delta.patch"
 fi
 ```
 
@@ -2652,49 +3108,54 @@ Re-run Steps 2.4 (scope gate), 2.4.5 (policy compliance if applicable), 2.4.6 (s
 Pass `currentIteration` to the synthesizer prompt:
 
 ```
-Read .signum/mechanic_report.json, .signum/reviews/claude.json,
-.signum/reviews/codex.json, .signum/reviews/gemini.json,
-.signum/holdout_report.json, .signum/execute_log.json,
-and .signum/audit_iteration_log.json.
+The canonical artifact root for this synthesis is `.signum/contracts/<activeContractId>/`.
+Read `mechanic_report.json`, `reviews/claude.json`, `reviews/codex.json`, `reviews/gemini.json`, `holdout_report.json`, `execute_log.json`, and `audit_iteration_log.json` from that canonical artifact root.
 Current iteration: <N>.
-Apply deterministic synthesis rules, compute confidence and iteration scores,
-and write .signum/audit_summary.json.
+Apply deterministic synthesis rules, compute confidence and iteration scores, and write `audit_summary.json` to that same canonical artifact root.
 ```
 
 **After synthesizer, store iteration artifacts and update tracking:**
 
 ```bash
-ITER_DIR=".signum/iterations/$(printf '%02d' $ITER_NUM)"
-mkdir -p "$ITER_DIR/reviews"
-cp .signum/combined.patch "$ITER_DIR/"
-cp .signum/iteration_delta.patch "$ITER_DIR/" 2>/dev/null || true
-cp .signum/mechanic_report.json "$ITER_DIR/"
-cp .signum/holdout_report.json "$ITER_DIR/" 2>/dev/null || true
-cp .signum/execute_log.json "$ITER_DIR/" 2>/dev/null || true
-cp .signum/reviews/*.json "$ITER_DIR/reviews/" 2>/dev/null || true
-cp .signum/audit_summary.json "$ITER_DIR/"
-cp .signum/repair_brief.json "$ITER_DIR/"
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+ITER_DIR="${ARTIFACT_ROOT}iterations/$(printf '%02d' $ITER_NUM)"
+ITER_REVIEWS_DIR="${ITER_DIR}/reviews"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+ITERATION_DELTA_PATH="${ARTIFACT_ROOT}iteration_delta.patch"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+REPAIR_BRIEF_PATH="${ARTIFACT_ROOT}repair_brief.json"
+AUDIT_ITERATION_LOG_PATH="${ARTIFACT_ROOT}audit_iteration_log.json"
+mkdir -p "$ITER_REVIEWS_DIR"
+cp "$COMBINED_PATCH_PATH" "$ITER_DIR/"
+cp "$ITERATION_DELTA_PATH" "$ITER_DIR/" 2>/dev/null || true
+cp "$MECHANIC_REPORT_PATH" "$ITER_DIR/"
+cp "$HOLDOUT_REPORT_PATH" "$ITER_DIR/" 2>/dev/null || true
+cp "$EXECUTE_LOG_PATH" "$ITER_DIR/" 2>/dev/null || true
+cp "$REVIEWS_DIR/"*.json "$ITER_REVIEWS_DIR/" 2>/dev/null || true
+cp "$AUDIT_SUMMARY_PATH" "$ITER_DIR/"
+cp "$REPAIR_BRIEF_PATH" "$ITER_DIR/"
 
 # Read new score
-NEW_SCORE=$(jq -r '.iterationScore // 0' .signum/audit_summary.json)
-NEW_DECISION=$(jq -r '.decision' .signum/audit_summary.json)
+NEW_SCORE=$(jq -r '.iterationScore // 0' "$AUDIT_SUMMARY_PATH")
+NEW_DECISION=$(jq -r '.decision' "$AUDIT_SUMMARY_PATH")
 
 # Extract deduplicated findings with fingerprints for cross-iteration comparison
-NEW_FINDINGS=$(jq '[.reviews[].findings[]? | {fingerprint: .fingerprint, severity: .severity, category: .category, file: .file, line: .line}] | unique_by(.fingerprint // (.file + ":" + (.line | tostring) + ":" + .category))' .signum/audit_summary.json)
+NEW_FINDINGS=$(jq '[.reviews[].findings[]? | {fingerprint: .fingerprint, severity: .severity, category: .category, file: .file, line: .line}] | unique_by(.fingerprint // (.file + ":" + (.line | tostring) + ":" + .category))' "$AUDIT_SUMMARY_PATH")
 NEW_FINDINGS_COUNT=$(jq '{
   critical: [.reviews[].findings[]? | select(.severity == "CRITICAL")] | length,
   major: [.reviews[].findings[]? | select(.severity == "MAJOR")] | length,
   minor: [.reviews[].findings[]? | select(.severity == "MINOR")] | length
-}' .signum/audit_summary.json)
+}' "$AUDIT_SUMMARY_PATH")
 
 # Update iteration log
-MECH_REG=$(jq -r '.hasRegressions' .signum/mechanic_report.json 2>/dev/null || echo "false")
-HOLDOUT_FAIL=$(jq '.failed // 0' .signum/holdout_report.json 2>/dev/null || echo 0)
-jq --argjson score "$NEW_SCORE" --arg decision "$NEW_DECISION" --argjson pass "$ITER_NUM" --argjson findings "$NEW_FINDINGS" --argjson findingsCount "$NEW_FINDINGS_COUNT" \
-  --arg mechReg "$MECH_REG" --argjson holdoutFail "$HOLDOUT_FAIL" \
-  '. + [{"pass": $pass, "score": $score, "decision": $decision, "findingsCount": $findingsCount, "canonicalFindings": $findings, "mechanicRegressions": ($mechReg == "true"), "holdoutFailures": $holdoutFail}]' \
-  .signum/audit_iteration_log.json > .signum/audit_iteration_log.json.tmp \
-  && mv .signum/audit_iteration_log.json.tmp .signum/audit_iteration_log.json
+MECH_REG=$(jq -r '.hasRegressions' "$MECHANIC_REPORT_PATH" 2>/dev/null || echo "false")
+HOLDOUT_FAIL=$(jq '.failed // 0' "$HOLDOUT_REPORT_PATH" 2>/dev/null || echo 0)
+jq --argjson score "$NEW_SCORE" --arg decision "$NEW_DECISION" --argjson pass "$ITER_NUM" --argjson findings "$NEW_FINDINGS" --argjson findingsCount "$NEW_FINDINGS_COUNT"   --arg mechReg "$MECH_REG" --argjson holdoutFail "$HOLDOUT_FAIL"   '. + [{"pass": $pass, "score": $score, "decision": $decision, "findingsCount": $findingsCount, "canonicalFindings": $findings, "mechanicRegressions": ($mechReg == "true"), "holdoutFailures": $holdoutFail}]'   "$AUDIT_ITERATION_LOG_PATH" > "${AUDIT_ITERATION_LOG_PATH}.tmp"   && mv "${AUDIT_ITERATION_LOG_PATH}.tmp" "$AUDIT_ITERATION_LOG_PATH"
 
 # Update best tracking
 if [ "$NEW_SCORE" -gt "$BEST_SCORE" ] || [ "$NEW_SCORE" -eq "$BEST_SCORE" -a "$ITER_NUM" -le "$BEST_ITERATION" ]; then
@@ -2729,38 +3190,46 @@ ITERATIONS_USED=$CURRENT_ITERATION
 
 RESTORE_FAILED=false
 if [ "$BEST_ITERATION" -ne "$CURRENT_ITERATION" ]; then
-  echo "Restoring best candidate from iteration $BEST_ITERATION"
-  # Rollback using stored patch: revert only files listed in current iteration's combined.patch
-  BASE=$(jq -r '.base_commit' .signum/execution_context.json)
-  PATCH_FILES=$(grep '^diff --git' .signum/combined.patch | sed 's|^diff --git a/||; s| b/.*||' | sort -u)
-  for f in $PATCH_FILES; do
-    git checkout "$BASE" -- "$f" 2>/dev/null || rm -f "$f" 2>/dev/null || true
-  done
-  # Always sync audit artifacts from best iteration so PACK reads consistent data
-  BEST_DIR=".signum/iterations/$(printf '%02d' $BEST_ITERATION)"
-  cp "${BEST_DIR}/combined.patch" .signum/
-  cp "${BEST_DIR}/iteration_delta.patch" .signum/ 2>/dev/null || rm -f .signum/iteration_delta.patch
-  cp "${BEST_DIR}/mechanic_report.json" .signum/
-  cp "${BEST_DIR}/holdout_report.json" .signum/ 2>/dev/null || true
-  cp "${BEST_DIR}/execute_log.json" .signum/ 2>/dev/null || true
-  rm -f .signum/reviews/*.json
-  cp "${BEST_DIR}/reviews/"*.json .signum/reviews/ 2>/dev/null || true
-  cp "${BEST_DIR}/audit_summary.json" .signum/
+echo "Restoring best candidate from iteration $BEST_ITERATION"
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+ITERATION_DELTA_PATH="${ARTIFACT_ROOT}iteration_delta.patch"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+# Rollback using stored patch: revert only files listed in current iteration's combined.patch
+BASE=$(jq -r '.base_commit' "$EXECUTION_CONTEXT_PATH")
+PATCH_FILES=$(grep '^diff --git' "$COMBINED_PATCH_PATH" | sed 's|^diff --git a/||; s| b/.*||' | sort -u)
+for f in $PATCH_FILES; do
+  git checkout "$BASE" -- "$f" 2>/dev/null || rm -f "$f" 2>/dev/null || true
+done
+# Always sync audit artifacts from best iteration so PACK reads consistent data
+BEST_DIR="${ARTIFACT_ROOT}iterations/$(printf '%02d' $BEST_ITERATION)"
+cp "${BEST_DIR}/combined.patch" "$COMBINED_PATCH_PATH"
+cp "${BEST_DIR}/iteration_delta.patch" "$ITERATION_DELTA_PATH" 2>/dev/null || reset_active_artifact "iteration_delta.patch"
+cp "${BEST_DIR}/mechanic_report.json" "$MECHANIC_REPORT_PATH"
+cp "${BEST_DIR}/holdout_report.json" "$HOLDOUT_REPORT_PATH" 2>/dev/null || true
+cp "${BEST_DIR}/execute_log.json" "$EXECUTE_LOG_PATH" 2>/dev/null || true
+rm -f "$REVIEWS_DIR/"*.json
+cp "${BEST_DIR}/reviews/"*.json "$REVIEWS_DIR/" 2>/dev/null || true
+cp "${BEST_DIR}/audit_summary.json" "$AUDIT_SUMMARY_PATH"
 
-  if ! git apply .signum/iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch; then
-    echo "ERROR: Failed to apply best candidate patch — forcing HUMAN_REVIEW"
+if ! git apply "${ARTIFACT_ROOT}iterations/$(printf '%02d' $BEST_ITERATION)/combined.patch"; then
+    echo "ERROR: Failed to apply best candidate patch - forcing HUMAN_REVIEW"
     RESTORE_FAILED=true
     FINAL_DECISION="HUMAN_REVIEW"
     # Override decision in the already-synced audit_summary
-    jq '.decision = "HUMAN_REVIEW" | .terminalReason = "final restore of best candidate patch failed"' \
-      .signum/audit_summary.json > .signum/audit_summary.json.tmp \
-      && mv .signum/audit_summary.json.tmp .signum/audit_summary.json
+    jq '.decision = "HUMAN_REVIEW" | .terminalReason = "final restore of best candidate patch failed"'       "$AUDIT_SUMMARY_PATH" > "${AUDIT_SUMMARY_PATH}.tmp"       && mv "${AUDIT_SUMMARY_PATH}.tmp" "$AUDIT_SUMMARY_PATH"
   fi
 fi
 
 # Determine terminal decision from best candidate
 if [ "$RESTORE_FAILED" != "true" ]; then
-  FINAL_DECISION=$(jq -r '.decision' .signum/audit_summary.json)
+  FINAL_DECISION=$(jq -r '.decision' "$AUDIT_SUMMARY_PATH")
 fi
 EARLY_STOP=$( [ "$NO_IMPROVE_COUNT" -ge 2 ] && echo "true" || echo "false" )
 EARLY_STOP_REASON=""
@@ -2768,28 +3237,22 @@ EARLY_STOP_REASON=""
 [ "$CURRENT_ITERATION" -ge "$MAX_ITERATIONS" ] && EARLY_STOP="true" && EARLY_STOP_REASON="max iterations reached"
 
 # Write iteration metadata unconditionally so PACK always has correct fields
-jq --argjson iters_used "$ITERATIONS_USED" \
-   --argjson iters_max "$MAX_ITERATIONS" \
-   --argjson best "$BEST_ITERATION" \
-   --arg early_stop "$EARLY_STOP" \
-   --arg early_stop_reason "$EARLY_STOP_REASON" \
-   '. + {
+jq --argjson iters_used "$ITERATIONS_USED"    --argjson iters_max "$MAX_ITERATIONS"    --argjson best "$BEST_ITERATION"    --arg early_stop "$EARLY_STOP"    --arg early_stop_reason "$EARLY_STOP_REASON"    '. + {
      iterationsUsed: $iters_used,
      iterationsMax: $iters_max,
      bestIteration: $best,
      earlyStop: ($early_stop == "true"),
      earlyStopReason: (if $early_stop_reason != "" then $early_stop_reason else null end)
-   }' .signum/audit_summary.json > .signum/audit_summary.json.tmp \
-   && mv .signum/audit_summary.json.tmp .signum/audit_summary.json
+   }' "$AUDIT_SUMMARY_PATH" > "${AUDIT_SUMMARY_PATH}.tmp"    && mv "${AUDIT_SUMMARY_PATH}.tmp" "$AUDIT_SUMMARY_PATH"
 
 if [ "$RESTORE_FAILED" != "true" ]; then
   # Terminal override based on remaining findings in best candidate
-  REMAINING_CRITICAL=$(jq '[.reviews[].findings[]? | select(.severity == "CRITICAL")] | length' .signum/audit_summary.json)
-  REMAINING_MAJOR=$(jq '[.reviews[].findings[]? | select(.severity == "MAJOR")] | length' .signum/audit_summary.json)
-  REMAINING_MINOR=$(jq '[.reviews[].findings[]? | select(.severity == "MINOR")] | length' .signum/audit_summary.json)
+  REMAINING_CRITICAL=$(jq '[.reviews[].findings[]? | select(.severity == "CRITICAL")] | length' "$AUDIT_SUMMARY_PATH")
+  REMAINING_MAJOR=$(jq '[.reviews[].findings[]? | select(.severity == "MAJOR")] | length' "$AUDIT_SUMMARY_PATH")
+  REMAINING_MINOR=$(jq '[.reviews[].findings[]? | select(.severity == "MINOR")] | length' "$AUDIT_SUMMARY_PATH")
 
-  BEST_MECH_REGRESSIONS=$(jq -r '.hasRegressions' .signum/mechanic_report.json 2>/dev/null || echo "false")
-  BEST_HOLDOUT_FAILED=$(jq '.failed // 0' .signum/holdout_report.json 2>/dev/null || echo 0)
+  BEST_MECH_REGRESSIONS=$(jq -r '.hasRegressions' "$MECHANIC_REPORT_PATH" 2>/dev/null || echo "false")
+  BEST_HOLDOUT_FAILED=$(jq '.failed // 0' "$HOLDOUT_REPORT_PATH" 2>/dev/null || echo 0)
 
   if [ "$REMAINING_CRITICAL" -gt 0 ]; then
     FINAL_DECISION="AUTO_BLOCK"
@@ -2814,15 +3277,11 @@ if [ "$RESTORE_FAILED" != "true" ]; then
   fi
 
   # Update audit_summary with decision metadata
-  jq --arg remaining_sev "$REMAINING_SEV" \
-     --arg final_decision "$FINAL_DECISION" \
-     --arg terminal_reason "$TERMINAL_REASON" \
-     '. + {
+  jq --arg remaining_sev "$REMAINING_SEV"      --arg final_decision "$FINAL_DECISION"      --arg terminal_reason "$TERMINAL_REASON"      '. + {
        decision: $final_decision,
        terminalReason: (if $final_decision != "AUTO_OK" then $terminal_reason else null end),
        remainingSeverity: $remaining_sev
-     }' .signum/audit_summary.json > .signum/audit_summary.json.tmp \
-     && mv .signum/audit_summary.json.tmp .signum/audit_summary.json
+     }' "$AUDIT_SUMMARY_PATH" > "${AUDIT_SUMMARY_PATH}.tmp"      && mv "${AUDIT_SUMMARY_PATH}.tmp" "$AUDIT_SUMMARY_PATH"
 fi
 
 echo "=== ITERATIVE AUDIT COMPLETE ==="
@@ -2846,11 +3305,15 @@ Proceed to Phase 4: PACK.
 Transition the contract status from `active` to `completed` and record the `completedAt` timestamp:
 
 ```bash
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+CONTRACT_TMP_PATH="${CONTRACT_PATH%.json}-tmp.json"
 COMPLETED_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 jq --arg ts "$COMPLETED_TS" \
   '.status = "completed" | .timestamps.completedAt = $ts' \
-  .signum/contract.json > .signum/contract-tmp.json && \
-  mv .signum/contract-tmp.json .signum/contract.json
+  "$CONTRACT_PATH" > "$CONTRACT_TMP_PATH" && \
+  mv "$CONTRACT_TMP_PATH" "$CONTRACT_PATH"
 echo "Contract status: active → completed at $COMPLETED_TS"
 ```
 
@@ -2880,34 +3343,55 @@ file_size() {
   wc -c < "$f" | tr -d ' '
 }
 
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+BASELINE_PATH="${ARTIFACT_ROOT}baseline.json"
+COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+MECHANIC_REPORT_PATH="${ARTIFACT_ROOT}mechanic_report.json"
+HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"
+POLICY_SCAN_PATH="${ARTIFACT_ROOT}policy_scan.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+APPROVAL_PATH="${ARTIFACT_ROOT}approval.json"
+PROOFPACK_PATH="${ARTIFACT_ROOT}proofpack.json"
+ANTI_ENTROPY_PATH="${ARTIFACT_ROOT}anti_entropy_report.json"
+CONTRACT_HASH_PATH="${ARTIFACT_ROOT}contract-hash.txt"
+EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+AUDIT_ITERATION_LOG_PATH="${ARTIFACT_ROOT}audit_iteration_log.json"
+REVIEWS_DIR="${ARTIFACT_ROOT}reviews"
+RECEIPTS_EXEC_PATH="${ARTIFACT_ROOT}receipts/execute.json"
+
 # Metadata
-DECISION=$(jq -r '.decision' .signum/audit_summary.json)
-GOAL=$(jq -r '.goal' .signum/contract.json)
-RISK=$(jq -r '.riskLevel' .signum/contract.json)
-ATTEMPTS=$(jq -r '.totalAttempts' .signum/execute_log.json 2>/dev/null || echo "unknown")
-MECHANIC=$(jq -r '.mechanic' .signum/audit_summary.json)
-CONFIDENCE=$(jq -r '.confidence.overall // 0' .signum/audit_summary.json)
+DECISION=$(jq -r '.decision' "$AUDIT_SUMMARY_PATH")
+GOAL=$(jq -r '.goal' "$CONTRACT_PATH")
+RISK=$(jq -r '.riskLevel' "$CONTRACT_PATH")
+ATTEMPTS=$(jq -r '.totalAttempts' "$EXECUTE_LOG_PATH" 2>/dev/null || echo "unknown")
+MECHANIC=$(jq -r '.mechanic' "$AUDIT_SUMMARY_PATH")
+CONFIDENCE=$(jq -r '.confidence.overall // 0' "$AUDIT_SUMMARY_PATH")
 RUN_DATE=$(date +%Y-%m-%dT%H:%M:%SZ)
 RUN_RANDOM=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 6)
 RUN_ID="signum-$(date +%Y-%m-%d)-${RUN_RANDOM}"
 
 # Audit chain
-CONTRACT_HASH=$(grep 'contract_sha256:' .signum/contract-hash.txt 2>/dev/null | awk '{print $2}' || echo "unavailable")
-APPROVED_AT=$(grep 'approved_at:' .signum/contract-hash.txt 2>/dev/null | awk '{print $2}' || echo "unavailable")
-BASE_COMMIT=$(jq -r '.base_commit // "unavailable"' .signum/execution_context.json 2>/dev/null || echo "unavailable")
+CONTRACT_HASH=$(grep 'contract_sha256:' "$CONTRACT_HASH_PATH" 2>/dev/null | awk '{print $2}' || echo "unavailable")
+APPROVED_AT=$(grep 'approved_at:' "$CONTRACT_HASH_PATH" 2>/dev/null | awk '{print $2}' || echo "unavailable")
+BASE_COMMIT=$(jq -r '.base_commit // "unavailable"' "$EXECUTION_CONTEXT_PATH" 2>/dev/null || echo "unavailable")
 
 # Contract redaction: strip holdoutScenarios, save to temp file
 REDACTED_CONTRACT=$(mktemp /tmp/signum-contract-redacted.XXXXXX.json)
-python3 -c "
-import json, sys
-with open('.signum/contract.json') as f:
+python3 - "$CONTRACT_PATH" <<'PY' > "$REDACTED_CONTRACT"
+import json
+import sys
+
+with open(sys.argv[1]) as f:
     data = json.load(f)
 data.pop('holdoutScenarios', None)
 json.dump(data, sys.stdout)
-" > "$REDACTED_CONTRACT"
+PY
 
 CONTRACT_SHA256=$(hash_file "$REDACTED_CONTRACT")
-CONTRACT_FULL_SHA256=$(hash_file .signum/contract.json)
+CONTRACT_FULL_SHA256=$(hash_file "$CONTRACT_PATH")
 
 # Envelope builder: embeds file content if <=102400 bytes, else omits
 # JSON files (.json) are embedded as objects, text files as strings
@@ -2948,34 +3432,34 @@ else
 fi
 
 # Diff embedding
-DIFF_ENV=$(build_envelope .signum/combined.patch)
+DIFF_ENV=$(build_envelope "$COMBINED_PATCH_PATH")
 
 # Baseline envelope (optional artifact)
-BASELINE_ENV=$(build_envelope .signum/baseline.json)
+BASELINE_ENV=$(build_envelope "$BASELINE_PATH")
 
 # Execute log envelope
-EXECUTE_ENV=$(build_envelope .signum/execute_log.json)
+EXECUTE_ENV=$(build_envelope "$EXECUTE_LOG_PATH")
 
 # Mechanic and holdout envelopes
-MECHANIC_ENV=$(build_envelope .signum/mechanic_report.json)
-HOLDOUT_ENV=$(build_envelope .signum/holdout_report.json)
+MECHANIC_ENV=$(build_envelope "$MECHANIC_REPORT_PATH")
+HOLDOUT_ENV=$(build_envelope "$HOLDOUT_REPORT_PATH")
 
 # Policy scan envelope — written to temp file so jq reads content directly,
 # avoiding shell variable limits on large reports.
 POLICY_SCAN_ENV_TMP=$(mktemp)
 trap 'rm -f "$POLICY_SCAN_ENV_TMP"' EXIT
-build_envelope .signum/policy_scan.json > "$POLICY_SCAN_ENV_TMP"
+build_envelope "$POLICY_SCAN_PATH" > "$POLICY_SCAN_ENV_TMP"
 
 # Audit summary envelope
-AUDIT_ENV=$(build_envelope .signum/audit_summary.json)
+AUDIT_ENV=$(build_envelope "$AUDIT_SUMMARY_PATH")
 
 # Approval envelope
-APPROVAL_ENV=$(build_envelope .signum/approval.json)
+APPROVAL_ENV=$(build_envelope "$APPROVAL_PATH")
 
-# Dynamic reviews: enumerate .signum/reviews/*.json
+# Dynamic reviews: enumerate canonical reviews/*.json
 REVIEWS_JSON='{'
 first=1
-for review_file in .signum/reviews/*.json; do
+for review_file in "$REVIEWS_DIR"/*.json; do
   [ -f "$review_file" ] || continue
   provider=$(basename "$review_file" .json)
   env_json=$(build_envelope "$review_file")
@@ -3029,23 +3513,23 @@ if [ -n "$PREV_PROOFPACK" ] && [ -f "$PREV_PROOFPACK" ]; then
 fi
 
 # Extract contractId for lineage
-PACK_CONTRACT_ID=$(jq -r '.contractId // empty' .signum/contract.json)
+PACK_CONTRACT_ID=$(jq -r '.contractId // empty' "$CONTRACT_PATH")
 
 # Read iteration metadata for iterativeAudit section
-ITERATIONS_USED_PACK=$(jq -r '.iterationsUsed // 1' .signum/audit_summary.json 2>/dev/null || echo 1)
-BEST_ITERATION_PACK=$(jq -r '.bestIteration // 1' .signum/audit_summary.json 2>/dev/null || echo 1)
+ITERATIONS_USED_PACK=$(jq -r '.iterationsUsed // 1' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo 1)
+BEST_ITERATION_PACK=$(jq -r '.bestIteration // 1' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo 1)
 ITERATIVE_AUDIT_JSON="null"
-if [ "$ITERATIONS_USED_PACK" -gt 1 ] && [ -f .signum/audit_iteration_log.json ]; then
+if [ "$ITERATIONS_USED_PACK" -gt 1 ] && [ -f "$AUDIT_ITERATION_LOG_PATH" ]; then
   # Read audit_summary metadata fields required by iterativeAudit schema
-  PACK_ITERS_MAX=$(jq -r '.iterationsMax // 20' .signum/audit_summary.json 2>/dev/null || echo 20)
-  PACK_EARLY_STOP=$(jq -r '.earlyStop // false' .signum/audit_summary.json 2>/dev/null || echo false)
-  PACK_EARLY_STOP_REASON=$(jq -r '.earlyStopReason // ""' .signum/audit_summary.json 2>/dev/null || echo "")
-  PACK_TERMINAL_REASON=$(jq -r '.terminalReason // ""' .signum/audit_summary.json 2>/dev/null || echo "")
-  PACK_REMAINING_SEV=$(jq -r '.remainingSeverity // "none"' .signum/audit_summary.json 2>/dev/null || echo "none")
+  PACK_ITERS_MAX=$(jq -r '.iterationsMax // 20' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo 20)
+  PACK_EARLY_STOP=$(jq -r '.earlyStop // false' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo false)
+  PACK_EARLY_STOP_REASON=$(jq -r '.earlyStopReason // ""' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo "")
+  PACK_TERMINAL_REASON=$(jq -r '.terminalReason // ""' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo "")
+  PACK_REMAINING_SEV=$(jq -r '.remainingSeverity // "none"' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo "none")
   # Build resolvedFindings: findings present in pass 1 but absent in best pass (by fingerprint)
   # Use .pass field lookup instead of array index to handle sparse logs from skipped iterations
   PACK_RESOLVED=$(jq -n \
-    --argjson log "$(cat .signum/audit_iteration_log.json)" \
+    --argjson log "$(cat "$AUDIT_ITERATION_LOG_PATH")" \
     --argjson best "$BEST_ITERATION_PACK" \
     '($log[0].canonicalFindings // []) as $first |
      (($log[] | select(.pass == $best)).canonicalFindings // []) as $last |
@@ -3053,7 +3537,7 @@ if [ "$ITERATIONS_USED_PACK" -gt 1 ] && [ -f .signum/audit_iteration_log.json ];
      [$first[] | select((.fingerprint // (.file + ":" + (.line|tostring) + ":" + .category)) as $fp | $lastFps | index($fp) | not)]')
   # Build remainingFindings: findings present in the best pass
   # Use .pass field lookup instead of array index to handle sparse logs from skipped iterations
-  PACK_REMAINING=$(jq --argjson best "$BEST_ITERATION_PACK" '(.[].pass as $p | select($p == $best) | .canonicalFindings) // []' .signum/audit_iteration_log.json 2>/dev/null || echo "[]")
+  PACK_REMAINING=$(jq --argjson best "$BEST_ITERATION_PACK" '(.[].pass as $p | select($p == $best) | .canonicalFindings) // []' "$AUDIT_ITERATION_LOG_PATH" 2>/dev/null || echo "[]")
   ITERATIVE_AUDIT_JSON=$(jq -n \
     --argjson iters_used "$ITERATIONS_USED_PACK" \
     --argjson iters_max "$PACK_ITERS_MAX" \
@@ -3064,7 +3548,7 @@ if [ "$ITERATIONS_USED_PACK" -gt 1 ] && [ -f .signum/audit_iteration_log.json ];
     --arg remaining_sev "$PACK_REMAINING_SEV" \
     --argjson resolved "$PACK_RESOLVED" \
     --argjson remaining "$PACK_REMAINING" \
-    --argjson log "$(cat .signum/audit_iteration_log.json)" \
+    --argjson log "$(cat "$AUDIT_ITERATION_LOG_PATH")" \
     '{iterationsUsed: $iters_used, iterationsMax: $iters_max, bestIteration: $best,
       earlyStop: $early_stop, earlyStopReason: $early_stop_reason,
       terminalReason: $terminal_reason, remainingSeverity: $remaining_sev,
@@ -3130,7 +3614,7 @@ jq -n \
   | if $ciContext != null then . + {ciContext: $ciContext} else . end
   | if $baselineComp != null then . + {baselineComparison: $baselineComp} else . end
   | if $iterativeAuditJson != null then . + {iterativeAudit: $iterativeAuditJson} else . end
-  ' > .signum/proofpack.json
+  ' > "$PROOFPACK_PATH"
 
 # Cleanup temp files
 rm -f "$REDACTED_CONTRACT"
@@ -3139,9 +3623,9 @@ rm -f "$REDACTED_CONTRACT"
 if [ -f lib/pack-anti-entropy.sh ]; then
   bash lib/pack-anti-entropy.sh \
     --project-root . \
-    --contract .signum/contract.json \
-    --proofpack .signum/proofpack.json \
-    --output .signum/anti_entropy_report.json || true
+    --contract "$CONTRACT_PATH" \
+    --proofpack "$PROOFPACK_PATH" \
+    --output "$ANTI_ENTROPY_PATH" || true
 fi
 
 echo "Proofpack written: $RUN_ID (schema v4.6)"
@@ -3154,12 +3638,16 @@ Use the Bash tool to transition the contract to `completed`:
 ```bash
 if [ -f lib/contract-dir.sh ]; then
   source lib/contract-dir.sh
-  CONTRACT_ID=$(jq -r '.contractId // empty' .signum/contract.json)
+  ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+  CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+  EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"
+  RECEIPTS_EXEC_PATH="${ARTIFACT_ROOT}receipts/execute.json"
+  CONTRACT_ID=$(jq -r '.contractId // empty' "$CONTRACT_PATH")
   if [ -n "$CONTRACT_ID" ]; then
     update_contract_status "$CONTRACT_ID" "completed"
-    RUN_ID=$(jq -r '.run_id // empty' .signum/execution_context.json 2>/dev/null || true)
+    RUN_ID=$(jq -r '.run_id // empty' "$EXECUTION_CONTEXT_PATH" 2>/dev/null || true)
     if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-      RUN_ID=$(jq -r '.run_id // empty' .signum/receipts/execute.json 2>/dev/null || true)
+      RUN_ID=$(jq -r '.run_id // empty' "$RECEIPTS_EXEC_PATH" 2>/dev/null || true)
     fi
     # Sync durable artifacts for this completed contract.
     sync_contract_artifacts "$CONTRACT_ID" \
@@ -3192,13 +3680,18 @@ fi
 Use the Bash tool:
 
 ```bash
-OBLIGATIONS=$(jq -r '.cleanupObligations // [] | length' .signum/contract.json)
-DECISION=$(jq -r '.decision' .signum/audit_summary.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+
+OBLIGATIONS=$(jq -r '.cleanupObligations // [] | length' "$CONTRACT_PATH")
+DECISION=$(jq -r '.decision' "$AUDIT_SUMMARY_PATH")
 if [ "$OBLIGATIONS" -eq 0 ] || [ "$DECISION" != "AUTO_OK" ]; then
   echo "RECONCILE skipped (obligations=$OBLIGATIONS, decision=$DECISION)"
 else
   echo "RECONCILE: $OBLIGATIONS obligation(s) to resolve"
-  jq -r '.cleanupObligations[] | "  - [\(.action)] \(.target): \(.description)"' .signum/contract.json
+  jq -r '.cleanupObligations[] | "  - [\(.action)] \(.target): \(.description)"' "$CONTRACT_PATH"
 fi
 ```
 
@@ -3211,8 +3704,11 @@ Use the Agent tool to launch a general-purpose agent (model: sonnet) with this p
 ```
 You are the RECONCILE agent for Signum. Your job is to resolve cleanup obligations after a successful implementation.
 
-Read .signum/contract.json — the cleanupObligations array lists what needs to be done.
-Read .signum/proofpack.json — the summary field describes what was implemented.
+The canonical artifact root for the active contract is `.signum/contracts/<activeContractId>/`.
+If needed, use `.signum/contracts/index.json.activeContractId` to locate it.
+
+Read `contract.json` under that canonical artifact root — the `cleanupObligations` array lists what needs to be done.
+Read `proofpack.json` under that same canonical artifact root — the `summary` field describes what was implemented.
 
 For each obligation:
 
@@ -3227,7 +3723,7 @@ For each obligation:
 5. action=update_manifest: Read the target file and update lifecycle/status fields.
 
 After resolving each obligation, report what you did.
-Write a summary to .signum/reconcile_report.json:
+Write a summary to `reconcile_report.json` under the same canonical artifact root:
 {
   "obligations_total": N,
   "resolved": N,
@@ -3243,21 +3739,27 @@ Write a summary to .signum/reconcile_report.json:
 Use the Bash tool:
 
 ```bash
-if [ ! -f .signum/reconcile_report.json ]; then
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+CONTRACT_TMP_PATH="${CONTRACT_PATH%.json}-tmp.json"
+RECONCILE_REPORT_PATH="${ARTIFACT_ROOT}reconcile_report.json"
+
+if [ ! -f "$RECONCILE_REPORT_PATH" ]; then
   echo "WARNING: reconcile_report.json missing — RECONCILE agent may have failed"
 else
-  RESOLVED=$(jq '.resolved' .signum/reconcile_report.json)
-  TOTAL=$(jq '.obligations_total' .signum/reconcile_report.json)
-  SKIPPED=$(jq '.skipped' .signum/reconcile_report.json)
+  RESOLVED=$(jq '.resolved' "$RECONCILE_REPORT_PATH")
+  TOTAL=$(jq '.obligations_total' "$RECONCILE_REPORT_PATH")
+  SKIPPED=$(jq '.skipped' "$RECONCILE_REPORT_PATH")
   echo "RECONCILE: $RESOLVED/$TOTAL resolved, $SKIPPED skipped"
-  jq -r '.details[] | "  [\(.status)] \(.action) \(.target): \(.what_changed)"' .signum/reconcile_report.json
+  jq -r '.details[] | "  [\(.status)] \(.action) \(.target): \(.what_changed)"' "$RECONCILE_REPORT_PATH"
 
   # Update contract: mark resolved obligations
   RECONCILE_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   jq --arg ts "$RECONCILE_TS" \
     '(.cleanupObligations // []) |= [.[] | . + {resolvedAt: $ts}] | .timestamps.reconciledAt = $ts' \
-    .signum/contract.json > .signum/contract-tmp.json && \
-    mv .signum/contract-tmp.json .signum/contract.json
+    "$CONTRACT_PATH" > "$CONTRACT_TMP_PATH" && \
+    mv "$CONTRACT_TMP_PATH" "$CONTRACT_PATH"
 fi
 ```
 
@@ -3268,17 +3770,24 @@ fi
 Use the Bash tool:
 
 ```bash
-RISK=$(jq -r '.riskLevel' .signum/contract.json)
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"
+EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+RETRO_PATH="${ARTIFACT_ROOT}retro.json"
+
+RISK=$(jq -r '.riskLevel' "$CONTRACT_PATH")
 if [ "$RISK" = "low" ]; then
   echo "Retro skipped (low risk)"
 else
-  INSCOPE_COUNT=$(jq '.inScope | length' .signum/contract.json)
+  INSCOPE_COUNT=$(jq '.inScope | length' "$CONTRACT_PATH")
   CHANGED_COUNT=$(git diff --name-only | wc -l | tr -d ' ')
-  ATTEMPTS=$(jq -r '.totalAttempts // "?"' .signum/execute_log.json)
-  ITERATIONS=$(jq -r '.iterationsUsed // 1' .signum/audit_summary.json)
-  FINDINGS=$(jq '[.reviews[].findings[]?] | length' .signum/audit_summary.json 2>/dev/null || echo 0)
+  ATTEMPTS=$(jq -r '.totalAttempts // "?"' "$EXECUTE_LOG_PATH")
+  ITERATIONS=$(jq -r '.iterationsUsed // 1' "$AUDIT_SUMMARY_PATH")
+  FINDINGS=$(jq '[.reviews[].findings[]?] | length' "$AUDIT_SUMMARY_PATH" 2>/dev/null || echo 0)
 
-  cat > .signum/retro.json << RETRO
+  cat > "$RETRO_PATH" << RETRO
 {
   "estimated_files": $INSCOPE_COUNT,
   "actual_files": $CHANGED_COUNT,
@@ -3303,25 +3812,42 @@ Display to the user:
 Use the Bash tool to list all produced artifacts:
 
 ```bash
-echo "=== Artifacts in .signum/ ==="
-ls -1 .signum/ .signum/reviews/ 2>/dev/null
+source lib/contract-dir.sh 2>/dev/null || true
+ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"
+PROOFPACK_PATH="${ARTIFACT_ROOT}proofpack.json"
+AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"
+DIFF_PATH="${ARTIFACT_ROOT}combined.patch"
+ANTI_ENTROPY_PATH="${ARTIFACT_ROOT}anti_entropy_report.json"
+
+echo "=== Canonical artifact root ==="
+echo "$ARTIFACT_ROOT"
 echo ""
-echo "Decision:   $(jq -r .decision .signum/proofpack.json)"
-echo "Confidence: $(jq -r '.confidence.overall' .signum/proofpack.json)%"
-echo "Run ID:     $(jq -r .runId   .signum/proofpack.json)"
-if [ -f .signum/anti_entropy_report.json ]; then
-  echo "Anti-entropy: $(jq -r ' .status + " — " + .summary' .signum/anti_entropy_report.json 2>/dev/null || echo 'unknown')"
+echo "=== Artifacts ==="
+if [ -d "$ARTIFACT_ROOT" ]; then
+  (
+    cd "$ARTIFACT_ROOT" &&
+    find . -maxdepth 2 -mindepth 1 | sed 's#^\./##' | LC_ALL=C sort
+  )
+else
+  echo "WARNING: artifact root not found"
 fi
-if [ -f .signum/reconcile_report.json ]; then
-  echo "Reconcile: $(jq '.resolved' .signum/reconcile_report.json)/$(jq '.obligations_total' .signum/reconcile_report.json) obligations resolved"
+echo ""
+echo "Decision:   $(jq -r .decision "$PROOFPACK_PATH")"
+echo "Confidence: $(jq -r '.confidence.overall' "$PROOFPACK_PATH")%"
+echo "Run ID:     $(jq -r .runId "$PROOFPACK_PATH")"
+if [ -f "$ANTI_ENTROPY_PATH" ]; then
+  echo "Anti-entropy: $(jq -r ' .status + " — " + .summary' "$ANTI_ENTROPY_PATH" 2>/dev/null || echo 'unknown')"
+fi
+if [ -f "${ARTIFACT_ROOT}reconcile_report.json" ]; then
+  echo "Reconcile: $(jq '.resolved' "${ARTIFACT_ROOT}reconcile_report.json")/$(jq '.obligations_total' "${ARTIFACT_ROOT}reconcile_report.json") obligations resolved"
 fi
 ```
 
 Then display the appropriate next steps based on the decision:
 
-- **AUTO_OK**: "Changes are verified. Review `.signum/combined.patch` and commit when ready."
-- **AUTO_BLOCK**: "Issues found. Review `.signum/audit_summary.json` and fix before committing."
-- **HUMAN_REVIEW**: "Audit inconclusive. Review `.signum/audit_summary.json`, then either: (1) refine acceptance criteria and re-run `/signum`, or (2) manually verify the flagged findings."
+- **AUTO_OK**: "Changes are verified. Review `combined.patch` under the canonical artifact root shown above and commit when ready."
+- **AUTO_BLOCK**: "Issues found. Review `audit_summary.json` under the canonical artifact root shown above and fix before committing."
+- **HUMAN_REVIEW**: "Audit inconclusive. Review `audit_summary.json` under the canonical artifact root shown above, then either: (1) refine acceptance criteria and re-run `/signum`, or (2) manually verify the flagged findings."
 
 ---
 

--- a/platforms/claude-code/docs/how-it-works.md
+++ b/platforms/claude-code/docs/how-it-works.md
@@ -43,7 +43,7 @@ Risk is assessed structurally (file count, keywords, surface area). Holdout scen
 
 **Orchestrator:** captures baseline, launches Engineer, enforces scope gate.
 
-1. **Baseline capture**: orchestrator runs lint/typecheck/tests BEFORE any changes and saves exit codes to `.signum/baseline.json`. This is the trust anchor for regression detection.
+1. **Baseline capture**: orchestrator runs lint/typecheck/tests BEFORE any changes and saves exit codes to `baseline.json` under the active contract artifact root. This is the trust anchor for regression detection.
 2. **Engineer** (sonnet) implements against the contract with a 3-attempt repair loop.
 3. **Scope gate**: deterministic check that all modified files are within `inScope` or `allowNewFilesUnder`. Stops pipeline on violation.
 
@@ -134,7 +134,7 @@ If the CLI returns malformed output or a non-zero exit code, the provider is mar
 
 ## Artifacts
 
-Live working-set artifacts are written to `.signum/` (auto-added to `.gitignore`). Signum also mirrors durable per-contract snapshots into `.signum/contracts/<contractId>/` for history/archive flows. That per-contract directory is not the active workspace while a run is in flight.
+Canonical run artifacts live under the active contract artifact root `.signum/contracts/<contractId>/`. Root `.signum/` stays auto-added to `.gitignore` and now mainly holds registry/state surfaces plus compatibility views during the contract-dir migration. The contract, pre-execute metadata, execute outputs, selected audit/pack file artifacts (`contract.json`, `spec_quality.json`, `spec_validation.json`, `clover_report.json`, `intent_check.json`, `approval.json`, `contract-hash.txt`, `contract-engineer.json`, `contract-policy.json`, `execution_context.json`, `baseline.json`, `combined.patch`, `execute_log.json`, `iteration_delta.patch`, `mechanic_report.json`, `holdout_report.json`, `policy_violations.json`, `policy_scan.json`, `audit_iteration_log.json`, `repair_brief.json`, `flaky_tests.json`, `audit_summary.json`, `proofpack.json`, `anti_entropy_report.json`), and active run directories (`reviews/`, `iterations/`, `receipts/`, `runs/`, `snapshots/`) are canonical under that contract directory.
 
 | File | Phase | Description |
 |------|-------|-------------|
@@ -147,6 +147,7 @@ Live working-set artifacts are written to `.signum/` (auto-added to `.gitignore`
 | `reviews/*.json` | AUDIT | Per-provider findings (specialized templates) |
 | `audit_summary.json` | AUDIT | Verdict with confidence scores |
 | `proofpack.json` | PACK | Final CI-gate artifact |
+| `anti_entropy_report.json` | PACK | Advisory follow-up findings (report-only, non-blocking) |
 | `iterations/NN/` | AUDIT | Per-iteration snapshots (v4.6+, only when iterative) |
 | `audit_iteration_log.json` | AUDIT | Summary of all iterations (v4.6+) |
 | `repair_brief.json` | AUDIT | Current repair brief for engineer (v4.6+) |
@@ -159,6 +160,8 @@ Durable per-contract snapshots typically mirror:
 - `audit_summary.json`
 - `approval.json`
 - `execution_context.json`
+- `reviews/`
+- `iterations/`
 - `receipts/`
 - `runs/<runId>/`
 - `snapshots/`

--- a/platforms/claude-code/docs/plans/2026-03-04-self-contained-proofpack-plan.md
+++ b/platforms/claude-code/docs/plans/2026-03-04-self-contained-proofpack-plan.md
@@ -157,28 +157,41 @@ file_size() {
 }
 
 # Metadata
-DECISION=$(jq -r '.decision' .signum/audit_summary.json)
-GOAL=$(jq -r '.goal' .signum/contract.json)
-RISK=$(jq -r '.riskLevel' .signum/contract.json)
-ATTEMPTS=$(jq -r '.totalAttempts' .signum/execute_log.json 2>/dev/null || echo "unknown")
-MECHANIC=$(jq -r '.mechanic' .signum/audit_summary.json)
-CONFIDENCE=$(jq -r '.confidence.overall // 0' .signum/audit_summary.json)
+ARTIFACT_ROOT=".signum/contracts/<contractId>"
+CONTRACT_PATH="$ARTIFACT_ROOT/contract.json"
+AUDIT_SUMMARY_PATH="$ARTIFACT_ROOT/audit_summary.json"
+EXECUTE_LOG_PATH="$ARTIFACT_ROOT/execute_log.json"
+BASELINE_PATH="$ARTIFACT_ROOT/baseline.json"
+MECHANIC_REPORT_PATH="$ARTIFACT_ROOT/mechanic_report.json"
+HOLDOUT_REPORT_PATH="$ARTIFACT_ROOT/holdout_report.json"
+COMBINED_PATCH_PATH="$ARTIFACT_ROOT/combined.patch"
+CONTRACT_HASH_PATH="$ARTIFACT_ROOT/contract-hash.txt"
+EXECUTION_CONTEXT_PATH="$ARTIFACT_ROOT/execution_context.json"
+REVIEWS_DIR="$ARTIFACT_ROOT/reviews"
+PROOFPACK_PATH="$ARTIFACT_ROOT/proofpack.json"
+
+DECISION=$(jq -r '.decision' "$AUDIT_SUMMARY_PATH")
+GOAL=$(jq -r '.goal' "$CONTRACT_PATH")
+RISK=$(jq -r '.riskLevel' "$CONTRACT_PATH")
+ATTEMPTS=$(jq -r '.totalAttempts' "$EXECUTE_LOG_PATH" 2>/dev/null || echo "unknown")
+MECHANIC=$(jq -r '.mechanic' "$AUDIT_SUMMARY_PATH")
+CONFIDENCE=$(jq -r '.confidence.overall // 0' "$AUDIT_SUMMARY_PATH")
 RUN_DATE=$(date +%Y-%m-%d)
 RUN_RANDOM=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 6)
 RUN_ID="signum-${RUN_DATE}-${RUN_RANDOM}"
 CREATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # Audit chain
-CONTRACT_HASH=$(grep 'contract_sha256:' .signum/contract-hash.txt 2>/dev/null | awk '{print $2}' || echo "unavailable")
-APPROVED_AT=$(grep 'approved_at:' .signum/contract-hash.txt 2>/dev/null | awk '{print $2}' || echo "unavailable")
-BASE_COMMIT=$(jq -r '.base_commit // "unavailable"' .signum/execution_context.json 2>/dev/null || echo "unavailable")
+CONTRACT_HASH=$(grep 'contract_sha256:' "$CONTRACT_HASH_PATH" 2>/dev/null | awk '{print $2}' || echo "unavailable")
+APPROVED_AT=$(grep 'approved_at:' "$CONTRACT_HASH_PATH" 2>/dev/null | awk '{print $2}' || echo "unavailable")
+BASE_COMMIT=$(jq -r '.base_commit // "unavailable"' "$EXECUTION_CONTEXT_PATH" 2>/dev/null || echo "unavailable")
 
 # Contract: redact holdouts, compute both hashes
-FULL_CONTRACT_SHA=$(hash_file .signum/contract.json)
-FULL_CONTRACT_SIZE=$(file_size .signum/contract.json)
+FULL_CONTRACT_SHA=$(hash_file "$CONTRACT_PATH")
+FULL_CONTRACT_SIZE=$(file_size "$CONTRACT_PATH")
 python3 -c "
 import json, sys
-with open('.signum/contract.json') as f:
+with open('$CONTRACT_PATH') as f:
     c = json.load(f)
 c.pop('holdoutScenarios', None)
 json.dump(c, sys.stdout, indent=2)
@@ -186,8 +199,8 @@ json.dump(c, sys.stdout, indent=2)
 REDACTED_CONTRACT_SHA=$(hash_file /tmp/signum-contract-redacted.json)
 
 # Diff: embed if <100KB, otherwise omit-but-hash
-DIFF_SIZE=$(file_size .signum/combined.patch)
-DIFF_SHA=$(hash_file .signum/combined.patch)
+DIFF_SIZE=$(file_size "$COMBINED_PATCH_PATH")
+DIFF_SHA=$(hash_file "$COMBINED_PATCH_PATH")
 DIFF_THRESHOLD=102400
 if [ "$DIFF_SIZE" -le "$DIFF_THRESHOLD" ]; then
   DIFF_STATUS="present"
@@ -220,7 +233,7 @@ ENV_CONTRACT=$(jq -n \
   '{content: $content, sha256: $sha, fullSha256: $fullSha, sizeBytes: $size, status: "present"}')
 
 if [ "$DIFF_STATUS" = "present" ]; then
-  DIFF_CONTENT=$(jq -Rs '.' .signum/combined.patch)
+  DIFF_CONTENT=$(jq -Rs '.' "$COMBINED_PATCH_PATH")
   ENV_DIFF=$(jq -n --argjson content "$DIFF_CONTENT" --arg sha "$DIFF_SHA" --argjson size "$DIFF_SIZE" \
     '{content: $content, sha256: $sha, sizeBytes: $size, status: "present"}')
 else
@@ -228,22 +241,22 @@ else
     '{content: null, sha256: $sha, sizeBytes: $size, status: "omitted", omitReason: $reason}')
 fi
 
-ENV_BASELINE=$(build_envelope .signum/baseline.json)
-ENV_EXEC_LOG=$(build_envelope .signum/execute_log.json)
-ENV_MECHANIC=$(build_envelope .signum/mechanic_report.json)
-ENV_AUDIT=$(build_envelope .signum/audit_summary.json)
+ENV_BASELINE=$(build_envelope "$BASELINE_PATH")
+ENV_EXEC_LOG=$(build_envelope "$EXECUTE_LOG_PATH")
+ENV_MECHANIC=$(build_envelope "$MECHANIC_REPORT_PATH")
+ENV_AUDIT=$(build_envelope "$AUDIT_SUMMARY_PATH")
 
 # Holdout report (optional)
-if [ -f .signum/holdout_report.json ]; then
-  ENV_HOLDOUT=$(build_envelope .signum/holdout_report.json)
+if [ -f "$HOLDOUT_REPORT_PATH" ]; then
+  ENV_HOLDOUT=$(build_envelope "$HOLDOUT_REPORT_PATH")
 else
   ENV_HOLDOUT=$(jq -n '{content: null, sha256: null, sizeBytes: 0, status: "omitted", omitReason: "no holdout scenarios"}')
 fi
 
-# Reviews (dynamic — enumerate .signum/reviews/)
+# Reviews (dynamic — enumerate $REVIEWS_DIR)
 REVIEWS_JSON="{}"
-if [ -d .signum/reviews ]; then
-  for REVIEW_FILE in .signum/reviews/*.json; do
+if [ -d "$REVIEWS_DIR" ]; then
+  for REVIEW_FILE in "$REVIEWS_DIR"/*.json; do
     [ -f "$REVIEW_FILE" ] || continue
     PROVIDER=$(basename "$REVIEW_FILE" .json)
     ENV=$(build_envelope "$REVIEW_FILE")
@@ -294,10 +307,10 @@ jq -n \
       reviews: $reviews,
       auditSummary: $auditSummary
     }
-  }' > .signum/proofpack.json
+  }' > "$PROOFPACK_PATH"
 
 rm -f /tmp/signum-contract-redacted.json
-echo "Proofpack v4.0 written: $RUN_ID ($(file_size .signum/proofpack.json) bytes)"
+echo "Proofpack v4.0 written: $RUN_ID ($(file_size "$PROOFPACK_PATH") bytes)"
 ```
 ````
 
@@ -475,27 +488,28 @@ Create a minimal test to verify the bash envelope builder works:
 
 ```bash
 cd /Users/vi/personal/skill7/devtools/signum
-mkdir -p /tmp/signum-test/.signum/reviews
-echo '{"goal":"test","riskLevel":"low"}' > /tmp/signum-test/.signum/contract.json
-echo 'diff content' > /tmp/signum-test/.signum/combined.patch
-echo '{"lint":0,"typecheck":0}' > /tmp/signum-test/.signum/baseline.json
-echo '{"totalAttempts":1}' > /tmp/signum-test/.signum/execute_log.json
-echo '{"mechanic":"pass","decision":"AUTO_OK","confidence":{"overall":90}}' > /tmp/signum-test/.signum/audit_summary.json
-echo '{"passed":0,"failed":0}' > /tmp/signum-test/.signum/mechanic_report.json
-echo '{"verdict":"APPROVE","findings":[],"summary":"ok"}' > /tmp/signum-test/.signum/reviews/claude.json
-echo 'contract_sha256: abc123' > /tmp/signum-test/.signum/contract-hash.txt
-echo 'approved_at: 2026-03-04T10:00:00Z' >> /tmp/signum-test/.signum/contract-hash.txt
-echo '{"base_commit":"def456"}' > /tmp/signum-test/.signum/execution_context.json
+ARTIFACT_ROOT=/tmp/signum-test/.signum/contracts/sig-test
+mkdir -p "$ARTIFACT_ROOT/reviews"
+echo '{"goal":"test","riskLevel":"low"}' > "$ARTIFACT_ROOT/contract.json"
+echo 'diff content' > "$ARTIFACT_ROOT/combined.patch"
+echo '{"lint":0,"typecheck":0}' > "$ARTIFACT_ROOT/baseline.json"
+echo '{"totalAttempts":1}' > "$ARTIFACT_ROOT/execute_log.json"
+echo '{"mechanic":"pass","decision":"AUTO_OK","confidence":{"overall":90}}' > "$ARTIFACT_ROOT/audit_summary.json"
+echo '{"passed":0,"failed":0}' > "$ARTIFACT_ROOT/mechanic_report.json"
+echo '{"verdict":"APPROVE","findings":[],"summary":"ok"}' > "$ARTIFACT_ROOT/reviews/claude.json"
+echo 'contract_sha256: abc123' > "$ARTIFACT_ROOT/contract-hash.txt"
+echo 'approved_at: 2026-03-04T10:00:00Z' >> "$ARTIFACT_ROOT/contract-hash.txt"
+echo '{"base_commit":"def456"}' > "$ARTIFACT_ROOT/execution_context.json"
 
 # Verify the generated proofpack has expected structure
 cd /tmp/signum-test
 # (paste the Phase 4 bash script and run it)
 # Then verify:
-jq '.schemaVersion' .signum/proofpack.json  # should be "4.0"
-jq '.contract.status' .signum/proofpack.json  # should be "present"
-jq '.contract.fullSha256' .signum/proofpack.json  # should be non-null
-jq '.diff.status' .signum/proofpack.json  # should be "present" (small diff)
-jq '.checks.reviews | keys' .signum/proofpack.json  # should be ["claude"]
+jq '.schemaVersion' "$ARTIFACT_ROOT/proofpack.json"  # should be "4.0"
+jq '.contract.status' "$ARTIFACT_ROOT/proofpack.json"  # should be "present"
+jq '.contract.fullSha256' "$ARTIFACT_ROOT/proofpack.json"  # should be non-null
+jq '.diff.status' "$ARTIFACT_ROOT/proofpack.json"  # should be "present" (small diff)
+jq '.checks.reviews | keys' "$ARTIFACT_ROOT/proofpack.json"  # should be ["claude"]
 rm -rf /tmp/signum-test
 ```
 

--- a/platforms/claude-code/docs/reference.md
+++ b/platforms/claude-code/docs/reference.md
@@ -47,7 +47,7 @@ Estimated cost: ~$0.50-1.00.
 
 # Reopen and run the same command
 /signum refactor the payment module
-# Signum detects .signum/contract.json and asks: resume from Phase 2, or restart?
+# Signum checks contracts/index.json first and asks: resume from Phase 2, or restart?
 ```
 
 ## Pipeline Phases
@@ -58,17 +58,17 @@ CONTRACT → EXECUTE → AUDIT → PACK
 
 ### Phase 1: CONTRACT
 
-Contractor agent (haiku) scans the codebase and produces `.signum/contract.json` — a structured specification with goal, scope, acceptance criteria, holdout scenarios, and risk assessment.
+Contractor agent (haiku) scans the codebase and produces `contract.json` under the active contract artifact root (`.signum/contracts/<contractId>/`) — a structured specification with goal, scope, acceptance criteria, holdout scenarios, and risk assessment.
 
 Hard stop if `openQuestions` is non-empty — the user must answer before proceeding.
 
 ### Phase 2: EXECUTE
 
-1. **Baseline capture** — orchestrator runs lint/typecheck/tests BEFORE any changes, saves to `.signum/baseline.json`.
+1. **Baseline capture** — orchestrator runs lint/typecheck/tests BEFORE any changes, saves `baseline.json` under the active contract artifact root.
 2. **Engineer agent** (sonnet) implements the contract. Repair loop: up to 3 attempts of implement → check acceptance criteria → fix failures.
 3. **Scope gate** — deterministic check that all modified files are within `inScope` or `allowNewFilesUnder`. Pipeline stops on scope violation.
 
-Outputs: `.signum/baseline.json`, `.signum/combined.patch`, `.signum/execute_log.json`.
+Outputs: `baseline.json`, `combined.patch`, `execute_log.json` under the active contract artifact root.
 
 ### Phase 3: AUDIT
 
@@ -89,11 +89,11 @@ Pre-existing failures (checks that failed in baseline AND still fail) no longer 
 
 ### Phase 4: PACK
 
-Assembles `.signum/proofpack.json` — self-contained evidence bundle with embedded artifact contents, SHA-256 checksums, and confidence score.
+Assembles `proofpack.json` under the active contract artifact root — self-contained evidence bundle with embedded artifact contents, SHA-256 checksums, and confidence score.
 
 ## Artifacts
 
-Live working-set artifacts are written to `.signum/` (auto-added to `.gitignore`). Durable per-contract snapshots are mirrored under `.signum/contracts/<contractId>/` for history/archive flows. The per-contract directory is not the active workspace for an in-flight run.
+Canonical run artifacts live under the active contract artifact root `.signum/contracts/<contractId>/`. Root `.signum/` stays auto-added to `.gitignore` and now mainly holds registry/state surfaces plus compatibility views during the contract-dir migration.
 
 | File | Phase | Contents |
 |------|-------|----------|
@@ -109,7 +109,7 @@ Live working-set artifacts are written to `.signum/` (auto-added to `.gitignore`
 | `audit_summary.json` | Audit | Synthesized decision with consensus reasoning and confidence scores |
 | `proofpack.json` | Pack | Self-contained evidence bundle with embedded artifacts, checksums, and confidence |
 
-Durable per-contract snapshots typically mirror:
+Canonical contract directories typically contain:
 - `contract.json`
 - `proofpack.json`
 - `audit_summary.json`
@@ -249,7 +249,7 @@ When AUDIT finds MAJOR or CRITICAL issues, it enters an iterative repair loop:
 | `SIGNUM_AUDIT_MAX_ITERATIONS` | `20` | Maximum audit fix iterations before terminal decision |
 | `SIGNUM_CI_RELAXED` | `false` | If `"true"`, HUMAN_REVIEW maps to exit 0 instead of 78 |
 
-Iteration artifacts are stored in `.signum/iterations/01/`, `.signum/iterations/02/`, etc. Each contains the full set of audit artifacts for that pass.
+Iteration artifacts are stored under the active contract artifact root, for example `.signum/contracts/<contractId>/iterations/01/`, `.signum/contracts/<contractId>/iterations/02/`, etc. Each contains the full set of audit artifacts for that pass.
 
 The proofpack includes an `iterativeAudit` section when >1 iteration was used, with per-iteration summaries, resolved/remaining findings, and the best iteration number.
 
@@ -348,11 +348,11 @@ Signum continues without the provider if auth fails.
 
 ### Provider timeout
 
-External providers are killed after 180 seconds. The review continues with remaining providers. Check `.signum/reviews/` for provider status.
+External providers are killed after 180 seconds. The review continues with remaining providers. Check `reviews/` under the active contract artifact root for provider status.
 
 ### `.signum/` exists from previous run
 
-Normal behavior. Signum detects existing `contract.json` and offers:
+Normal behavior. Signum detects an existing active contract through `contracts/index.json.activeContractId` and offers:
 - **Resume**: continue from Phase 2
 - **Restart**: clear artifacts, start fresh
 

--- a/platforms/claude-code/lib/contract-dir.sh
+++ b/platforms/claude-code/lib/contract-dir.sh
@@ -1,10 +1,85 @@
 #!/usr/bin/env bash
 # contract-dir.sh — per-contract directory management for Signum
-# Functions: contract_dir, init_contract_dir, sync_contract_artifacts,
-#            register_contract, update_contract_status,
-#            get_active_contract, current_contract_dir
+# Functions: new_contract_id, contract_dir, init_contract_dir,
+#            sync_contract_artifacts, register_contract, set_active_contract,
+#            clear_active_contract, update_contract_status,
+#            get_active_contract, get_contract_status,
+#            describe_active_contract_state,
+#            active_artifact_root, active_artifact_path,
+#            link_active_artifact, ensure_active_artifact_dir,
+#            remove_root_artifact_view, archive_contract_artifacts,
+#            purge_root_working_set_views, reset_active_artifact,
+#            promote_root_artifact_to_active, current_contract_dir
 #
 # Requires: jq, bash 4.0+, standard POSIX utils
+
+# _random_hex4
+# Returns 4 lowercase hex chars.
+_random_hex4() {
+  if command -v od >/dev/null 2>&1; then
+    od -An -N2 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n'
+  else
+    printf '%04x' "$((RANDOM % 65536))"
+  fi
+}
+
+# new_contract_id
+# Returns a canonical contract id for a new run.
+new_contract_id() {
+  printf 'sig-%s-%s\n' "$(date -u +%Y%m%d-%H%M)" "$(_random_hex4)"
+}
+
+# _relative_path <target> <from_dir>
+# Returns a relative path from from_dir to target.
+_relative_path() {
+  local target="${1:-}"
+  local from_dir="${2:-}"
+  if [[ -z "$target" || -z "$from_dir" ]]; then
+    echo "_relative_path: target and from_dir required" >&2
+    return 1
+  fi
+  python3 - "$target" "$from_dir" <<'PY'
+import os
+import sys
+
+target = sys.argv[1]
+from_dir = sys.argv[2]
+print(os.path.relpath(target, from_dir))
+PY
+}
+
+# _realpath_or_self <path>
+# Returns the normalized absolute path, resolving symlinks where possible.
+_realpath_or_self() {
+  local path="${1:-}"
+  if [[ -z "$path" ]]; then
+    echo "_realpath_or_self: path required" >&2
+    return 1
+  fi
+  python3 - "$path" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))
+PY
+}
+
+# _remove_artifact_path <path>
+# Removes a file, symlink, or directory path without following symlinked dirs.
+_remove_artifact_path() {
+  local path="${1:-}"
+  if [[ -z "$path" ]]; then
+    echo "_remove_artifact_path: path required" >&2
+    return 1
+  fi
+  if [[ -L "$path" ]]; then
+    rm -f "$path"
+  elif [[ -d "$path" ]]; then
+    rm -rf "$path"
+  elif [[ -e "$path" ]]; then
+    rm -f "$path"
+  fi
+}
 
 # contract_dir <contractId>
 # Returns the path for a contract's isolated directory.
@@ -31,7 +106,7 @@ init_contract_dir() {
     return 1
   fi
   local dir
-  dir=$(contract_dir "$contract_id")
+  dir=$(contract_dir "$contract_id") || return 1
   mkdir -p "${dir}"
   echo "Initialized contract directory: ${dir}"
 }
@@ -52,10 +127,10 @@ sync_contract_artifacts() {
   fi
 
   local dir
-  dir=$(contract_dir "$contract_id")
+  dir=$(contract_dir "$contract_id") || return 1
   mkdir -p "$dir"
 
-  local rel src dst copied=0
+  local rel src dst src_real dst_real copied=0
   for rel in "$@"; do
     if [[ -z "$rel" ]]; then
       continue
@@ -65,6 +140,11 @@ sync_contract_artifacts() {
       continue
     fi
     dst="${dir}${rel}"
+    src_real=$(_realpath_or_self "$src")
+    dst_real=$(_realpath_or_self "$dst")
+    if [[ "$src_real" == "$dst_real" ]]; then
+      continue
+    fi
     if [[ -d "$src" ]]; then
       mkdir -p "$dst"
       cp -R "$src"/. "$dst"/
@@ -90,7 +170,7 @@ _ensure_index() {
 
 # register_contract <contractId> <contract_status>
 # Adds or updates an entry in .signum/contracts/index.json.
-# Sets activeContractId to this contract.
+# Does not change activeContractId; callers must set that explicitly.
 register_contract() {
   local contract_id="${1:-}"
   local contract_status="${2:-draft}"
@@ -116,7 +196,7 @@ register_contract() {
     assumptions_arg=$(jq -c '[(.assumptions // [])[] | .text // .]' "$contract_file" 2>/dev/null || echo '[]')
   fi
 
-  # Add or update entry; also set activeContractId
+  # Add or update entry
   jq --arg id "$contract_id" \
      --arg st "$contract_status" \
      --arg dir "$dir" \
@@ -125,7 +205,6 @@ register_contract() {
      --argjson inscope "${inscope_arg:-[]}" \
      --argjson assumptions "${assumptions_arg:-[]}" \
      '
-     .activeContractId = $id |
      if any(.contracts[]; .contractId == $id) then
        .contracts = [.contracts[] |
          if .contractId == $id then
@@ -137,6 +216,69 @@ register_contract() {
      ' "$index" > "${index}.tmp" && mv "${index}.tmp" "$index"
 
   echo "Registered contract ${contract_id} (status=${contract_status}) in ${index}"
+}
+
+# set_active_contract <contractId>
+# Updates activeContractId for an already-registered contract.
+set_active_contract() {
+  local contract_id="${1:-}"
+  if [[ -z "$contract_id" ]]; then
+    echo "set_active_contract: contractId required" >&2
+    return 1
+  fi
+
+  _ensure_index
+
+  local index=".signum/contracts/index.json"
+  local exists
+  exists=$(jq --arg id "$contract_id" 'any(.contracts[]; .contractId == $id)' "$index")
+  if [[ "$exists" != "true" ]]; then
+    echo "set_active_contract: contractId '${contract_id}' not found in index" >&2
+    return 1
+  fi
+
+  jq --arg id "$contract_id" '.activeContractId = $id' \
+    "$index" > "${index}.tmp" && mv "${index}.tmp" "$index"
+
+  echo "Set active contract to ${contract_id}"
+}
+
+# clear_active_contract
+# Clears activeContractId in index.json.
+clear_active_contract() {
+  _ensure_index
+
+  local index=".signum/contracts/index.json"
+  jq '.activeContractId = null' \
+    "$index" > "${index}.tmp" && mv "${index}.tmp" "$index"
+
+  echo "Cleared active contract"
+}
+
+# _is_terminal_status <status>
+# Returns success for statuses that must not remain active.
+_is_terminal_status() {
+  case "${1:-}" in
+    completed|archived|closed|superseded)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# _is_resumable_status <status>
+# Returns success for statuses that may remain active/resumable.
+_is_resumable_status() {
+  case "${1:-}" in
+    draft|active|approved|executing|auditing|human_review|blocked)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 # update_contract_status <contractId> <newStatus>
@@ -168,6 +310,12 @@ update_contract_status() {
        if .contractId == $id then . + {status: $st} else . end]' \
      "$index" > "${index}.tmp" && mv "${index}.tmp" "$index"
 
+  local active
+  active=$(jq -r '.activeContractId // empty' "$index")
+  if [[ "$active" == "$contract_id" ]] && _is_terminal_status "$new_status"; then
+    clear_active_contract >/dev/null
+  fi
+
   echo "Updated contract ${contract_id} status to ${new_status}"
 }
 
@@ -182,14 +330,324 @@ get_active_contract() {
   jq -r '.activeContractId // empty' "$index"
 }
 
-# current_contract_dir
-# Returns the directory path for the currently active contract.
-current_contract_dir() {
+# get_contract_status <contractId>
+# Reads and returns the status for a contract in index.json.
+get_contract_status() {
+  local contract_id="${1:-}"
+  if [[ -z "$contract_id" ]]; then
+    echo "get_contract_status: contractId required" >&2
+    return 1
+  fi
+
+  local index=".signum/contracts/index.json"
+  if [[ ! -f "$index" ]]; then
+    echo "get_contract_status: index.json not found" >&2
+    return 1
+  fi
+
+  local status
+  status=$(jq -r --arg id "$contract_id" '.contracts[] | select(.contractId == $id) | .status // empty' "$index")
+  if [[ -z "$status" ]]; then
+    echo "get_contract_status: contractId '${contract_id}' not found in index" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$status"
+}
+
+# describe_active_contract_state
+# Emits JSON describing the current active/resumable contract state.
+describe_active_contract_state() {
+  local state="NONE"
+  local active=""
+  local status=""
+  local root=""
+
+  active=$(get_active_contract 2>/dev/null || true)
+  if [[ -n "$active" ]]; then
+    status=$(get_contract_status "$active" 2>/dev/null || true)
+    root=$(contract_dir "$active" 2>/dev/null || true)
+
+    if [[ -z "$root" ]]; then
+      clear_active_contract >/dev/null 2>&1 || true
+      active=""
+      status=""
+    elif [[ -n "$status" ]] && ! _is_resumable_status "$status"; then
+      clear_active_contract >/dev/null 2>&1 || true
+      active=""
+      status=""
+      root=""
+    elif [[ -f "${root}contract.json" && -f "${root}execution_context.json" ]]; then
+      state="RESUMABLE"
+    elif [[ -f "${root}contract.json" ]]; then
+      state="CONTRACT_ONLY"
+    else
+      clear_active_contract >/dev/null 2>&1 || true
+      active=""
+      status=""
+      root=""
+    fi
+  fi
+
+  jq -n \
+    --arg state "$state" \
+    --arg contract_id "$active" \
+    --arg status "$status" \
+    --arg artifact_root "$root" \
+    '{
+      state: $state,
+      contractId: (if $contract_id == "" then null else $contract_id end),
+      status: (if $status == "" then null else $status end),
+      artifactRoot: (if $artifact_root == "" then null else $artifact_root end)
+    }'
+}
+
+# active_artifact_root
+# Returns the canonical artifact root for the currently active contract.
+active_artifact_root() {
   local active
   active=$(get_active_contract)
   if [[ -z "$active" ]]; then
-    echo "current_contract_dir: no active contract in index.json" >&2
+    echo "active_artifact_root: no active contract in index.json" >&2
     return 1
   fi
   contract_dir "$active"
+}
+
+# active_artifact_path <relative_path>
+# Returns the path for an artifact under the active contract root.
+active_artifact_path() {
+  local rel="${1:-}"
+  if [[ -z "$rel" ]]; then
+    echo "active_artifact_path: relative path required" >&2
+    return 1
+  fi
+  local root
+  root=$(active_artifact_root) || return 1
+  printf '%s%s\n' "$root" "$rel"
+}
+
+# remove_root_artifact_view <relative_path>
+# Removes only the root .signum/ compatibility view for an artifact.
+remove_root_artifact_view() {
+  local rel="${1:-}"
+  if [[ -z "$rel" ]]; then
+    echo "remove_root_artifact_view: relative path required" >&2
+    return 1
+  fi
+
+  local root_path=".signum/${rel}"
+  _remove_artifact_path "$root_path"
+
+  echo "Removed root artifact view: ${root_path}"
+}
+
+# archive_contract_artifacts <contractId> <archive_dir>
+# Copies archive-worthy canonical artifacts for a contract into archive_dir.
+archive_contract_artifacts() {
+  local contract_id="${1:-}"
+  local archive_dir="${2:-}"
+  if [[ -z "$contract_id" || -z "$archive_dir" ]]; then
+    echo "archive_contract_artifacts: contractId and archive_dir required" >&2
+    return 1
+  fi
+
+  local dir
+  dir=$(contract_dir "$contract_id") || return 1
+  if [[ ! -d "$dir" ]]; then
+    echo "archive_contract_artifacts: contract directory not found: ${dir}" >&2
+    return 1
+  fi
+
+  mkdir -p "$archive_dir"
+
+  local rel copied=0
+  for rel in \
+    contract.json \
+    proofpack.json \
+    approval.json \
+    audit_summary.json \
+    anti_entropy_report.json \
+    execution_context.json \
+    reconcile_report.json \
+    retro.json; do
+    if [[ -f "${dir}${rel}" ]]; then
+      cp "${dir}${rel}" "$archive_dir/"
+      copied=$((copied + 1))
+    fi
+  done
+
+  for rel in receipts runs snapshots; do
+    if [[ -d "${dir}${rel}" ]]; then
+      mkdir -p "${archive_dir}/${rel}"
+      cp -R "${dir}${rel}/." "${archive_dir}/${rel}/"
+      copied=$((copied + 1))
+    fi
+  done
+
+  echo "Archived ${copied} contract artifact(s) from ${dir} to ${archive_dir}"
+}
+
+# purge_root_working_set_views
+# Removes the root .signum/ compatibility surface for the active working set.
+purge_root_working_set_views() {
+  local rel
+  for rel in \
+    contract.json \
+    contract-engineer.json \
+    contract-policy.json \
+    execute_log.json \
+    combined.patch \
+    iteration_delta.patch \
+    baseline.json \
+    mechanic_report.json \
+    holdout_report.json \
+    audit_summary.json \
+    proofpack.json \
+    approval.json \
+    anti_entropy_report.json \
+    policy_violations.json \
+    policy_scan.json \
+    spec_quality.json \
+    spec_validation.json \
+    repo_contract_baseline.json \
+    repo_contract_violations.json \
+    contract-hash.txt \
+    execution_context.json \
+    review_prompt_codex.txt \
+    review_prompt_gemini.txt \
+    review_context.json \
+    clover_report.json \
+    intent_check.json \
+    audit_iteration_log.json \
+    repair_brief.json \
+    flaky_tests.json \
+    reconcile_report.json \
+    retro.json; do
+    remove_root_artifact_view "$rel" >/dev/null 2>&1 || true
+  done
+
+  for rel in reviews iterations receipts runs snapshots; do
+    remove_root_artifact_view "$rel" >/dev/null 2>&1 || true
+  done
+
+  echo "Purged root working set views"
+}
+
+# link_active_artifact <relative_path>
+# Creates a compatibility symlink in root .signum/ that points at the active contract artifact.
+link_active_artifact() {
+  local rel="${1:-}"
+  if [[ -z "$rel" ]]; then
+    echo "link_active_artifact: relative path required" >&2
+    return 1
+  fi
+
+  local root_path=".signum/${rel}"
+  local active_path
+  active_path=$(active_artifact_path "$rel") || return 1
+
+  mkdir -p "$(dirname "$root_path")" "$(dirname "$active_path")"
+
+  if [[ -e "$root_path" || -L "$root_path" ]]; then
+    remove_root_artifact_view "$rel" >/dev/null
+  fi
+
+  local link_target
+  link_target=$(_relative_path "$active_path" "$(dirname "$root_path")")
+  ln -s "$link_target" "$root_path"
+
+  echo "Linked ${root_path} -> ${active_path}"
+}
+
+# ensure_active_artifact_dir <relative_path>
+# Ensures a canonical directory exists in the active contract root and exposes
+# it through a root compatibility symlink.
+ensure_active_artifact_dir() {
+  local rel="${1:-}"
+  if [[ -z "$rel" ]]; then
+    echo "ensure_active_artifact_dir: relative path required" >&2
+    return 1
+  fi
+
+  local active_path
+  active_path=$(active_artifact_path "$rel") || return 1
+  mkdir -p "$active_path"
+  link_active_artifact "$rel" >/dev/null
+
+  echo "Ensured active artifact dir: ${active_path}"
+}
+
+# reset_active_artifact <relative_path> [file|dir]
+# Clears both the root compatibility path and the canonical active artifact,
+# then recreates the compatibility link for the requested kind.
+reset_active_artifact() {
+  local rel="${1:-}"
+  local kind="${2:-file}"
+  if [[ -z "$rel" ]]; then
+    echo "reset_active_artifact: relative path required" >&2
+    return 1
+  fi
+
+  local active_path
+  active_path=$(active_artifact_path "$rel") || return 1
+
+  remove_root_artifact_view "$rel" >/dev/null
+  _remove_artifact_path "$active_path"
+
+  case "$kind" in
+    file)
+      link_active_artifact "$rel" >/dev/null
+      ;;
+    dir)
+      ensure_active_artifact_dir "$rel" >/dev/null
+      ;;
+    *)
+      echo "reset_active_artifact: kind must be file or dir" >&2
+      return 1
+      ;;
+  esac
+
+  echo "Reset active artifact: ${active_path} (${kind})"
+}
+
+# promote_root_artifact_to_active <relative_path>
+# Moves an existing root .signum artifact into the active contract dir, then
+# recreates the root path as a compatibility symlink to the canonical location.
+promote_root_artifact_to_active() {
+  local rel="${1:-}"
+  if [[ -z "$rel" ]]; then
+    echo "promote_root_artifact_to_active: relative path required" >&2
+    return 1
+  fi
+
+  local root_path=".signum/${rel}"
+  local active_path
+  active_path=$(active_artifact_path "$rel") || return 1
+
+  mkdir -p "$(dirname "$root_path")" "$(dirname "$active_path")"
+
+  if [[ -L "$root_path" ]]; then
+    rm -f "$root_path"
+  elif [[ -d "$root_path" ]]; then
+    mkdir -p "$active_path"
+    cp -R "$root_path"/. "$active_path"/
+    rm -rf "$root_path"
+  elif [[ -e "$root_path" ]]; then
+    if [[ -e "$active_path" ]]; then
+      cp -f "$root_path" "$active_path"
+      rm -f "$root_path"
+    else
+      mv "$root_path" "$active_path"
+    fi
+  fi
+
+  link_active_artifact "$rel" >/dev/null
+  echo "Promoted ${root_path} -> ${active_path}"
+}
+
+# current_contract_dir
+# Backward-compatible alias for active_artifact_root.
+current_contract_dir() {
+  active_artifact_root
 }

--- a/platforms/claude-code/lib/mechanic-parser.sh
+++ b/platforms/claude-code/lib/mechanic-parser.sh
@@ -5,18 +5,26 @@
 # Structured JSON output for ruff (--output-format json) and eslint (-f json).
 # Parseable text patterns for pytest/cargo test (origin:stable_text).
 # Usage: mechanic-parser.sh <baseline_json_path>
-# Output: .signum/mechanic_report.json
+# Output: <baseline_dir>/mechanic_report.json
 # Exit 0: report written (checks may have regressions — that is not a fatal error)
 # Exit 1: fatal error (missing jq, missing baseline file)
 
 set -uo pipefail
 
 BASELINE_FILE="${1:-}"
+OUTPUT_DIR=""
+MECHANIC_REPORT_PATH=""
+FLAKY_TESTS_PATH=""
 
 if [ -z "$BASELINE_FILE" ]; then
   echo "Usage: mechanic-parser.sh <baseline_json_path>" >&2
   exit 1
 fi
+
+OUTPUT_DIR=$(dirname "$BASELINE_FILE")
+[ -n "$OUTPUT_DIR" ] || OUTPUT_DIR="."
+MECHANIC_REPORT_PATH="${OUTPUT_DIR}/mechanic_report.json"
+FLAKY_TESTS_PATH="${OUTPUT_DIR}/flaky_tests.json"
 
 if ! command -v jq > /dev/null 2>&1; then
   echo "ERROR: jq not found" >&2
@@ -28,7 +36,7 @@ if [ ! -f "$BASELINE_FILE" ]; then
   exit 1
 fi
 
-mkdir -p .signum
+mkdir -p "$OUTPUT_DIR"
 
 # ---------------------------------------------------------------------------
 # Read baseline exit codes
@@ -183,7 +191,7 @@ if [ -f "pyproject.toml" ] && grep -q "pytest" pyproject.toml 2>/dev/null; then
   # Persist flaky tests
   jq -n --argjson flaky "$FLAKY_TESTS" \
     '{"detectedAt": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'", "flakyTests": $flaky}' \
-    > .signum/flaky_tests.json
+    > "$FLAKY_TESTS_PATH"
   if [ "$(echo "$FLAKY_TESTS" | jq 'length')" -gt 0 ]; then
     echo "Flaky tests detected (removed from NEW_FAILURES): $(echo "$FLAKY_TESTS" | jq -r '.[]' | tr '\n' ' ')"
   fi
@@ -394,6 +402,6 @@ jq -n \
                  regression: (if ($new_failures | length) > 0 then true
                               elif $bl_test == 0 and $test_exit != 0 then true
                               else false end) }
-  }' > .signum/mechanic_report.json
+  }' > "$MECHANIC_REPORT_PATH"
 
 echo "Mechanic done. Lint=${LINT_ID}:${LINT_EXIT}(bl:${BL_LINT}) Typecheck=${TYPE_ID}:${TYPE_EXIT}(bl:${BL_TYPE}) Tests=${TEST_ID}:${TEST_EXIT}(bl:${BL_TEST})"

--- a/platforms/claude-code/lib/policy-scanner.sh
+++ b/platforms/claude-code/lib/policy-scanner.sh
@@ -2,18 +2,24 @@
 # policy-scanner.sh -- deterministic policy scan on combined.patch (zero LLM cost)
 # Scans only addition lines (+) in the patch for security, unsafe, and dependency patterns.
 # Usage: policy-scanner.sh <patch_file>
-# Output: .signum/policy_scan.json
+# Output: <patch_dir>/policy_scan.json
 # Exit 0: scan complete (findings may be empty)
 # Exit 1: fatal error (missing tools, missing patch file — writes JSON error + exits non-zero)
 
 set -euo pipefail
 
 PATCH_FILE="${1:-}"
+OUTPUT_DIR=""
+OUTPUT_PATH=""
 
 if [ -z "$PATCH_FILE" ]; then
   echo "Usage: policy-scanner.sh <patch_file>" >&2
   exit 1
 fi
+
+OUTPUT_DIR=$(dirname "$PATCH_FILE")
+[ -n "$OUTPUT_DIR" ] || OUTPUT_DIR="."
+OUTPUT_PATH="${OUTPUT_DIR}/policy_scan.json"
 
 if ! command -v jq > /dev/null 2>&1; then
   echo "ERROR: jq not found" >&2
@@ -22,10 +28,10 @@ fi
 
 if [ ! -f "$PATCH_FILE" ]; then
   echo "ERROR: policy-scanner.sh: patch file not found: $PATCH_FILE" >&2
-  mkdir -p .signum
+  mkdir -p "$OUTPUT_DIR"
   jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg pf "$PATCH_FILE" \
     '{scannedAt:$ts, patchFile:$pf, error:"missing_combined_patch", findings:[], summaryCounts:{critical:0,major:0,minor:0,total:0}}' \
-    > .signum/policy_scan.json
+    > "$OUTPUT_PATH"
   exit 1
 fi
 
@@ -184,7 +190,7 @@ jq -n \
     patchFile: $patchFile,
     findings: $findings,
     summaryCounts: $summaryCounts
-  }' > .signum/policy_scan.json
+  }' > "$OUTPUT_PATH"
 
 TOTAL=$(echo "$COUNTS" | jq -r '.total')
 CRITICAL=$(echo "$COUNTS" | jq -r '.critical')

--- a/platforms/claude-code/lib/signum-ci.sh
+++ b/platforms/claude-code/lib/signum-ci.sh
@@ -1,117 +1,238 @@
 #!/usr/bin/env bash
-# signum-ci.sh — CI wrapper for Signum pipeline
+# signum-ci.sh - CI wrapper for Signum pipeline
 # Runs Signum with a pre-approved contract and maps decision to exit code.
 #
 # Exit codes:
-#   0  — AUTO_OK (safe to merge)
-#   1  — AUTO_BLOCK (issues found, block merge)
-#   78 — HUMAN_REVIEW (needs manual review)
+#   0  - AUTO_OK (safe to merge)
+#   1  - AUTO_BLOCK (issues found, block merge)
+#   78 - HUMAN_REVIEW (needs manual review)
 #
 # Environment variables:
-#   SIGNUM_CONTRACT_PATH — path to pre-approved contract.json (required)
-#   SIGNUM_MAX_TURNS     — max agent turns (default: 30)
-#   SIGNUM_ALLOWED_TOOLS — comma-separated tool allowlist (optional)
-#   SIGNUM_PROJECT_ROOT  — project root (default: current directory)
-#   SIGNUM_AUDIT_MAX_ITERATIONS — max audit fix iterations (default: 20, inherited by pipeline)
-#   SIGNUM_CI_RELAXED    — if "true", HUMAN_REVIEW maps to exit 0 (pass with warning)
+#   SIGNUM_CONTRACT_PATH - path to pre-approved contract.json (required)
+#   SIGNUM_MAX_TURNS     - max agent turns (default: 30)
+#   SIGNUM_ALLOWED_TOOLS - comma-separated tool allowlist (optional)
+#   SIGNUM_PROJECT_ROOT  - project root (default: current directory)
+#   SIGNUM_AUDIT_MAX_ITERATIONS - max audit fix iterations (default: 20, inherited by pipeline)
+#   SIGNUM_CI_RELAXED    - if "true", HUMAN_REVIEW maps to exit 0 (pass with warning)
 
 set -euo pipefail
 
-# --- Validate inputs ---
-CONTRACT="${SIGNUM_CONTRACT_PATH:-}"
-if [ -z "$CONTRACT" ]; then
-  echo "ERROR: SIGNUM_CONTRACT_PATH is required" >&2
-  exit 1
-fi
-if [ ! -f "$CONTRACT" ]; then
-  echo "ERROR: Contract not found: $CONTRACT" >&2
-  exit 1
-fi
+resolve_ci_single_contract_dir() {
+  local project_root="${1:-}"
+  local contracts_root="${project_root}/.signum/contracts"
+  local dir_count=""
+  local only_dir=""
 
-# Validate contract has required fields
-if ! jq -e '.schemaVersion and .goal and .inScope and .acceptanceCriteria and .riskLevel' \
-  "$CONTRACT" > /dev/null 2>&1; then
-  echo "ERROR: Invalid contract (missing required fields)" >&2
-  exit 1
-fi
+  if [ -z "$project_root" ] || [ ! -d "$contracts_root" ]; then
+    return 1
+  fi
 
-PROJECT_ROOT="${SIGNUM_PROJECT_ROOT:-$(pwd)}"
-MAX_TURNS="${SIGNUM_MAX_TURNS:-30}"
+  dir_count=$(find "$contracts_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d '[:space:]')
+  if [ "$dir_count" != "1" ]; then
+    return 1
+  fi
 
-echo "=== Signum CI ==="
-echo "Contract: $CONTRACT"
-echo "Project:  $PROJECT_ROOT"
-echo "Max turns: $MAX_TURNS"
+  only_dir=$(find "$contracts_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -n 1)
+  if [ -n "$only_dir" ] && [ -d "$only_dir" ]; then
+    printf '%s\n' "$only_dir"
+    return 0
+  fi
 
-# --- Setup .signum directory ---
-mkdir -p "$PROJECT_ROOT/.signum/reviews"
-cp "$CONTRACT" "$PROJECT_ROOT/.signum/contract.json"
+  return 1
+}
 
-# --- Build claude invocation ---
-TASK=$(jq -r '.goal' "$CONTRACT")
+resolve_ci_artifact_root() {
+  local project_root="${1:-}"
+  local contract_id="${2:-}"
+  local index_path="${project_root}/.signum/contracts/index.json"
+  local active_id=""
+  local last_dir=""
+  local single_dir=""
 
-CLAUDE_ARGS=(
-  -p "/signum $TASK"
-  --output-format json
-  --max-turns "$MAX_TURNS"
-  --verbose
-)
+  if [ -z "$project_root" ]; then
+    echo "resolve_ci_artifact_root: project_root required" >&2
+    return 1
+  fi
 
-if [ -n "${SIGNUM_ALLOWED_TOOLS:-}" ]; then
-  CLAUDE_ARGS+=(--allowedTools "$SIGNUM_ALLOWED_TOOLS")
-fi
+  if [ -n "$contract_id" ] && [ -d "$project_root/.signum/contracts/$contract_id" ]; then
+    printf '%s\n' "$project_root/.signum/contracts/$contract_id"
+    return 0
+  fi
 
-echo "Starting Signum pipeline..."
-cd "$PROJECT_ROOT"
-claude "${CLAUDE_ARGS[@]}" || true
-
-# --- Extract decision ---
-if [ ! -f .signum/proofpack.json ]; then
-  echo "ERROR: proofpack.json not produced" >&2
-  exit 1
-fi
-
-DECISION=$(jq -r '.decision' .signum/proofpack.json)
-CONFIDENCE=$(jq -r '.confidence.overall // 0' .signum/proofpack.json)
-RUN_ID=$(jq -r '.runId' .signum/proofpack.json)
-
-echo ""
-echo "=== Result ==="
-echo "Decision:   $DECISION"
-echo "Confidence: ${CONFIDENCE}%"
-echo "Run ID:     $RUN_ID"
-
-# --- Compute proofpack hash for artifact integrity ---
-if command -v sha256sum >/dev/null 2>&1; then
-  PP_HASH=$(sha256sum .signum/proofpack.json | awk '{print $1}')
-elif command -v shasum >/dev/null 2>&1; then
-  PP_HASH=$(shasum -a 256 .signum/proofpack.json | awk '{print $1}')
-else
-  PP_HASH="unavailable"
-fi
-echo "Proofpack SHA-256: $PP_HASH"
-
-# --- Map decision to exit code ---
-case "$DECISION" in
-  AUTO_OK)
-    echo "Status: PASS"
-    exit 0
-    ;;
-  AUTO_BLOCK)
-    echo "Status: BLOCKED"
-    exit 1
-    ;;
-  HUMAN_REVIEW)
-    if [ "${SIGNUM_CI_RELAXED:-false}" = "true" ]; then
-      echo "Status: NEEDS REVIEW (relaxed mode — passing)"
-      exit 0
-    else
-      echo "Status: NEEDS REVIEW"
-      exit 78
+  if [ -f "$index_path" ]; then
+    active_id=$(jq -r '.activeContractId // empty' "$index_path" 2>/dev/null || true)
+    if [ -n "$active_id" ] && [ -d "$project_root/.signum/contracts/$active_id" ]; then
+      printf '%s\n' "$project_root/.signum/contracts/$active_id"
+      return 0
     fi
-    ;;
-  *)
-    echo "ERROR: Unknown decision: $DECISION" >&2
+
+    last_dir=$(jq -r '.contracts[-1].directory // empty' "$index_path" 2>/dev/null || true)
+    last_dir="${last_dir%/}"
+    if [ -n "$last_dir" ] && [ -d "$project_root/$last_dir" ]; then
+      printf '%s\n' "$project_root/$last_dir"
+      return 0
+    fi
+  fi
+
+  single_dir=$(resolve_ci_single_contract_dir "$project_root" 2>/dev/null || true)
+  if [ -n "$single_dir" ] && [ -d "$single_dir" ]; then
+    printf '%s\n' "$single_dir"
+    return 0
+  fi
+
+  # Legacy fallback during migration.
+  if [ -d "$project_root/.signum" ]; then
+    printf '%s\n' "$project_root/.signum"
+    return 0
+  fi
+
+  return 1
+}
+
+resolve_ci_proofpack_path() {
+  local project_root="${1:-}"
+  local contract_id="${2:-}"
+  local artifact_root=""
+  local single_dir=""
+
+  if [ -z "$project_root" ]; then
+    echo "resolve_ci_proofpack_path: project_root required" >&2
+    return 1
+  fi
+
+  artifact_root=$(resolve_ci_artifact_root "$project_root" "$contract_id" 2>/dev/null || true)
+  if [ -n "$artifact_root" ] && [ -f "$artifact_root/proofpack.json" ]; then
+    printf '%s\n' "$artifact_root/proofpack.json"
+    return 0
+  fi
+
+  single_dir=$(resolve_ci_single_contract_dir "$project_root" 2>/dev/null || true)
+  if [ -n "$single_dir" ] && [ -f "$single_dir/proofpack.json" ]; then
+    printf '%s\n' "$single_dir/proofpack.json"
+    return 0
+  fi
+
+  # Legacy fallback during migration.
+  if [ -f "$project_root/.signum/proofpack.json" ]; then
+    printf '%s\n' "$project_root/.signum/proofpack.json"
+    return 0
+  fi
+
+  return 1
+}
+
+signum_ci_main() {
+  local contract="${SIGNUM_CONTRACT_PATH:-}"
+  local input_contract_id=""
+  local project_root="${SIGNUM_PROJECT_ROOT:-$(pwd)}"
+  local max_turns="${SIGNUM_MAX_TURNS:-30}"
+  local task=""
+  local artifact_root=""
+  local proofpack_path=""
+  local decision=""
+  local confidence=""
+  local run_id=""
+  local pp_hash=""
+
+  if [ -z "$contract" ]; then
+    echo "ERROR: SIGNUM_CONTRACT_PATH is required" >&2
     exit 1
-    ;;
-esac
+  fi
+  if [ ! -f "$contract" ]; then
+    echo "ERROR: Contract not found: $contract" >&2
+    exit 1
+  fi
+
+  if ! jq -e '.schemaVersion and .goal and .inScope and .acceptanceCriteria and .riskLevel' \
+    "$contract" > /dev/null 2>&1; then
+    echo "ERROR: Invalid contract (missing required fields)" >&2
+    exit 1
+  fi
+
+  input_contract_id=$(jq -r '.contractId // empty' "$contract" 2>/dev/null || true)
+
+  echo "=== Signum CI ==="
+  echo "Contract: $contract"
+  echo "Project:  $project_root"
+  echo "Max turns: $max_turns"
+
+  mkdir -p "$project_root/.signum"
+  echo "Contract mode: file (Phase 1 imports SIGNUM_CONTRACT_PATH into canonical artifact root)"
+
+  task=$(jq -r '.goal' "$contract")
+
+  CLAUDE_ARGS=(
+    -p "/signum $task"
+    --output-format json
+    --max-turns "$max_turns"
+    --verbose
+  )
+
+  if [ -n "${SIGNUM_ALLOWED_TOOLS:-}" ]; then
+    CLAUDE_ARGS+=(--allowedTools "$SIGNUM_ALLOWED_TOOLS")
+  fi
+
+  echo "Starting Signum pipeline..."
+  cd "$project_root"
+  claude "${CLAUDE_ARGS[@]}" || true
+
+  artifact_root=$(resolve_ci_artifact_root "$project_root" "$input_contract_id" 2>/dev/null || true)
+  proofpack_path=$(resolve_ci_proofpack_path "$project_root" "$input_contract_id" 2>/dev/null || true)
+  if [ -z "$artifact_root" ] && [ -n "$proofpack_path" ]; then
+    artifact_root=$(dirname "$proofpack_path")
+  fi
+
+  if [ -z "$proofpack_path" ] || [ ! -f "$proofpack_path" ]; then
+    echo "ERROR: proofpack.json not produced" >&2
+    exit 1
+  fi
+
+  decision=$(jq -r '.decision' "$proofpack_path")
+  confidence=$(jq -r '.confidence.overall // 0' "$proofpack_path")
+  run_id=$(jq -r '.runId' "$proofpack_path")
+
+  echo ""
+  echo "=== Result ==="
+  echo "Artifact root: ${artifact_root:-unresolved}"
+  echo "Proofpack:  $proofpack_path"
+  echo "Decision:   $decision"
+  echo "Confidence: ${confidence}%"
+  echo "Run ID:     $run_id"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    pp_hash=$(sha256sum "$proofpack_path" | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    pp_hash=$(shasum -a 256 "$proofpack_path" | awk '{print $1}')
+  else
+    pp_hash="unavailable"
+  fi
+  echo "Proofpack SHA-256: $pp_hash"
+
+  case "$decision" in
+    AUTO_OK)
+      echo "Status: PASS"
+      exit 0
+      ;;
+    AUTO_BLOCK)
+      echo "Status: BLOCKED"
+      exit 1
+      ;;
+    HUMAN_REVIEW)
+      if [ "${SIGNUM_CI_RELAXED:-false}" = "true" ]; then
+        echo "Status: NEEDS REVIEW (relaxed mode - passing)"
+        exit 0
+      else
+        echo "Status: NEEDS REVIEW"
+        exit 78
+      fi
+      ;;
+    *)
+      echo "ERROR: Unknown decision: $decision" >&2
+      exit 1
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  signum_ci_main "$@"
+fi

--- a/platforms/claude-code/lib/templates/signum-gate.yml
+++ b/platforms/claude-code/lib/templates/signum-gate.yml
@@ -49,11 +49,32 @@ jobs:
           EXIT_CODE=$?
           echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
 
-          # Extract decision for PR comment
-          if [ -f .signum/proofpack.json ]; then
-            DECISION=$(jq -r '.decision' .signum/proofpack.json)
-            CONFIDENCE=$(jq -r '.confidence.overall // 0' .signum/proofpack.json)
-            RUN_ID=$(jq -r '.runId' .signum/proofpack.json)
+          # Extract canonical artifact paths and decision for PR comment
+          source lib/signum-ci.sh
+          INPUT_CONTRACT_ID=$(jq -r '.contractId // empty' "$SIGNUM_CONTRACT_PATH" 2>/dev/null || true)
+          ARTIFACT_ROOT=$(resolve_ci_artifact_root "$SIGNUM_PROJECT_ROOT" "$INPUT_CONTRACT_ID" 2>/dev/null || true)
+          PROOFPACK_PATH=$(resolve_ci_proofpack_path "$SIGNUM_PROJECT_ROOT" "$INPUT_CONTRACT_ID" 2>/dev/null || true)
+          ARTIFACT_UPLOAD_PATH="${ARTIFACT_ROOT:-$SIGNUM_PROJECT_ROOT/.signum/contracts}"
+          if [ ! -d "$ARTIFACT_UPLOAD_PATH" ] && [ -d "$SIGNUM_PROJECT_ROOT/.signum" ]; then
+            ARTIFACT_UPLOAD_PATH="$SIGNUM_PROJECT_ROOT/.signum"
+          fi
+          PROOFPACK_UPLOAD_PATH="${PROOFPACK_PATH:-}"
+          if [ -z "$PROOFPACK_UPLOAD_PATH" ] && [ -n "$ARTIFACT_ROOT" ]; then
+            PROOFPACK_UPLOAD_PATH="$ARTIFACT_ROOT/proofpack.json"
+          fi
+          if [ -z "$PROOFPACK_UPLOAD_PATH" ]; then
+            PROOFPACK_UPLOAD_PATH="$ARTIFACT_UPLOAD_PATH/proofpack.json"
+          fi
+          echo "artifact_upload_path=$ARTIFACT_UPLOAD_PATH" >> "$GITHUB_OUTPUT"
+          echo "proofpack_upload_path=$PROOFPACK_UPLOAD_PATH" >> "$GITHUB_OUTPUT"
+          if [ -n "$ARTIFACT_ROOT" ]; then
+            echo "artifact_root=$ARTIFACT_ROOT" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -n "$PROOFPACK_PATH" ] && [ -f "$PROOFPACK_PATH" ]; then
+            DECISION=$(jq -r '.decision' "$PROOFPACK_PATH")
+            CONFIDENCE=$(jq -r '.confidence.overall // 0' "$PROOFPACK_PATH")
+            RUN_ID=$(jq -r '.runId' "$PROOFPACK_PATH")
+            echo "proofpack_path=$PROOFPACK_PATH" >> "$GITHUB_OUTPUT"
             echo "decision=$DECISION" >> "$GITHUB_OUTPUT"
             echo "confidence=$CONFIDENCE" >> "$GITHUB_OUTPUT"
             echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
@@ -66,7 +87,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: signum-proofpack-${{ steps.signum.outputs.run_id || 'unknown' }}
-          path: .signum/proofpack.json
+          path: ${{ steps.signum.outputs.proofpack_upload_path }}
           retention-days: 90
           if-no-files-found: warn
 
@@ -75,7 +96,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: signum-audit-${{ steps.signum.outputs.run_id || 'unknown' }}
-          path: .signum/
+          path: ${{ steps.signum.outputs.artifact_upload_path }}
           retention-days: 30
           if-no-files-found: warn
 

--- a/platforms/claude-code/tests/test-contract-dir.sh
+++ b/platforms/claude-code/tests/test-contract-dir.sh
@@ -59,8 +59,8 @@ assert_eq() {
 echo "=== contract_dir ==="
 
 assert_eq "returns path for valid id" \
-  ".signum/contracts/sig-20260314-abcd/" \
-  "$(contract_dir "sig-20260314-abcd")"
+  ".signum/contracts/sig-20260314-1030-abcd/" \
+  "$(contract_dir "sig-20260314-1030-abcd")"
 
 assert_fail "rejects empty id" "contractId required" \
   contract_dir ""
@@ -73,6 +73,27 @@ assert_fail "rejects double dot in id" "path traversal" \
 
 assert_fail "rejects slashed path" "path traversal" \
   contract_dir "../../etc/passwd"
+
+echo ""
+echo "=== new_contract_id ==="
+
+ID1=$(new_contract_id)
+ID2=$(new_contract_id)
+if [[ "$ID1" =~ ^sig-[0-9]{8}-[0-9]{4}-[0-9a-f]{4}$ ]]; then
+  printf '  PASS: new_contract_id format includes HHMM\n'
+  passed=$((passed + 1))
+else
+  printf '  FAIL: new_contract_id format includes HHMM - got "%s"\n' "$ID1"
+  failed=$((failed + 1))
+fi
+
+if [[ "$ID1" != "$ID2" ]]; then
+  printf '  PASS: new_contract_id produces unique values\n'
+  passed=$((passed + 1))
+else
+  printf '  FAIL: new_contract_id produces unique values - both were "%s"\n' "$ID1"
+  failed=$((failed + 1))
+fi
 
 echo ""
 echo "=== init_contract_dir ==="
@@ -130,7 +151,7 @@ echo "=== register_contract ==="
 
 assert_ok "registers new contract" register_contract "sig-test-001" "draft"
 ACTIVE=$(jq -r '.activeContractId' .signum/contracts/index.json)
-assert_eq "sets activeContractId" "sig-test-001" "$ACTIVE"
+assert_eq "register does not set activeContractId" "null" "$ACTIVE"
 
 STATUS=$(jq -r '.contracts[] | select(.contractId == "sig-test-001") | .status' .signum/contracts/index.json)
 assert_eq "status is draft" "draft" "$STATUS"
@@ -138,29 +159,47 @@ assert_eq "status is draft" "draft" "$STATUS"
 # Register second contract
 assert_ok "registers second contract" register_contract "sig-test-002" "active"
 ACTIVE=$(jq -r '.activeContractId' .signum/contracts/index.json)
-assert_eq "active switches to second" "sig-test-002" "$ACTIVE"
+assert_eq "register still leaves active unset" "null" "$ACTIVE"
 
 COUNT=$(jq '.contracts | length' .signum/contracts/index.json)
 assert_eq "two contracts in index" "2" "$COUNT"
 
-# Re-register updates existing (NOTE: this also sets activeContractId back to sig-test-001)
+# Re-register updates existing without stealing active selection
+assert_ok "sets active contract explicitly" set_active_contract "sig-test-002"
+ACTIVE=$(jq -r '.activeContractId' .signum/contracts/index.json)
+assert_eq "active switches only via explicit setter" "sig-test-002" "$ACTIVE"
+
 assert_ok "re-register updates existing" register_contract "sig-test-001" "completed"
 STATUS=$(jq -r '.contracts[] | select(.contractId == "sig-test-001") | .status' .signum/contracts/index.json)
 assert_eq "status updated to completed" "completed" "$STATUS"
 COUNT=$(jq '.contracts | length' .signum/contracts/index.json)
 assert_eq "still two contracts (no dup)" "2" "$COUNT"
 ACTIVE=$(jq -r '.activeContractId' .signum/contracts/index.json)
-assert_eq "active switches back on re-register" "sig-test-001" "$ACTIVE"
+assert_eq "re-register does not change active" "sig-test-002" "$ACTIVE"
 
 assert_fail "register fails without id" "contractId required" \
   register_contract ""
+assert_fail "set_active_contract fails without id" "contractId required" \
+  set_active_contract ""
+assert_fail "set_active_contract fails for missing contract" "not found in index" \
+  set_active_contract "sig-missing"
+
+echo ""
+echo "=== clear_active_contract ==="
+
+assert_ok "clears active contract explicitly" clear_active_contract
+ACTIVE=$(jq -r '.activeContractId' .signum/contracts/index.json)
+assert_eq "activeContractId is null after clear" "null" "$ACTIVE"
 
 echo ""
 echo "=== update_contract_status ==="
 
+assert_ok "re-sets active contract for terminal status test" set_active_contract "sig-test-002"
 assert_ok "updates existing status" update_contract_status "sig-test-002" "archived"
 STATUS=$(jq -r '.contracts[] | select(.contractId == "sig-test-002") | .status' .signum/contracts/index.json)
 assert_eq "status is archived" "archived" "$STATUS"
+ACTIVE=$(jq -r '.activeContractId' .signum/contracts/index.json)
+assert_eq "terminal status clears active contract" "null" "$ACTIVE"
 
 assert_fail "fails for missing contract" "not found in index" \
   update_contract_status "sig-nonexistent" "active"
@@ -172,13 +211,189 @@ echo ""
 echo "=== get_active_contract ==="
 
 ACTIVE=$(get_active_contract)
-assert_eq "returns active id" "sig-test-001" "$ACTIVE"
+assert_eq "returns empty when no active id is set" "" "$ACTIVE"
+
+STATUS=$(get_contract_status "sig-test-002")
+assert_eq "get_contract_status returns archived status" "archived" "$STATUS"
+assert_fail "get_contract_status fails without id" "contractId required" \
+  get_contract_status ""
+assert_fail "get_contract_status fails for missing contract" "not found in index" \
+  get_contract_status "sig-missing"
 
 echo ""
-echo "=== current_contract_dir ==="
+echo "=== describe_active_contract_state ==="
 
+STATE_JSON=$(describe_active_contract_state)
+assert_eq "describe_active_contract_state returns NONE without active contract" "NONE" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.state')"
+assert_eq "describe_active_contract_state returns null contractId when inactive" "null" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.contractId')"
+
+echo ""
+echo "=== active_artifact_root / current_contract_dir ==="
+
+ACTIVE_ID="sig-active-001"
+assert_ok "creates active draft contract dir" init_contract_dir "$ACTIVE_ID"
+printf '{"goal":"active"}\n' > ".signum/contracts/${ACTIVE_ID}/contract.json"
+assert_ok "registers active draft contract" register_contract "$ACTIVE_ID" "draft"
+assert_ok "sets active contract for root lookup" set_active_contract "$ACTIVE_ID"
+DIR=$(active_artifact_root)
+assert_eq "returns active artifact root" ".signum/contracts/${ACTIVE_ID}/" "$DIR"
 DIR=$(current_contract_dir)
-assert_eq "returns active dir" ".signum/contracts/sig-test-001/" "$DIR"
+assert_eq "current_contract_dir remains alias" ".signum/contracts/${ACTIVE_ID}/" "$DIR"
+PATH_TO_CONTRACT=$(active_artifact_path "contract.json")
+assert_eq "active_artifact_path returns active file path" ".signum/contracts/${ACTIVE_ID}/contract.json" "$PATH_TO_CONTRACT"
+STATE_JSON=$(describe_active_contract_state)
+assert_eq "active contract with only contract.json is CONTRACT_ONLY" "CONTRACT_ONLY" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.state')"
+assert_eq "describe_active_contract_state includes active contract id" "$ACTIVE_ID" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.contractId')"
+assert_eq "describe_active_contract_state includes active artifact root" ".signum/contracts/${ACTIVE_ID}/" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.artifactRoot')"
+
+echo ""
+echo "=== link_active_artifact / promote_root_artifact_to_active ==="
+
+printf '{"goal":"canonical"}\n' > .signum/contract.json
+assert_ok "promotes root contract into active root" promote_root_artifact_to_active "contract.json"
+assert_eq "promoted contract now exists in active root" "true" \
+  "$([ -f .signum/contracts/${ACTIVE_ID}/contract.json ] && echo true || echo false)"
+assert_eq "root contract path becomes symlink" "true" \
+  "$([ -L .signum/contract.json ] && echo true || echo false)"
+PROMOTED_CONTENT=$(cat ".signum/contracts/${ACTIVE_ID}/contract.json")
+assert_eq "promoted contract content preserved" '{"goal":"canonical"}' "$PROMOTED_CONTENT"
+
+assert_ok "links phase1 spec artifact into active root" link_active_artifact "spec_quality.json"
+assert_eq "root spec_quality path becomes symlink" "true" \
+  "$([ -L .signum/spec_quality.json ] && echo true || echo false)"
+printf '{"total":91}\n' > .signum/spec_quality.json
+assert_eq "writing through symlink lands in active root" '{"total":91}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/spec_quality.json")"
+assert_ok "links execution context into active root" link_active_artifact "execution_context.json"
+printf '{"run_id":"run-01"}\n' > .signum/execution_context.json
+STATE_JSON=$(describe_active_contract_state)
+assert_eq "active contract with execution_context becomes RESUMABLE" "RESUMABLE" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.state')"
+
+assert_ok "links execute patch into active root" link_active_artifact "combined.patch"
+printf 'diff --git a/foo b/foo\n' > .signum/combined.patch
+assert_eq "execute patch is written to active root" 'diff --git a/foo b/foo' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/combined.patch")"
+rm -f .signum/combined.patch
+assert_ok "re-links execute patch after cleanup" link_active_artifact "combined.patch"
+printf 'diff --git a/bar b/bar\n' > .signum/combined.patch
+assert_eq "relinked execute patch still writes canonically" 'diff --git a/bar b/bar' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/combined.patch")"
+
+assert_ok "links audit summary into active root" link_active_artifact "audit_summary.json"
+printf '{"decision":"AUTO_OK"}\n' > .signum/audit_summary.json
+assert_eq "audit summary is written to active root" '{"decision":"AUTO_OK"}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/audit_summary.json")"
+
+assert_ok "links proofpack into active root" link_active_artifact "proofpack.json"
+printf '{"runId":"sig-active-001"}\n' > .signum/proofpack.json
+assert_eq "proofpack is written to active root" '{"runId":"sig-active-001"}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/proofpack.json")"
+assert_ok "sync of symlinked active proofpack is a no-op" \
+  sync_contract_artifacts "$ACTIVE_ID" "proofpack.json"
+assert_eq "self-copy sync keeps canonical proofpack content" '{"runId":"sig-active-001"}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/proofpack.json")"
+
+echo ""
+echo "=== ensure_active_artifact_dir / remove_root_artifact_view / reset_active_artifact ==="
+
+assert_ok "creates active reviews dir bridge" ensure_active_artifact_dir "reviews"
+assert_eq "root reviews path becomes symlink" "true" \
+  "$([ -L .signum/reviews ] && echo true || echo false)"
+mkdir -p .signum/reviews
+printf '{"decision":"APPROVE"}\n' > .signum/reviews/claude.json
+assert_eq "reviews dir writes into active root" '{"decision":"APPROVE"}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/reviews/claude.json")"
+assert_ok "sync of symlinked active reviews dir is a no-op" \
+  sync_contract_artifacts "$ACTIVE_ID" "reviews"
+assert_eq "self-copy sync keeps canonical reviews content" '{"decision":"APPROVE"}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/reviews/claude.json")"
+
+assert_ok "removes only root reviews view" remove_root_artifact_view "reviews"
+assert_eq "root reviews view removed" "false" \
+  "$([ -e .signum/reviews ] && echo true || echo false)"
+assert_eq "canonical reviews dir preserved" "true" \
+  "$([ -f ".signum/contracts/${ACTIVE_ID}/reviews/claude.json" ] && echo true || echo false)"
+
+assert_ok "resets dir artifact and re-links it" reset_active_artifact "reviews" "dir"
+assert_eq "reviews root relinked after reset" "true" \
+  "$([ -L .signum/reviews ] && echo true || echo false)"
+assert_eq "reviews canonical contents cleared on reset" "false" \
+  "$([ -f ".signum/contracts/${ACTIVE_ID}/reviews/claude.json" ] && echo true || echo false)"
+printf '{"decision":"RETRY"}\n' > .signum/reviews/codex.json
+assert_eq "reviews dir can be reused after reset" '{"decision":"RETRY"}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/reviews/codex.json")"
+
+assert_ok "resets file artifact and re-links it" reset_active_artifact "iteration_delta.patch"
+assert_eq "iteration delta path is symlink after reset" "true" \
+  "$([ -L .signum/iteration_delta.patch ] && echo true || echo false)"
+assert_eq "iteration delta target cleared on reset" "false" \
+  "$([ -e ".signum/contracts/${ACTIVE_ID}/iteration_delta.patch" ] && echo true || echo false)"
+printf 'delta-v2\n' > .signum/iteration_delta.patch
+assert_eq "iteration delta writes canonically after reset" 'delta-v2' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/iteration_delta.patch")"
+
+assert_fail "reset_active_artifact rejects invalid kind" "kind must be file or dir" \
+  reset_active_artifact "proofpack.json" "weird"
+
+echo ""
+echo "=== archive_contract_artifacts / purge_root_working_set_views ==="
+
+assert_ok "re-links proofpack before archive helper" link_active_artifact "proofpack.json"
+printf '{"runId":"sig-active-001-archive"}\n' > .signum/proofpack.json
+printf '{"resolved":1}\n' > ".signum/contracts/${ACTIVE_ID}/reconcile_report.json"
+printf '{"risk":"medium"}\n' > ".signum/contracts/${ACTIVE_ID}/retro.json"
+mkdir -p ".signum/contracts/${ACTIVE_ID}/receipts"
+printf '{"status":"PASS"}\n' > ".signum/contracts/${ACTIVE_ID}/receipts/execute.json"
+ARCHIVE_OUT=".signum/archive/${ACTIVE_ID}"
+assert_ok "archives canonical contract payload" archive_contract_artifacts "$ACTIVE_ID" "$ARCHIVE_OUT"
+assert_eq "archive copies canonical contract" "true" \
+  "$([ -f "${ARCHIVE_OUT}/contract.json" ] && echo true || echo false)"
+assert_eq "archive copies canonical proofpack" "true" \
+  "$([ -f "${ARCHIVE_OUT}/proofpack.json" ] && echo true || echo false)"
+assert_eq "archive copies reconcile report" "true" \
+  "$([ -f "${ARCHIVE_OUT}/reconcile_report.json" ] && echo true || echo false)"
+assert_eq "archive copies retro" "true" \
+  "$([ -f "${ARCHIVE_OUT}/retro.json" ] && echo true || echo false)"
+assert_eq "archive copies receipts dir contents" "true" \
+  "$([ -f "${ARCHIVE_OUT}/receipts/execute.json" ] && echo true || echo false)"
+assert_fail "archive helper rejects missing contract id" "contractId and archive_dir required" \
+  archive_contract_artifacts ""
+
+printf '{"baseline":true}\n' > .signum/repo_contract_baseline.json
+printf 'prompt\n' > .signum/review_prompt_codex.txt
+assert_ok "re-links review context before purge" link_active_artifact "review_context.json"
+printf '{"issue_refs":[]}\n' > .signum/review_context.json
+assert_ok "purges root working set compatibility surface" purge_root_working_set_views
+assert_eq "root proofpack view removed" "false" \
+  "$([ -e .signum/proofpack.json ] && echo true || echo false)"
+assert_eq "root reviews view removed" "false" \
+  "$([ -e .signum/reviews ] && echo true || echo false)"
+assert_eq "root repo baseline removed" "false" \
+  "$([ -e .signum/repo_contract_baseline.json ] && echo true || echo false)"
+assert_eq "root review prompt removed" "false" \
+  "$([ -e .signum/review_prompt_codex.txt ] && echo true || echo false)"
+assert_eq "root review context removed" "false" \
+  "$([ -e .signum/review_context.json ] && echo true || echo false)"
+assert_eq "canonical proofpack preserved after purge" "true" \
+  "$([ -f ".signum/contracts/${ACTIVE_ID}/proofpack.json" ] && echo true || echo false)"
+assert_eq "canonical reviews preserved after purge" "true" \
+  "$([ -f ".signum/contracts/${ACTIVE_ID}/reviews/codex.json" ] && echo true || echo false)"
+assert_eq "canonical review context preserved after purge" "true" \
+  "$([ -f ".signum/contracts/${ACTIVE_ID}/review_context.json" ] && echo true || echo false)"
+
+assert_ok "marks contract terminal for stale-active cleanup test" update_contract_status "$ACTIVE_ID" "completed"
+assert_ok "re-sets completed contract as active to simulate stale index" set_active_contract "$ACTIVE_ID"
+STATE_JSON=$(describe_active_contract_state)
+assert_eq "terminal active contract is treated as NONE" "NONE" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.state')"
+assert_eq "terminal active contract is cleared from index" "" \
+  "$(get_active_contract)"
 
 echo ""
 echo "=== Results ==="

--- a/platforms/claude-code/tests/test-signum-ci.sh
+++ b/platforms/claude-code/tests/test-signum-ci.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CI_SCRIPT="$SCRIPT_DIR/../lib/signum-ci.sh"
+source "$CI_SCRIPT"
 
 passed=0
 failed=0
@@ -35,6 +36,17 @@ assert_contains() {
     passed=$((passed + 1))
   else
     printf '  FAIL: %s — output missing "%s"\n' "$name" "$expected"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_equals() {
+  local name="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s — expected "%s", got "%s"\n' "$name" "$expected" "$actual"
     failed=$((failed + 1))
   fi
 }
@@ -91,6 +103,60 @@ set -e
 
 assert_contains "shows header" "=== Signum CI ===" "$output"
 assert_contains "shows contract path" "valid.json" "$output"
+
+echo ""
+echo "=== Artifact discovery ==="
+
+CANONICAL="$WORK/canonical"
+mkdir -p "$CANONICAL/.signum/contracts/sig-ci-001"
+cat > "$CANONICAL/.signum/contracts/index.json" <<'EOF'
+{
+  "activeContractId": null,
+  "contracts": [
+    {
+      "contractId": "sig-ci-001",
+      "status": "completed",
+      "directory": ".signum/contracts/sig-ci-001/"
+    }
+  ]
+}
+EOF
+cat > "$CANONICAL/.signum/contracts/sig-ci-001/proofpack.json" <<'EOF'
+{"runId":"sig-ci-001","decision":"AUTO_OK","confidence":{"overall":91}}
+EOF
+
+assert_equals "overlay resolver prefers canonical contract dir by contract id" \
+  "$(resolve_ci_artifact_root "$CANONICAL" "sig-ci-001")" \
+  "$CANONICAL/.signum/contracts/sig-ci-001"
+assert_equals "overlay proofpack resolver prefers canonical contract dir" \
+  "$(resolve_ci_proofpack_path "$CANONICAL" "sig-ci-001")" \
+  "$CANONICAL/.signum/contracts/sig-ci-001/proofpack.json"
+
+SINGLE_CANONICAL="$WORK/single-canonical"
+mkdir -p "$SINGLE_CANONICAL/.signum/contracts/sig-ci-003"
+cat > "$SINGLE_CANONICAL/.signum/contracts/sig-ci-003/proofpack.json" <<'EOF'
+{"runId":"sig-ci-003","decision":"AUTO_OK","confidence":{"overall":88}}
+EOF
+
+assert_equals "overlay resolver falls back to single canonical contract dir without index" \
+  "$(resolve_ci_artifact_root "$SINGLE_CANONICAL" "")" \
+  "$SINGLE_CANONICAL/.signum/contracts/sig-ci-003"
+assert_equals "overlay proofpack resolver falls back to single canonical contract proofpack without index" \
+  "$(resolve_ci_proofpack_path "$SINGLE_CANONICAL" "")" \
+  "$SINGLE_CANONICAL/.signum/contracts/sig-ci-003/proofpack.json"
+
+ROOT_FALLBACK="$WORK/root-fallback"
+mkdir -p "$ROOT_FALLBACK/.signum"
+cat > "$ROOT_FALLBACK/.signum/proofpack.json" <<'EOF'
+{"runId":"legacy","decision":"HUMAN_REVIEW","confidence":{"overall":50}}
+EOF
+
+assert_equals "overlay resolver keeps legacy root artifact dir as final fallback" \
+  "$(resolve_ci_artifact_root "$ROOT_FALLBACK" "")" \
+  "$ROOT_FALLBACK/.signum"
+assert_equals "overlay proofpack resolver keeps legacy root proofpack as final fallback" \
+  "$(resolve_ci_proofpack_path "$ROOT_FALLBACK" "")" \
+  "$ROOT_FALLBACK/.signum/proofpack.json"
 
 echo ""
 echo "=== Exit code mapping (direct test) ==="

--- a/platforms/codex/SKILL.md
+++ b/platforms/codex/SKILL.md
@@ -76,26 +76,31 @@ Treat `network_error`, `timeout`, and `server_error` as degraded audit coverage,
 2. If the contract is vague, stop and improve it before coding.
 3. The implementation should be checked against deterministic criteria, not just model opinion.
 4. Separate implementation context from audit context when possible.
-5. Keep all pipeline artifacts in `.signum/`.
+5. Keep pipeline artifacts under the active contract artifact root `.signum/contracts/<contractId>/`. Treat root `.signum/` as registry/state plus compatibility views.
 6. If the pipeline cannot verify a claim, say so explicitly.
 7. If the task is too small for the full pipeline, reduce scope but keep the contract-first principle.
 
 ## Artifact Layout
 
-Create and use:
+Create and use the active contract artifact root:
 
-- `.signum/contract.json`
-- `.signum/contract-engineer.json`
-- `.signum/contract-policy.json`
-- `.signum/baseline.json`
-- `.signum/execute_log.json`
-- `.signum/combined.patch`
-- `.signum/mechanic_report.json`
-- `.signum/audit_summary.json`
-- `.signum/proofpack.json`
-- `.signum/reviews/`
+- `.signum/contracts/<contractId>/`
+- `.signum/contracts/index.json.activeContractId`
 
-Also ensure `.signum/` is ignored by git when appropriate.
+Within that active contract root, create and use:
+
+- `contract.json`
+- `contract-engineer.json`
+- `contract-policy.json`
+- `baseline.json`
+- `execute_log.json`
+- `combined.patch`
+- `mechanic_report.json`
+- `audit_summary.json`
+- `proofpack.json`
+- `reviews/`
+
+Also ensure root `.signum/` is ignored by git when appropriate.
 
 ## Phase 1: CONTRACT
 
@@ -162,9 +167,9 @@ Goal: implement against the contract, not against a vague prompt.
 
 Before coding:
 
-1. Capture baseline checks into `.signum/baseline.json`
-2. Derive a reduced implementation contract in `.signum/contract-engineer.json`
-3. Derive an execution policy in `.signum/contract-policy.json`
+1. Capture baseline checks into `baseline.json` under the active contract artifact root
+2. Derive a reduced implementation contract in `contract-engineer.json` under the active contract artifact root
+3. Derive an execution policy in `contract-policy.json` under the active contract artifact root
 
 The policy should restrict:
 
@@ -181,7 +186,7 @@ Implementation rules:
 4. If verification fails, attempt targeted repair.
 5. Stop after bounded repair attempts instead of thrashing.
 
-Record attempts and outcomes in `.signum/execute_log.json`.
+Record attempts and outcomes in `execute_log.json` under the active contract artifact root.
 
 ## Phase 3: AUDIT
 
@@ -258,7 +263,7 @@ Do not upgrade to `AUTO_OK` if the audit coverage was materially reduced by exte
 
 ## Resume Behavior
 
-If `.signum/contract.json` or other pipeline artifacts already exist:
+If `contracts/index.json.activeContractId` or other pipeline artifacts already exist:
 
 1. Inspect what phases are complete.
 2. Resume from the first incomplete phase when safe.

--- a/tests/test-anti-entropy-report.sh
+++ b/tests/test-anti-entropy-report.sh
@@ -51,9 +51,15 @@ assert_pass "reporter is executable after chmod" chmod +x "$REPORTER"
 
 setup_clean_project() {
   local dir="$1"
-  mkdir -p "$dir/.signum" "$dir/docs"
+  local contract_id="sig-20260410-1000-test"
+  local artifact_root="$dir/.signum/contracts/$contract_id"
+  mkdir -p "$artifact_root" "$dir/.signum/contracts" "$dir/docs"
 
-  cat > "$dir/.signum/contract.json" <<'EOF'
+  cat > "$dir/.signum/contracts/index.json" <<EOF
+{"activeContractId":"$contract_id","contracts":[{"contractId":"$contract_id","status":"auditing","directory":".signum/contracts/$contract_id"}]}
+EOF
+
+  cat > "$artifact_root/contract.json" <<'EOF'
 {
   "schemaVersion": "3.8",
   "contractId": "sig-1",
@@ -78,7 +84,7 @@ setup_clean_project() {
 }
 EOF
 
-  cat > "$dir/.signum/proofpack.json" <<'EOF'
+  cat > "$artifact_root/proofpack.json" <<'EOF'
 {
   "schemaVersion": "4.7",
   "signumVersion": "4.19.1",
@@ -141,7 +147,7 @@ modules:
     name: ghost
     status: removed
 EOF
-cat > "$DIRTY/.signum/proofpack.json" <<'EOF'
+cat > "$DIRTY/.signum/contracts/sig-20260410-1000-test/proofpack.json" <<'EOF'
 {
   "schemaVersion": "4.7",
   "signumVersion": "4.19.1",
@@ -216,10 +222,19 @@ assert_contains "metric_regression category imported" "$(echo "$IMPORTED_OUT" | 
 
 echo ""
 echo "=== Output file ==="
-OUT_FILE="$WORK/report.json"
-assert_pass "reporter writes output file" "$REPORTER" --project-root "$CLEAN" --as-of 2026-04-10 --output "$OUT_FILE"
+OUT_FILE="$CLEAN/.signum/contracts/sig-20260410-1000-test/anti_entropy_report.json"
+assert_pass "reporter writes output file in canonical artifact root" "$REPORTER" --project-root "$CLEAN" --as-of 2026-04-10 --output "$OUT_FILE"
 assert_pass "output file created" test -f "$OUT_FILE"
 assert_equals "output file content is ok status" "$(jq -r '.status' "$OUT_FILE")" "ok"
+
+echo ""
+echo "=== Output path infers canonical inputs ==="
+OUTPUT_ONLY="$WORK/output-only"
+setup_clean_project "$OUTPUT_ONLY"
+OUTPUT_ONLY_PATH="$OUTPUT_ONLY/.signum/contracts/sig-20260410-1000-test/anti_entropy_report.json"
+assert_pass "reporter succeeds with only output path under canonical dir" "$REPORTER" --project-root "$OUTPUT_ONLY" --as-of 2026-04-10 --output "$OUTPUT_ONLY_PATH"
+assert_pass "output-only report written" test -f "$OUTPUT_ONLY_PATH"
+assert_equals "output-only report status ok" "$(jq -r '.status' "$OUTPUT_ONLY_PATH")" "ok"
 
 echo ""
 echo "=== Results ==="

--- a/tests/test-architecture-canonical-artifact-root.sh
+++ b/tests/test-architecture-canonical-artifact-root.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# test-architecture-canonical-artifact-root.sh -- keep ARCHITECTURE.md aligned with canonical contract-root storage
+set -euo pipefail
+
+DOC="$(cd "$(dirname "$0")/.." && pwd)/ARCHITECTURE.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing \"%s\"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found \"%s\"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Architecture canonical artifact root ==="
+
+assert_contains '.signum/contracts/<contractId>/proofpack.json' "architecture doc uses canonical proofpack path"
+assert_contains 'creates canonical `contract.json` under the active contract artifact root' "main flow uses canonical contract wording"
+assert_contains 'assembles `proofpack.json` under the active contract artifact root' "pack flow uses canonical proofpack wording"
+
+assert_not_contains 'The output artifact is `.signum/proofpack.json`' "old root proofpack summary removed"
+assert_not_contains 'Contractor creates `.signum/contract.json`' "old root contract flow removed"
+assert_not_contains 'PACK assembles `.signum/proofpack.json`' "old root pack flow removed"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-brownfield-harness-flow.sh
+++ b/tests/test-brownfield-harness-flow.sh
@@ -37,7 +37,9 @@ assert_equals() {
 
 setup_brownfield_repo() {
   local dir="$1"
-  mkdir -p "$dir/src/legacy" "$dir/.signum"
+  local contract_id="sig-20260410-1000-test"
+  local artifact_root="$dir/.signum/contracts/$contract_id"
+  mkdir -p "$dir/src/legacy" "$artifact_root" "$dir/.signum/contracts"
 
   cat > "$dir/README.md" <<'DOC'
 # Downstream Example
@@ -72,11 +74,15 @@ modules:
     remove_after: 2026-01-01
 DOC
 
-  cat > "$dir/.signum/contract.json" <<'DOC'
+  cat > "$dir/.signum/contracts/index.json" <<EOF
+{"activeContractId":"$contract_id","contracts":[{"contractId":"$contract_id","status":"auditing","directory":".signum/contracts/$contract_id"}]}
+EOF
+
+  cat > "$artifact_root/contract.json" <<'DOC'
 {"schemaVersion":"3.8","cleanupObligations":[],"removals":[]}
 DOC
 
-  cat > "$dir/.signum/proofpack.json" <<'DOC'
+  cat > "$artifact_root/proofpack.json" <<'DOC'
 {
   "schemaVersion":"4.7",
   "signumVersion":"4.19.1",
@@ -145,11 +151,11 @@ assert_equals "existing glossary preserved" "$(hash_file "$BROWNFIELD/project.gl
 echo ""
 echo "=== Advisory anti-entropy artifact ==="
 assert_pass "packer exits 0 for brownfield repo" "$PACKER" --project-root "$BROWNFIELD" --as-of 2026-04-10
-assert_pass "anti-entropy report written" test -f "$BROWNFIELD/.signum/anti_entropy_report.json"
-assert_equals "anti-entropy report is warn due to overdue module" "$(jq -r '.status' "$BROWNFIELD/.signum/anti_entropy_report.json")" "warn"
-assert_equals "modules.yaml imported as source" "$(jq -r '.sources | index("modules_yaml") != null' "$BROWNFIELD/.signum/anti_entropy_report.json")" "true"
-assert_equals "overdue module finding present" "$(jq -r '[.findings[] | select(.category=="module_deadline_passed")] | length' "$BROWNFIELD/.signum/anti_entropy_report.json")" "1"
-assert_equals "finding targets legacy module path" "$(jq -r '.findings[] | select(.category=="module_deadline_passed") | .target' "$BROWNFIELD/.signum/anti_entropy_report.json")" "src/legacy"
+assert_pass "anti-entropy report written in canonical artifact root" test -f "$BROWNFIELD/.signum/contracts/sig-20260410-1000-test/anti_entropy_report.json"
+assert_equals "anti-entropy report is warn due to overdue module" "$(jq -r '.status' "$BROWNFIELD/.signum/contracts/sig-20260410-1000-test/anti_entropy_report.json")" "warn"
+assert_equals "modules.yaml imported as source" "$(jq -r '.sources | index("modules_yaml") != null' "$BROWNFIELD/.signum/contracts/sig-20260410-1000-test/anti_entropy_report.json")" "true"
+assert_equals "overdue module finding present" "$(jq -r '[.findings[] | select(.category=="module_deadline_passed")] | length' "$BROWNFIELD/.signum/contracts/sig-20260410-1000-test/anti_entropy_report.json")" "1"
+assert_equals "finding targets legacy module path" "$(jq -r '.findings[] | select(.category=="module_deadline_passed") | .target' "$BROWNFIELD/.signum/contracts/sig-20260410-1000-test/anti_entropy_report.json")" "src/legacy"
 
 echo ""
 echo "=== Results ==="

--- a/tests/test-canonical-archive-cleanup-paths.sh
+++ b/tests/test-canonical-archive-cleanup-paths.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# test-canonical-archive-cleanup-paths.sh -- ensure archive/close/finalize use canonical helpers
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_COMMAND="$SCRIPT_DIR/../commands/signum.md"
+OVERLAY_COMMAND="$SCRIPT_DIR/../platforms/claude-code/commands/signum.md"
+
+passed=0
+failed=0
+
+assert_pass() {
+  local name="$1"; shift
+  local output
+  if output=$("$@" 2>&1); then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s | %s\n' "$name" "$output"
+    failed=$((failed + 1))
+  fi
+}
+
+section_between() {
+  local file="$1"
+  local start_pat="$2"
+  local end_pat="$3"
+  awk -v start_pat="$start_pat" -v end_pat="$end_pat" '
+    $0 ~ start_pat { in_section=1 }
+    in_section { print }
+    in_section && $0 ~ end_pat { exit }
+  ' "$file"
+}
+
+assert_section_absent() {
+  local name="$1"
+  local pattern="$2"
+  local section="$3"
+  if grep -Fq "$pattern" <<<"$section"; then
+    printf '  FAIL: %s | found forbidden pattern: %s\n' "$name" "$pattern"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Canonical archive/cleanup paths ==="
+
+ROOT_ARCHIVE_SECTION=$(section_between "$ROOT_COMMAND" '^If the user.*`archive`' '^## Close Mode$')
+ROOT_CLOSE_SECTION=$(section_between "$ROOT_COMMAND" '^## Close Mode$' '^## Project Resolution$')
+ROOT_FINALIZE_SECTION=$(section_between "$ROOT_COMMAND" '^### Step 4\.5: Finalize run' '^## Error Handling$')
+OVERLAY_ARCHIVE_SECTION=$(section_between "$OVERLAY_COMMAND" '^If the user.*`archive`' '^## Close Mode$')
+OVERLAY_CLOSE_SECTION=$(section_between "$OVERLAY_COMMAND" '^## Close Mode$' '^## Project Resolution$')
+
+assert_pass "root archive uses archive_contract_artifacts" \
+  grep -Fq 'archive_contract_artifacts "$CONTRACT_ID" "$ARCHIVE_DIR"' <<<"$ROOT_ARCHIVE_SECTION"
+assert_pass "overlay archive uses archive_contract_artifacts" \
+  grep -Fq 'archive_contract_artifacts "$CONTRACT_ID" "$ARCHIVE_DIR"' <<<"$OVERLAY_ARCHIVE_SECTION"
+assert_pass "root archive cleans root compatibility views" \
+  grep -Fq 'purge_root_working_set_views >/dev/null 2>&1 || true' <<<"$ROOT_ARCHIVE_SECTION"
+assert_pass "overlay archive cleans root compatibility views" \
+  grep -Fq 'purge_root_working_set_views >/dev/null 2>&1 || true' <<<"$OVERLAY_ARCHIVE_SECTION"
+assert_pass "root close cleans root compatibility views" \
+  grep -Fq 'purge_root_working_set_views >/dev/null 2>&1 || true' <<<"$ROOT_CLOSE_SECTION"
+assert_pass "overlay close cleans root compatibility views" \
+  grep -Fq 'purge_root_working_set_views >/dev/null 2>&1 || true' <<<"$OVERLAY_CLOSE_SECTION"
+assert_pass "root finalize archives from canonical contract dir" \
+  grep -Fq 'archive_contract_artifacts "$CONTRACT_ID" "$ARCHIVE_TMP"' <<<"$ROOT_FINALIZE_SECTION"
+assert_pass "root finalize purges root views via helper" \
+  grep -Fq 'purge_root_working_set_views >/dev/null 2>&1 || true' <<<"$ROOT_FINALIZE_SECTION"
+assert_pass "root finalize copies archive tmp recursively" \
+  grep -Fq 'cp -R "$ARCHIVE_TMP"/. "$ARCHIVE_FINAL"/' <<<"$ROOT_FINALIZE_SECTION"
+
+assert_section_absent "root finalize no direct root contract copy" 'cp .signum/contract.json "$ARCHIVE_TMP/"' "$ROOT_FINALIZE_SECTION"
+assert_section_absent "root finalize no direct root receipts copy" 'cp -R .signum/receipts/. "$ARCHIVE_TMP/receipts/"' "$ROOT_FINALIZE_SECTION"
+assert_section_absent "root finalize no manual rm file list" 'rm -f .signum/contract.json' "$ROOT_FINALIZE_SECTION"
+assert_section_absent "root archive no direct canonical file copies in command doc" 'cp "${DIR}contract.json" "$ARCHIVE_DIR"' "$ROOT_ARCHIVE_SECTION"
+assert_section_absent "overlay archive no direct canonical file copies in command doc" 'cp "${DIR}contract.json" "$ARCHIVE_DIR"' "$OVERLAY_ARCHIVE_SECTION"
+
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+fi

--- a/tests/test-changelog-canonical-storage-wording.sh
+++ b/tests/test-changelog-canonical-storage-wording.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# test-changelog-canonical-storage-wording.sh -- keep recent changelog entries aligned with canonical contract-root storage wording
+set -euo pipefail
+
+CHANGELOG="$(cd "$(dirname "$0")/.." && pwd)/CHANGELOG.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$CHANGELOG"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$CHANGELOG"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Changelog canonical storage wording ==="
+
+assert_contains 'anti_entropy_report.json` under the active contract artifact root' "anti-entropy changelog uses canonical root wording"
+assert_contains 'writes append-only receipts under the active contract artifact root in `runs/<run_id>/`' "receipt-chain changelog uses canonical runs wording"
+assert_contains 'receipt-chain paths (`receipts/`, `runs/`, `snapshots/`) under the active contract artifact root' "engineer prompt changelog uses canonical verifier-owned paths"
+assert_contains 'Lane artifacts in `iterations/NN/lanes/A|B/` under the active contract artifact root' "parallel lanes changelog uses canonical iteration root"
+assert_contains 'Per-iteration artifact storage in `iterations/NN/` under the active contract artifact root' "iterative audit changelog uses canonical iteration root"
+
+assert_not_contains 'emits advisory `.signum/anti_entropy_report.json`' "changelog no longer teaches root anti-entropy artifact path"
+assert_not_contains 'writes append-only receipt to `.signum/runs/<run_id>/`' "changelog no longer teaches root runs path"
+assert_not_contains 'receipt-chain paths (`.signum/receipts/`, `.signum/runs/`, `.signum/snapshots/`)' "changelog no longer teaches root verifier-owned dirs"
+assert_not_contains 'Lane artifacts in `.signum/iterations/NN/lanes/A|B/`' "changelog no longer teaches root lane paths"
+assert_not_contains 'Per-iteration artifact storage in `.signum/iterations/NN/`' "changelog no longer teaches root iteration paths"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-claude-overlay-pack-parity.sh
+++ b/tests/test-claude-overlay-pack-parity.sh
@@ -23,9 +23,10 @@ assert_pass() {
 echo "=== Claude overlay PACK parity ==="
 assert_pass "overlay command exists" test -f "$COMMAND"
 assert_pass "explain mode lists anti-entropy PACK step" grep -Fq '"emit advisory anti-entropy report"' "$COMMAND"
-assert_pass "explain mode lists anti-entropy artifact" grep -Fq '".signum/anti_entropy_report.json"' "$COMMAND"
+assert_pass "explain mode lists canonical artifact root" grep -Fq '"artifactRoot": ".signum/contracts/<contractId>/"' "$COMMAND"
+assert_pass "explain mode lists anti-entropy artifact name" grep -Fq '"anti_entropy_report.json"' "$COMMAND"
 assert_pass "PACK calls pack-anti-entropy wrapper" grep -Fq 'bash lib/pack-anti-entropy.sh' "$COMMAND"
-assert_pass "per-contract sync copies anti-entropy artifact" grep -Fq 'cp .signum/anti_entropy_report.json "${DIR}"' "$COMMAND"
+assert_pass "per-contract sync includes anti-entropy artifact" grep -Fq '"anti_entropy_report.json"' "$COMMAND"
 assert_pass "final output shows anti-entropy summary" grep -Fq 'echo "Anti-entropy:' "$COMMAND"
 
 echo ""

--- a/tests/test-codex-clarification-research-canonical-paths.sh
+++ b/tests/test-codex-clarification-research-canonical-paths.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# test-codex-clarification-research-canonical-paths.sh -- keep codex clarification/self-improvement research doc aligned with canonical contract-root storage
+set -euo pipefail
+
+DOC="$(cd "$(dirname "$0")/.." && pwd)/docs/research/2026-03-15-codex-contract-clarification-self-improvement-loops.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Codex clarification research canonical paths ==="
+
+assert_contains '.signum/contracts/<contractId>/contract.json' "research doc uses canonical contract path"
+assert_not_contains '.signum/contract.json' "old root contract path removed"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-codex-skill-canonical-paths.sh
+++ b/tests/test-codex-skill-canonical-paths.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# test-codex-skill-canonical-paths.sh -- keep Codex Signum skill instructions aligned with canonical contract-root storage
+set -euo pipefail
+
+DOC="$(cd "$(dirname "$0")/.." && pwd)/platforms/codex/SKILL.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Codex skill canonical paths ==="
+
+assert_contains '.signum/contracts/<contractId>/' "skill doc introduces canonical artifact root"
+assert_contains '.signum/contracts/index.json.activeContractId' "skill doc mentions active contract registry"
+assert_contains 'Record attempts and outcomes in `execute_log.json` under the active contract artifact root.' "skill doc uses canonical execute log wording"
+assert_contains 'If `contracts/index.json.activeContractId` or other pipeline artifacts already exist:' "skill doc uses registry-first resume wording"
+
+assert_not_contains 'Keep all pipeline artifacts in `.signum/`.' "old root artifact rule removed"
+assert_not_contains '- `.signum/contract.json`' "old root contract path removed"
+assert_not_contains 'Capture baseline checks into `.signum/baseline.json`' "old root baseline wording removed"
+assert_not_contains 'Record attempts and outcomes in `.signum/execute_log.json`.' "old root execute log wording removed"
+assert_not_contains 'If `.signum/contract.json` or other pipeline artifacts already exist:' "old root resume wording removed"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-contract-bootstrap-canonical-paths.sh
+++ b/tests/test-contract-bootstrap-canonical-paths.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_CMD="/Users/vi/personal/heurema/signum/commands/signum.md"
+OVERLAY_CMD="/Users/vi/personal/heurema/signum/platforms/claude-code/commands/signum.md"
+
+extract_section() {
+  local file="$1"
+  local start="$2"
+  local end="$3"
+  awk -v start="$start" -v end="$end" '
+    $0 ~ start { capture=1 }
+    capture { print }
+    $0 ~ end && capture { exit }
+  ' "$file"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if ! grep -Fq -- "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to contain: $needle" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to not contain: $needle" >&2
+    exit 1
+  fi
+}
+
+check_file() {
+  local file="$1"
+  local label="$2"
+
+  local launch validate bootstrap
+  launch="$(extract_section "$file" '^### Step 1\.1: Launch Contractor' '^### Step 1\.2: Validate contract')"
+  validate="$(extract_section "$file" '^### Step 1\.2: Validate contract' '^### Step 1\.2\.3: Contract injection scan|^### Step 1\.2\.5: Finalize canonical contract bootstrap')"
+  bootstrap="$(extract_section "$file" '^### Step 1\.2\.5: Finalize canonical contract bootstrap' '^### Step 1\.2\.7: Module lifecycle check|^### Step 1\.3: Check for open questions')"
+
+  assert_contains "$launch" 'FILE_CONTRACT_ID=""' "$label launch"
+  assert_contains "$launch" 'SIGNUM_CONTRACT_PATH' "$label launch"
+  assert_contains "$launch" 'new_contract_id' "$label launch"
+  assert_contains "$launch" 'CONTRACT_ID="${FILE_CONTRACT_ID:-$(new_contract_id)}"' "$label launch"
+  assert_contains "$launch" 'init_contract_dir "$CONTRACT_ID"' "$label launch"
+  assert_contains "$launch" 'register_contract "$CONTRACT_ID" "draft"' "$label launch"
+  assert_contains "$launch" 'set_active_contract "$CONTRACT_ID"' "$label launch"
+  assert_contains "$launch" 'ARTIFACT_ROOT="$(active_artifact_root)"' "$label launch"
+  assert_contains "$launch" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label launch"
+  assert_contains "$launch" 'link_active_artifact "contract.json"' "$label launch"
+  assert_contains "$launch" 'cp "$SIGNUM_CONTRACT_PATH" "$CONTRACT_PATH"' "$label launch"
+  assert_contains "$launch" 'skip contractor launch and continue to Step 1.2' "$label launch"
+  assert_contains "$launch" 'CANONICAL_ARTIFACT_ROOT: <value emitted above>' "$label launch"
+  assert_contains "$launch" 'write `contract.json` to the canonical artifact root above' "$label launch"
+  assert_not_contains "$launch" 'write .signum/contract.json' "$label launch"
+
+  assert_contains "$validate" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label validate"
+  assert_contains "$validate" 'Pre-approved contract file is missing or invalid' "$label validate"
+  assert_not_contains "$validate" '.signum/contract.json' "$label validate"
+
+  assert_contains "$bootstrap" 'CONTRACT_ID="$(get_active_contract)"' "$label bootstrap"
+  assert_contains "$bootstrap" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label bootstrap"
+  assert_contains "$bootstrap" 'register_contract "$CONTRACT_ID" "draft"' "$label bootstrap"
+  assert_contains "$bootstrap" 'link_active_artifact "contract.json"' "$label bootstrap"
+  assert_not_contains "$bootstrap" 'sync_contract_artifacts "$CONTRACT_ID" "contract.json"' "$label bootstrap"
+  assert_not_contains "$bootstrap" 'promote_root_artifact_to_active "contract.json"' "$label bootstrap"
+  assert_not_contains "$bootstrap" '.signum/contract.json' "$label bootstrap"
+}
+
+check_file "$ROOT_CMD" "root"
+check_file "$OVERLAY_CMD" "overlay"
+
+echo "ok: contract bootstrap uses canonical active contract root from the start"

--- a/tests/test-contract-dir.sh
+++ b/tests/test-contract-dir.sh
@@ -59,8 +59,8 @@ assert_eq() {
 echo "=== contract_dir ==="
 
 assert_eq "returns path for valid id" \
-  ".signum/contracts/sig-20260314-abcd/" \
-  "$(contract_dir "sig-20260314-abcd")"
+  ".signum/contracts/sig-20260314-1030-abcd/" \
+  "$(contract_dir "sig-20260314-1030-abcd")"
 
 assert_fail "rejects empty id" "contractId required" \
   contract_dir ""
@@ -73,6 +73,27 @@ assert_fail "rejects double dot in id" "path traversal" \
 
 assert_fail "rejects slashed path" "path traversal" \
   contract_dir "../../etc/passwd"
+
+echo ""
+echo "=== new_contract_id ==="
+
+ID1=$(new_contract_id)
+ID2=$(new_contract_id)
+if [[ "$ID1" =~ ^sig-[0-9]{8}-[0-9]{4}-[0-9a-f]{4}$ ]]; then
+  printf '  PASS: new_contract_id format includes HHMM\n'
+  passed=$((passed + 1))
+else
+  printf '  FAIL: new_contract_id format includes HHMM - got "%s"\n' "$ID1"
+  failed=$((failed + 1))
+fi
+
+if [[ "$ID1" != "$ID2" ]]; then
+  printf '  PASS: new_contract_id produces unique values\n'
+  passed=$((passed + 1))
+else
+  printf '  FAIL: new_contract_id produces unique values - both were "%s"\n' "$ID1"
+  failed=$((failed + 1))
+fi
 
 echo ""
 echo "=== init_contract_dir ==="
@@ -130,7 +151,7 @@ echo "=== register_contract ==="
 
 assert_ok "registers new contract" register_contract "sig-test-001" "draft"
 ACTIVE=$(jq -r '.activeContractId' .signum/contracts/index.json)
-assert_eq "sets activeContractId" "sig-test-001" "$ACTIVE"
+assert_eq "register does not set activeContractId" "null" "$ACTIVE"
 
 STATUS=$(jq -r '.contracts[] | select(.contractId == "sig-test-001") | .status' .signum/contracts/index.json)
 assert_eq "status is draft" "draft" "$STATUS"
@@ -138,29 +159,47 @@ assert_eq "status is draft" "draft" "$STATUS"
 # Register second contract
 assert_ok "registers second contract" register_contract "sig-test-002" "active"
 ACTIVE=$(jq -r '.activeContractId' .signum/contracts/index.json)
-assert_eq "active switches to second" "sig-test-002" "$ACTIVE"
+assert_eq "register still leaves active unset" "null" "$ACTIVE"
 
 COUNT=$(jq '.contracts | length' .signum/contracts/index.json)
 assert_eq "two contracts in index" "2" "$COUNT"
 
-# Re-register updates existing (NOTE: this also sets activeContractId back to sig-test-001)
+# Re-register updates existing without stealing active selection
+assert_ok "sets active contract explicitly" set_active_contract "sig-test-002"
+ACTIVE=$(jq -r '.activeContractId' .signum/contracts/index.json)
+assert_eq "active switches only via explicit setter" "sig-test-002" "$ACTIVE"
+
 assert_ok "re-register updates existing" register_contract "sig-test-001" "completed"
 STATUS=$(jq -r '.contracts[] | select(.contractId == "sig-test-001") | .status' .signum/contracts/index.json)
 assert_eq "status updated to completed" "completed" "$STATUS"
 COUNT=$(jq '.contracts | length' .signum/contracts/index.json)
 assert_eq "still two contracts (no dup)" "2" "$COUNT"
 ACTIVE=$(jq -r '.activeContractId' .signum/contracts/index.json)
-assert_eq "active switches back on re-register" "sig-test-001" "$ACTIVE"
+assert_eq "re-register does not change active" "sig-test-002" "$ACTIVE"
 
 assert_fail "register fails without id" "contractId required" \
   register_contract ""
+assert_fail "set_active_contract fails without id" "contractId required" \
+  set_active_contract ""
+assert_fail "set_active_contract fails for missing contract" "not found in index" \
+  set_active_contract "sig-missing"
+
+echo ""
+echo "=== clear_active_contract ==="
+
+assert_ok "clears active contract explicitly" clear_active_contract
+ACTIVE=$(jq -r '.activeContractId' .signum/contracts/index.json)
+assert_eq "activeContractId is null after clear" "null" "$ACTIVE"
 
 echo ""
 echo "=== update_contract_status ==="
 
+assert_ok "re-sets active contract for terminal status test" set_active_contract "sig-test-002"
 assert_ok "updates existing status" update_contract_status "sig-test-002" "archived"
 STATUS=$(jq -r '.contracts[] | select(.contractId == "sig-test-002") | .status' .signum/contracts/index.json)
 assert_eq "status is archived" "archived" "$STATUS"
+ACTIVE=$(jq -r '.activeContractId' .signum/contracts/index.json)
+assert_eq "terminal status clears active contract" "null" "$ACTIVE"
 
 assert_fail "fails for missing contract" "not found in index" \
   update_contract_status "sig-nonexistent" "active"
@@ -172,13 +211,189 @@ echo ""
 echo "=== get_active_contract ==="
 
 ACTIVE=$(get_active_contract)
-assert_eq "returns active id" "sig-test-001" "$ACTIVE"
+assert_eq "returns empty when no active id is set" "" "$ACTIVE"
+
+STATUS=$(get_contract_status "sig-test-002")
+assert_eq "get_contract_status returns archived status" "archived" "$STATUS"
+assert_fail "get_contract_status fails without id" "contractId required" \
+  get_contract_status ""
+assert_fail "get_contract_status fails for missing contract" "not found in index" \
+  get_contract_status "sig-missing"
 
 echo ""
-echo "=== current_contract_dir ==="
+echo "=== describe_active_contract_state ==="
 
+STATE_JSON=$(describe_active_contract_state)
+assert_eq "describe_active_contract_state returns NONE without active contract" "NONE" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.state')"
+assert_eq "describe_active_contract_state returns null contractId when inactive" "null" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.contractId')"
+
+echo ""
+echo "=== active_artifact_root / current_contract_dir ==="
+
+ACTIVE_ID="sig-active-001"
+assert_ok "creates active draft contract dir" init_contract_dir "$ACTIVE_ID"
+printf '{"goal":"active"}\n' > ".signum/contracts/${ACTIVE_ID}/contract.json"
+assert_ok "registers active draft contract" register_contract "$ACTIVE_ID" "draft"
+assert_ok "sets active contract for root lookup" set_active_contract "$ACTIVE_ID"
+DIR=$(active_artifact_root)
+assert_eq "returns active artifact root" ".signum/contracts/${ACTIVE_ID}/" "$DIR"
 DIR=$(current_contract_dir)
-assert_eq "returns active dir" ".signum/contracts/sig-test-001/" "$DIR"
+assert_eq "current_contract_dir remains alias" ".signum/contracts/${ACTIVE_ID}/" "$DIR"
+PATH_TO_CONTRACT=$(active_artifact_path "contract.json")
+assert_eq "active_artifact_path returns active file path" ".signum/contracts/${ACTIVE_ID}/contract.json" "$PATH_TO_CONTRACT"
+STATE_JSON=$(describe_active_contract_state)
+assert_eq "active contract with only contract.json is CONTRACT_ONLY" "CONTRACT_ONLY" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.state')"
+assert_eq "describe_active_contract_state includes active contract id" "$ACTIVE_ID" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.contractId')"
+assert_eq "describe_active_contract_state includes active artifact root" ".signum/contracts/${ACTIVE_ID}/" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.artifactRoot')"
+
+echo ""
+echo "=== link_active_artifact / promote_root_artifact_to_active ==="
+
+printf '{"goal":"canonical"}\n' > .signum/contract.json
+assert_ok "promotes root contract into active root" promote_root_artifact_to_active "contract.json"
+assert_eq "promoted contract now exists in active root" "true" \
+  "$([ -f .signum/contracts/${ACTIVE_ID}/contract.json ] && echo true || echo false)"
+assert_eq "root contract path becomes symlink" "true" \
+  "$([ -L .signum/contract.json ] && echo true || echo false)"
+PROMOTED_CONTENT=$(cat ".signum/contracts/${ACTIVE_ID}/contract.json")
+assert_eq "promoted contract content preserved" '{"goal":"canonical"}' "$PROMOTED_CONTENT"
+
+assert_ok "links phase1 spec artifact into active root" link_active_artifact "spec_quality.json"
+assert_eq "root spec_quality path becomes symlink" "true" \
+  "$([ -L .signum/spec_quality.json ] && echo true || echo false)"
+printf '{"total":91}\n' > .signum/spec_quality.json
+assert_eq "writing through symlink lands in active root" '{"total":91}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/spec_quality.json")"
+assert_ok "links execution context into active root" link_active_artifact "execution_context.json"
+printf '{"run_id":"run-01"}\n' > .signum/execution_context.json
+STATE_JSON=$(describe_active_contract_state)
+assert_eq "active contract with execution_context becomes RESUMABLE" "RESUMABLE" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.state')"
+
+assert_ok "links execute patch into active root" link_active_artifact "combined.patch"
+printf 'diff --git a/foo b/foo\n' > .signum/combined.patch
+assert_eq "execute patch is written to active root" 'diff --git a/foo b/foo' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/combined.patch")"
+rm -f .signum/combined.patch
+assert_ok "re-links execute patch after cleanup" link_active_artifact "combined.patch"
+printf 'diff --git a/bar b/bar\n' > .signum/combined.patch
+assert_eq "relinked execute patch still writes canonically" 'diff --git a/bar b/bar' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/combined.patch")"
+
+assert_ok "links audit summary into active root" link_active_artifact "audit_summary.json"
+printf '{"decision":"AUTO_OK"}\n' > .signum/audit_summary.json
+assert_eq "audit summary is written to active root" '{"decision":"AUTO_OK"}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/audit_summary.json")"
+
+assert_ok "links proofpack into active root" link_active_artifact "proofpack.json"
+printf '{"runId":"sig-active-001"}\n' > .signum/proofpack.json
+assert_eq "proofpack is written to active root" '{"runId":"sig-active-001"}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/proofpack.json")"
+assert_ok "sync of symlinked active proofpack is a no-op" \
+  sync_contract_artifacts "$ACTIVE_ID" "proofpack.json"
+assert_eq "self-copy sync keeps canonical proofpack content" '{"runId":"sig-active-001"}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/proofpack.json")"
+
+echo ""
+echo "=== ensure_active_artifact_dir / remove_root_artifact_view / reset_active_artifact ==="
+
+assert_ok "creates active reviews dir bridge" ensure_active_artifact_dir "reviews"
+assert_eq "root reviews path becomes symlink" "true" \
+  "$([ -L .signum/reviews ] && echo true || echo false)"
+mkdir -p .signum/reviews
+printf '{"decision":"APPROVE"}\n' > .signum/reviews/claude.json
+assert_eq "reviews dir writes into active root" '{"decision":"APPROVE"}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/reviews/claude.json")"
+assert_ok "sync of symlinked active reviews dir is a no-op" \
+  sync_contract_artifacts "$ACTIVE_ID" "reviews"
+assert_eq "self-copy sync keeps canonical reviews content" '{"decision":"APPROVE"}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/reviews/claude.json")"
+
+assert_ok "removes only root reviews view" remove_root_artifact_view "reviews"
+assert_eq "root reviews view removed" "false" \
+  "$([ -e .signum/reviews ] && echo true || echo false)"
+assert_eq "canonical reviews dir preserved" "true" \
+  "$([ -f ".signum/contracts/${ACTIVE_ID}/reviews/claude.json" ] && echo true || echo false)"
+
+assert_ok "resets dir artifact and re-links it" reset_active_artifact "reviews" "dir"
+assert_eq "reviews root relinked after reset" "true" \
+  "$([ -L .signum/reviews ] && echo true || echo false)"
+assert_eq "reviews canonical contents cleared on reset" "false" \
+  "$([ -f ".signum/contracts/${ACTIVE_ID}/reviews/claude.json" ] && echo true || echo false)"
+printf '{"decision":"RETRY"}\n' > .signum/reviews/codex.json
+assert_eq "reviews dir can be reused after reset" '{"decision":"RETRY"}' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/reviews/codex.json")"
+
+assert_ok "resets file artifact and re-links it" reset_active_artifact "iteration_delta.patch"
+assert_eq "iteration delta path is symlink after reset" "true" \
+  "$([ -L .signum/iteration_delta.patch ] && echo true || echo false)"
+assert_eq "iteration delta target cleared on reset" "false" \
+  "$([ -e ".signum/contracts/${ACTIVE_ID}/iteration_delta.patch" ] && echo true || echo false)"
+printf 'delta-v2\n' > .signum/iteration_delta.patch
+assert_eq "iteration delta writes canonically after reset" 'delta-v2' \
+  "$(cat ".signum/contracts/${ACTIVE_ID}/iteration_delta.patch")"
+
+assert_fail "reset_active_artifact rejects invalid kind" "kind must be file or dir" \
+  reset_active_artifact "proofpack.json" "weird"
+
+echo ""
+echo "=== archive_contract_artifacts / purge_root_working_set_views ==="
+
+assert_ok "re-links proofpack before archive helper" link_active_artifact "proofpack.json"
+printf '{"runId":"sig-active-001-archive"}\n' > .signum/proofpack.json
+printf '{"resolved":1}\n' > ".signum/contracts/${ACTIVE_ID}/reconcile_report.json"
+printf '{"risk":"medium"}\n' > ".signum/contracts/${ACTIVE_ID}/retro.json"
+mkdir -p ".signum/contracts/${ACTIVE_ID}/receipts"
+printf '{"status":"PASS"}\n' > ".signum/contracts/${ACTIVE_ID}/receipts/execute.json"
+ARCHIVE_OUT=".signum/archive/${ACTIVE_ID}"
+assert_ok "archives canonical contract payload" archive_contract_artifacts "$ACTIVE_ID" "$ARCHIVE_OUT"
+assert_eq "archive copies canonical contract" "true" \
+  "$([ -f "${ARCHIVE_OUT}/contract.json" ] && echo true || echo false)"
+assert_eq "archive copies canonical proofpack" "true" \
+  "$([ -f "${ARCHIVE_OUT}/proofpack.json" ] && echo true || echo false)"
+assert_eq "archive copies reconcile report" "true" \
+  "$([ -f "${ARCHIVE_OUT}/reconcile_report.json" ] && echo true || echo false)"
+assert_eq "archive copies retro" "true" \
+  "$([ -f "${ARCHIVE_OUT}/retro.json" ] && echo true || echo false)"
+assert_eq "archive copies receipts dir contents" "true" \
+  "$([ -f "${ARCHIVE_OUT}/receipts/execute.json" ] && echo true || echo false)"
+assert_fail "archive helper rejects missing contract id" "contractId and archive_dir required" \
+  archive_contract_artifacts ""
+
+printf '{"baseline":true}\n' > .signum/repo_contract_baseline.json
+printf 'prompt\n' > .signum/review_prompt_codex.txt
+assert_ok "re-links review context before purge" link_active_artifact "review_context.json"
+printf '{"issue_refs":[]}\n' > .signum/review_context.json
+assert_ok "purges root working set compatibility surface" purge_root_working_set_views
+assert_eq "root proofpack view removed" "false" \
+  "$([ -e .signum/proofpack.json ] && echo true || echo false)"
+assert_eq "root reviews view removed" "false" \
+  "$([ -e .signum/reviews ] && echo true || echo false)"
+assert_eq "root repo baseline removed" "false" \
+  "$([ -e .signum/repo_contract_baseline.json ] && echo true || echo false)"
+assert_eq "root review prompt removed" "false" \
+  "$([ -e .signum/review_prompt_codex.txt ] && echo true || echo false)"
+assert_eq "root review context removed" "false" \
+  "$([ -e .signum/review_context.json ] && echo true || echo false)"
+assert_eq "canonical proofpack preserved after purge" "true" \
+  "$([ -f ".signum/contracts/${ACTIVE_ID}/proofpack.json" ] && echo true || echo false)"
+assert_eq "canonical reviews preserved after purge" "true" \
+  "$([ -f ".signum/contracts/${ACTIVE_ID}/reviews/codex.json" ] && echo true || echo false)"
+assert_eq "canonical review context preserved after purge" "true" \
+  "$([ -f ".signum/contracts/${ACTIVE_ID}/review_context.json" ] && echo true || echo false)"
+
+assert_ok "marks contract terminal for stale-active cleanup test" update_contract_status "$ACTIVE_ID" "completed"
+assert_ok "re-sets completed contract as active to simulate stale index" set_active_contract "$ACTIVE_ID"
+STATE_JSON=$(describe_active_contract_state)
+assert_eq "terminal active contract is treated as NONE" "NONE" \
+  "$(printf '%s' "$STATE_JSON" | jq -r '.state')"
+assert_eq "terminal active contract is cleared from index" "" \
+  "$(get_active_contract)"
 
 echo ""
 echo "=== Results ==="

--- a/tests/test-contract-hierarchy-research-canonical-paths.sh
+++ b/tests/test-contract-hierarchy-research-canonical-paths.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# test-contract-hierarchy-research-canonical-paths.sh -- keep contract hierarchy research doc aligned with canonical contract-root storage
+set -euo pipefail
+
+DOC="$(cd "$(dirname "$0")/.." && pwd)/docs/research/2026-03-15-contract-hierarchy-clarification-architecture-2026.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Contract hierarchy research canonical paths ==="
+
+assert_contains '.signum/contracts/<contractId>/contract.json' "research doc uses canonical contract path"
+assert_contains '.signum/contracts/<contractId>/contract-engineer.json' "research doc uses canonical contract-engineer path"
+assert_contains '.signum/contracts/<contractId>/contract-policy.json' "research doc uses canonical contract-policy path"
+assert_contains '.signum/contracts/<contractId>/proofpack.json' "research doc uses canonical proofpack path"
+
+assert_not_contains '├── .signum/contract.json' "old root contract path removed"
+assert_not_contains '├── .signum/contract-engineer.json' "old root contract-engineer path removed"
+assert_not_contains '├── .signum/contract-policy.json' "old root contract-policy path removed"
+assert_not_contains '└── .signum/proofpack.json' "old root proofpack path removed"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-contract-injection-scan.sh
+++ b/tests/test-contract-injection-scan.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# test-contract-injection-scan.sh -- tests canonical and legacy path discovery for lib/contract-injection-scan.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCAN_SCRIPT="$SCRIPT_DIR/../lib/contract-injection-scan.sh"
+
+passed=0
+failed=0
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+assert_exit() {
+  local name="$1" expected_exit="$2"
+  shift 2
+  local output exit_code
+  set +e
+  output=$("$@" 2>&1)
+  exit_code=$?
+  set -e
+  if [ "$exit_code" -eq "$expected_exit" ]; then
+    printf '  PASS: %s (exit=%s)\n' "$name" "$exit_code"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- expected exit %s, got %s: %s\n' "$name" "$expected_exit" "$exit_code" "$output"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$name" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+write_clean_contract() {
+  local path="$1"
+  cat > "$path" <<'JSON'
+{
+  "schemaVersion": "3.8",
+  "goal": "Ship clean contract",
+  "inScope": ["src/app.py"],
+  "acceptanceCriteria": [
+    {"id": "AC1", "description": "Works", "verify": "pytest"}
+  ],
+  "riskLevel": "low"
+}
+JSON
+}
+
+write_injected_contract() {
+  local path="$1"
+  python3 - "$path" <<'PY'
+import json, sys
+path = sys.argv[1]
+data = {
+    "schemaVersion": "3.8",
+    "goal": "Ship\u200b injected contract",
+    "inScope": ["src/app.py"],
+    "acceptanceCriteria": [{"id": "AC1", "description": "Works", "verify": "pytest"}],
+    "riskLevel": "low"
+}
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(data, f)
+PY
+}
+
+echo "=== Existence ==="
+assert_exit "script exists and is executable after chmod" 0 chmod +x "$SCAN_SCRIPT"
+
+echo ""
+echo "=== Canonical default path ==="
+CANONICAL="$WORK/canonical"
+mkdir -p "$CANONICAL/.signum/contracts/sig-20260421-1200-abcd"
+cat > "$CANONICAL/.signum/contracts/index.json" <<'JSON'
+{
+  "activeContractId": "sig-20260421-1200-abcd",
+  "contracts": [
+    {
+      "contractId": "sig-20260421-1200-abcd",
+      "status": "draft",
+      "directory": ".signum/contracts/sig-20260421-1200-abcd/"
+    }
+  ]
+}
+JSON
+write_clean_contract "$CANONICAL/.signum/contracts/sig-20260421-1200-abcd/contract.json"
+assert_exit "default scan resolves canonical active contract path" 0 bash -lc "cd '$CANONICAL' && '$SCAN_SCRIPT'"
+
+echo ""
+echo "=== Legacy fallback ==="
+LEGACY="$WORK/legacy"
+mkdir -p "$LEGACY/.signum"
+write_clean_contract "$LEGACY/.signum/contract.json"
+assert_exit "default scan falls back to legacy root contract" 0 bash -lc "cd '$LEGACY' && '$SCAN_SCRIPT'"
+
+echo ""
+echo "=== Single canonical contract dir fallback ==="
+SINGLE_CANONICAL="$WORK/single-canonical"
+mkdir -p "$SINGLE_CANONICAL/.signum/contracts/sig-20260421-1315-cafe"
+write_clean_contract "$SINGLE_CANONICAL/.signum/contracts/sig-20260421-1315-cafe/contract.json"
+assert_exit "default scan falls back to single canonical contract dir without index" 0 bash -lc "cd '$SINGLE_CANONICAL' && '$SCAN_SCRIPT'"
+
+echo ""
+echo "=== Explicit path and blocked unicode ==="
+BLOCKED="$WORK/blocked"
+mkdir -p "$BLOCKED"
+write_injected_contract "$BLOCKED/injected.json"
+set +e
+BLOCKED_OUTPUT=$("$SCAN_SCRIPT" "$BLOCKED/injected.json" 2>&1)
+BLOCKED_EXIT=$?
+set -e
+if [ "$BLOCKED_EXIT" -eq 1 ]; then
+  printf '  PASS: explicit injected contract is blocked (exit=1)\n'
+  passed=$((passed + 1))
+else
+  printf '  FAIL: explicit injected contract -- expected exit 1, got %s: %s\n' "$BLOCKED_EXIT" "$BLOCKED_OUTPUT"
+  failed=$((failed + 1))
+fi
+assert_contains "blocked output mentions invisible Unicode" 'BLOCKED: invisible Unicode' "$BLOCKED_OUTPUT"
+
+echo ""
+echo "=== Missing file ==="
+MISSING="$WORK/missing"
+mkdir -p "$MISSING"
+assert_exit "missing default contract returns usage error" 2 bash -lc "cd '$MISSING' && '$SCAN_SCRIPT'"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-contract-phase-canonical-paths.sh
+++ b/tests/test-contract-phase-canonical-paths.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_CMD="/Users/vi/personal/heurema/signum/commands/signum.md"
+OVERLAY_CMD="/Users/vi/personal/heurema/signum/platforms/claude-code/commands/signum.md"
+
+extract_section() {
+  local file="$1"
+  local start="$2"
+  local end="$3"
+  awk -v start="$start" -v end="$end" '
+    $0 ~ start { capture=1 }
+    capture { print }
+    $0 ~ end && capture { exit }
+  ' "$file"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if ! grep -Fq -- "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to contain: $needle" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to not contain: $needle" >&2
+    exit 1
+  fi
+}
+
+check_file() {
+  local file="$1"
+  local label="$2"
+
+  local open_questions spec_quality intent spec_validation clover summary hash engineer policy
+  open_questions="$(extract_section "$file" '^### Step 1\.3: Check for open questions' '^### Step 1\.3\.5: Spec quality check')"
+  spec_quality="$(extract_section "$file" '^### Step 1\.3\.5: Spec quality check' '^### Step 1\.3\.6: Intent alignment check')"
+  intent="$(extract_section "$file" '^### Step 1\.3\.6: Intent alignment check' '^### Step 1\.3\.7: Multi-model spec validation')"
+  spec_validation="$(extract_section "$file" '^### Step 1\.3\.7: Multi-model spec validation' '^### Step 1\.3\.8: Clover reconstruction test')"
+  clover="$(extract_section "$file" '^### Step 1\.3\.8: Clover reconstruction test' '^### Step 1\.4: Display contract summary')"
+  summary="$(extract_section "$file" '^### Step 1\.4: Display contract summary' '^### Step 1\.4\.5: Record approval timestamp')"
+  hash="$(extract_section "$file" '^### Step 1\.4\.5: Record approval timestamp' '^### Step 1\.5: Prepare sanitized engineer contract')"
+  engineer="$(extract_section "$file" '^### Step 1\.5: Prepare sanitized engineer contract' '^### Step 1\.6: Generate execution policy')"
+  policy="$(extract_section "$file" '^### Step 1\.6: Generate execution policy' '^---$')"
+
+  assert_contains "$open_questions" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label open questions"
+  assert_not_contains "$open_questions" '.signum/contract.json' "$label open questions"
+
+  assert_contains "$spec_quality" 'SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"' "$label spec quality"
+  assert_contains "$spec_quality" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label spec quality"
+  assert_not_contains "$spec_quality" '.signum/contract.json' "$label spec quality"
+  assert_not_contains "$spec_quality" '.signum/spec_quality.json' "$label spec quality"
+
+  assert_contains "$intent" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label intent"
+  assert_contains "$intent" 'intent_check.json` under the canonical artifact root' "$label intent"
+  assert_not_contains "$intent" '.signum/contract.json' "$label intent"
+  assert_not_contains "$intent" '.signum/intent_check.json' "$label intent"
+
+  assert_contains "$spec_validation" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label spec validation"
+  assert_contains "$spec_validation" 'SPEC_VALIDATION_PATH="${ARTIFACT_ROOT}spec_validation.json"' "$label spec validation"
+  assert_not_contains "$spec_validation" '.signum/contract.json' "$label spec validation"
+  assert_not_contains "$spec_validation" '.signum/spec_validation.json' "$label spec validation"
+
+  assert_contains "$clover" 'CLOVER_REPORT_PATH="${ARTIFACT_ROOT}clover_report.json"' "$label clover"
+  assert_contains "$clover" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label clover"
+  assert_not_contains "$clover" '.signum/contract.json' "$label clover"
+  assert_not_contains "$clover" '.signum/clover_report.json' "$label clover"
+
+  assert_contains "$summary" 'SPEC_QUALITY_PATH="${ARTIFACT_ROOT}spec_quality.json"' "$label summary"
+  assert_contains "$summary" 'CLOVER_REPORT_PATH="${ARTIFACT_ROOT}clover_report.json"' "$label summary"
+  assert_contains "$summary" 'INTENT_CHECK_PATH="${ARTIFACT_ROOT}intent_check.json"' "$label summary"
+  assert_contains "$summary" 'APPROVAL_PATH="${ARTIFACT_ROOT}approval.json"' "$label summary"
+  assert_not_contains "$summary" '.signum/contract.json' "$label summary"
+  assert_not_contains "$summary" '.signum/spec_quality.json' "$label summary"
+  assert_not_contains "$summary" '.signum/clover_report.json' "$label summary"
+  assert_not_contains "$summary" '.signum/intent_check.json' "$label summary"
+  assert_not_contains "$summary" '.signum/approval.json' "$label summary"
+
+  assert_contains "$hash" 'CONTRACT_HASH_PATH="${ARTIFACT_ROOT}contract-hash.txt"' "$label hash"
+  assert_contains "$hash" 'contract_file: $CONTRACT_PATH' "$label hash"
+  assert_not_contains "$hash" '.signum/contract.json' "$label hash"
+  assert_not_contains "$hash" '.signum/contract-hash.txt' "$label hash"
+
+  assert_contains "$engineer" 'CONTRACT_ENGINEER_PATH="${ARTIFACT_ROOT}contract-engineer.json"' "$label engineer"
+  assert_contains "$engineer" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label engineer"
+  assert_not_contains "$engineer" '.signum/contract.json' "$label engineer"
+  assert_not_contains "$engineer" '.signum/contract-engineer.json' "$label engineer"
+
+  assert_contains "$policy" 'CONTRACT_POLICY_PATH="${ARTIFACT_ROOT}contract-policy.json"' "$label policy"
+  assert_contains "$policy" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label policy"
+  assert_not_contains "$policy" '.signum/contract.json' "$label policy"
+  assert_not_contains "$policy" '.signum/contract-policy.json' "$label policy"
+}
+
+check_file "$ROOT_CMD" "root"
+check_file "$OVERLAY_CMD" "overlay"
+
+echo "ok: contract phase post-promotion flow uses canonical artifact-root paths"

--- a/tests/test-contractor-prompt-canonical-paths.sh
+++ b/tests/test-contractor-prompt-canonical-paths.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_PROMPT="/Users/vi/personal/heurema/signum/agents/contractor.md"
+OVERLAY_PROMPT="/Users/vi/personal/heurema/signum/platforms/claude-code/agents/contractor.md"
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if ! grep -Fq -- "$needle" "$file"; then
+    echo "FAIL: expected ${label} to contain: $needle" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    echo "FAIL: expected ${label} to not contain: $needle" >&2
+    exit 1
+  fi
+}
+
+check_file() {
+  local file="$1"
+  local label="$2"
+
+  assert_contains "$file" 'Write `contract.json` under the canonical active contract root provided by the orchestrator' "$label"
+  assert_contains "$file" 'canonical path under `.signum/contracts/<contractId>/` is the source of truth' "$label"
+  assert_contains "$file" '`.signum/contract.json` is only a compatibility view pointing at that canonical file' "$label"
+  assert_contains "$file" 'you MUST call Write for canonical `contract.json` by turn 10' "$label"
+  assert_not_contains "$file" 'Write `.signum/contract.json` following the schema' "$label"
+  assert_not_contains "$file" 'you MUST call Write for `.signum/contract.json` by turn 10' "$label"
+}
+
+check_file "$ROOT_PROMPT" "root contractor prompt"
+check_file "$OVERLAY_PROMPT" "overlay contractor prompt"
+
+echo "ok: contractor prompts use canonical contract root language"

--- a/tests/test-diff-progression-design-doc-canonical-paths.sh
+++ b/tests/test-diff-progression-design-doc-canonical-paths.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# test-diff-progression-design-doc-canonical-paths.sh -- keep diff progression design doc aligned with canonical contract-root storage
+set -euo pipefail
+
+DOC="$(cd "$(dirname "$0")/.." && pwd)/docs/plans/2026-03-15-diff-progression-design.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Diff progression design canonical paths ==="
+
+assert_contains 'ARTIFACT_ROOT=".signum/contracts/<contractId>"' "design doc introduces canonical artifact root"
+assert_contains 'git diff > "$ARTIFACT_ROOT/iteration_delta.patch"' "delta capture writes canonical working copy"
+assert_contains 'git diff "$BASE" > "$ARTIFACT_ROOT/combined.patch"' "combined patch capture writes canonical working copy"
+assert_contains '.signum/contracts/<contractId>/' "storage tree uses canonical contract root"
+assert_contains 'current delta (canonical working copy)' "storage description calls out canonical working copy"
+
+assert_not_contains 'git diff > .signum/iteration_delta.patch' "old root delta capture removed"
+assert_not_contains 'git diff $BASE > .signum/combined.patch' "old root combined patch capture removed"
+assert_not_contains 'rm -f .signum/iteration_delta.patch .signum/execute_log .signum/combined.patch' "old root stale-clear snippet removed"
+assert_not_contains '.signum/iterations/' "old root iteration storage removed"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-doc-canonical-artifact-root.sh
+++ b/tests/test-doc-canonical-artifact-root.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# test-doc-canonical-artifact-root.sh -- ensure core docs describe canonical contract artifact root
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+README="$SCRIPT_DIR/../README.md"
+REFERENCE="$SCRIPT_DIR/../docs/reference.md"
+HOW_IT_WORKS="$SCRIPT_DIR/../docs/how-it-works.md"
+
+passed=0
+failed=0
+
+assert_pass() {
+  local name="$1"; shift
+  local output
+  if output=$("$@" 2>&1); then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s — exited non-zero: %s\n' "$name" "$output"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_absent() {
+  local name="$1"; shift
+  local pattern="$1"; shift
+  local file="$1"
+  if grep -Fq "$pattern" "$file"; then
+    printf '  FAIL: %s — found forbidden pattern: %s\n' "$name" "$pattern"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Doc canonical artifact root ==="
+
+assert_pass "README mentions canonical contract artifact root" \
+  grep -Fq '.signum/contracts/<contractId>/' "$README"
+assert_pass "README describes root signum as registry/state surface" \
+  grep -Fq 'registry/state surface' "$README"
+assert_pass "reference doc mentions active contract artifact root" \
+  grep -Fq 'active contract artifact root' "$REFERENCE"
+assert_pass "how-it-works mentions active contract artifact root" \
+  grep -Fq 'active contract artifact root' "$HOW_IT_WORKS"
+
+assert_absent "README no longer says root signum is live working set" \
+  '.signum/` remains the live working set for the current run' "$README"
+assert_absent "reference doc no longer says contractor writes root contract.json" \
+  'produces `.signum/contract.json`' "$REFERENCE"
+assert_absent "reference doc no longer lists execute outputs as root paths" \
+  'Outputs: `.signum/baseline.json`, `.signum/combined.patch`, `.signum/execute_log.json`.' "$REFERENCE"
+assert_absent "reference doc no longer says pack assembles root proofpack" \
+  'Assembles `.signum/proofpack.json`' "$REFERENCE"
+assert_absent "reference doc no longer points provider status to root reviews dir" \
+  'Check `.signum/reviews/` for provider status.' "$REFERENCE"
+assert_absent "reference doc no longer says root signum is live working set" \
+  'Live working-set artifacts are written to `.signum/`' "$REFERENCE"
+assert_absent "how-it-works no longer says baseline saved to root path" \
+  'saves exit codes to `.signum/baseline.json`' "$HOW_IT_WORKS"
+assert_absent "how-it-works no longer says root signum is live working set" \
+  'Live working-set artifacts are written to `.signum/`' "$HOW_IT_WORKS"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+fi

--- a/tests/test-engineer-prompt-canonical-paths.sh
+++ b/tests/test-engineer-prompt-canonical-paths.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# test-engineer-prompt-canonical-paths.sh -- keep engineer prompts aligned with canonical contract-root storage
+set -euo pipefail
+
+ROOT_PROMPT="$(cd "$(dirname "$0")/.." && pwd)/agents/engineer.md"
+OVERLAY_PROMPT="$(cd "$(dirname "$0")/.." && pwd)/platforms/claude-code/agents/engineer.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+check_prompt() {
+  local file="$1"
+  local label="$2"
+
+  assert_contains "$file" '.signum/contracts/<contractId>/' "$label mentions canonical artifact root"
+  assert_contains "$file" '.signum/contracts/<contractId>/contract-engineer.json' "$label uses canonical contract-engineer path"
+  assert_contains "$file" '.signum/contracts/<contractId>/baseline.json' "$label uses canonical baseline path"
+  assert_contains "$file" '.signum/contracts/<contractId>/execute_log.json' "$label uses canonical execute log path"
+  assert_contains "$file" '.signum/contracts/<contractId>/combined.patch' "$label uses canonical combined patch path"
+
+  assert_not_contains "$file" '- `.signum/contract-engineer.json`' "$label removes root contract-engineer input"
+  assert_not_contains "$file" 'Read `.signum/baseline.json`' "$label removes root baseline read"
+  assert_not_contains "$file" 'Generate `.signum/combined.patch` via `git diff`' "$label removes root combined patch output"
+  assert_not_contains "$file" 'Write `.signum/execute_log.json`' "$label removes root execute log output"
+}
+
+echo "=== Engineer prompt canonical paths ==="
+check_prompt "$ROOT_PROMPT" "root prompt"
+check_prompt "$OVERLAY_PROMPT" "overlay prompt"
+
+assert_contains "$OVERLAY_PROMPT" '.signum/contracts/<contractId>/receipts/**' "overlay prompt uses canonical forbidden receipt path"
+assert_not_contains "$OVERLAY_PROMPT" '.signum/receipts/**' "overlay prompt removes root forbidden receipt path"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-execute-boundary-canonical-paths.sh
+++ b/tests/test-execute-boundary-canonical-paths.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_CMD="/Users/vi/personal/heurema/signum/commands/signum.md"
+OVERLAY_CMD="/Users/vi/personal/heurema/signum/platforms/claude-code/commands/signum.md"
+
+extract_section() {
+  local file="$1"
+  local start="$2"
+  local end="$3"
+  awk -v start="$start" -v end="$end" '
+    $0 ~ start { capture=1 }
+    capture { print }
+    $0 ~ end && capture { exit }
+  ' "$file"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if ! grep -Fq -- "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to contain: $needle" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to not contain: $needle" >&2
+    exit 1
+  fi
+}
+
+check_file() {
+  local file="$1"
+  local label="$2"
+
+  local baseline snapshot execute boundary
+  baseline="$(extract_section "$file" '^### Step 2\.0: Capture baseline' '^If `repo-contract\.json` exists')"
+  snapshot="$(extract_section "$file" '^### Step 2\.0\.5: Capture pre-execute snapshot' '^### Step 2\.1: Launch Engineer')"
+  execute="$(extract_section "$file" '^### Step 2\.1: Launch Engineer' '^### Step 2\.4: Scope gate')"
+  boundary="$(extract_section "$file" '^### Step 2\.5: Boundary verification' '^If transition verifier exits non-zero')"
+
+  assert_contains "$baseline" 'EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"' "$label baseline"
+  assert_contains "$baseline" 'BASELINE_PATH="${ARTIFACT_ROOT}baseline.json"' "$label baseline"
+  assert_contains "$baseline" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label baseline"
+  assert_not_contains "$baseline" '> .signum/execution_context.json' "$label baseline"
+  assert_not_contains "$baseline" '> .signum/baseline.json' "$label baseline"
+
+  assert_contains "$snapshot" 'SNAPSHOT_PATH="${ARTIFACT_ROOT}snapshots/execute-attempt-01.json"' "$label snapshot"
+  assert_contains "$snapshot" '--signum-dir "$ARTIFACT_ROOT"' "$label snapshot"
+  assert_not_contains "$snapshot" '.signum/snapshots/execute-attempt-01.json' "$label snapshot"
+
+  assert_contains "$execute" 'The canonical artifact root for this execute phase is `.signum/contracts/<activeContractId>/`.' "$label execute"
+  assert_contains "$execute" 'EXECUTE_LOG_PATH="${ARTIFACT_ROOT}execute_log.json"' "$label execute"
+  assert_contains "$execute" 'COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"' "$label execute"
+  assert_not_contains "$execute" 'Read .signum/contract-engineer.json' "$label execute"
+  assert_not_contains "$execute" '.signum/execute_log.json' "$label execute"
+  assert_not_contains "$execute" '.signum/combined.patch' "$label execute"
+
+  assert_contains "$boundary" '--signum-dir "$ARTIFACT_ROOT"' "$label boundary"
+  assert_contains "$boundary" '--execution-context "$EXECUTION_CONTEXT_PATH"' "$label boundary"
+  assert_contains "$boundary" '--snapshot "$SNAPSHOT_PATH"' "$label boundary"
+  assert_not_contains "$boundary" '.signum/snapshots/execute-attempt-01.json' "$label boundary"
+}
+
+check_file "$ROOT_CMD" "root"
+check_file "$OVERLAY_CMD" "overlay"
+
+echo "ok: early execute and boundary flow use canonical artifact-root paths"

--- a/tests/test-execute-policy-holdout-canonical-paths.sh
+++ b/tests/test-execute-policy-holdout-canonical-paths.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_CMD="/Users/vi/personal/heurema/signum/commands/signum.md"
+OVERLAY_CMD="/Users/vi/personal/heurema/signum/platforms/claude-code/commands/signum.md"
+
+extract_section() {
+  local file="$1"
+  local start="$2"
+  local end="$3"
+  awk -v start="$start" -v end="$end" '
+    $0 ~ start { capture=1 }
+    capture { print }
+    $0 ~ end && capture { exit }
+  ' "$file"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if ! grep -Fq -- "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to contain: $needle" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to not contain: $needle" >&2
+    exit 1
+  fi
+}
+
+check_file() {
+  local file="$1"
+  local label="$2"
+
+  local scope_gate policy_gate scope_exists risk mechanic policy_scan holdout
+  scope_gate="$(extract_section "$file" '^### Step 2\.4: Scope gate' '^If scope violation')"
+  policy_gate="$(extract_section "$file" '^### Step 2\.4\.5: Policy compliance check' '^If output contains `AUTO_BLOCK`')"
+  scope_exists="$(extract_section "$file" '^### Step 2\.4\.6: Scope existence gate' '^### Phase 3: AUDIT')"
+  risk="$(extract_section "$file" '^Use the Bash tool to read the risk level and save it for conditional checks:' '^Save `RISK_LEVEL`')"
+  mechanic="$(extract_section "$file" '^### Step 3\.1: Mechanic' '^If any check has a NEW regression')"
+  policy_scan="$(extract_section "$file" '^### Step 3\.1\.3: Policy scanner' '^If `POLICY_CRITICAL` is greater than 0')"
+  holdout="$(extract_section "$file" '^### Step 3\.1\.5: Holdout validation' '^### Step 3\.2\.0: Gather review context')"
+
+  assert_contains "$scope_gate" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label scope gate"
+  assert_not_contains "$scope_gate" '.signum/contract.json' "$label scope gate"
+
+  assert_contains "$policy_gate" 'CONTRACT_POLICY_PATH="${ARTIFACT_ROOT}contract-policy.json"' "$label policy gate"
+  assert_contains "$policy_gate" 'POLICY_VIOLATIONS_PATH="${ARTIFACT_ROOT}policy_violations.json"' "$label policy gate"
+  assert_not_contains "$policy_gate" '.signum/contract-policy.json' "$label policy gate"
+  assert_not_contains "$policy_gate" '.signum/policy_violations.json' "$label policy gate"
+
+  assert_contains "$scope_exists" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label scope existence"
+  assert_not_contains "$scope_exists" '.signum/contract.json' "$label scope existence"
+
+  assert_contains "$risk" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label risk"
+  assert_not_contains "$risk" '.signum/contract.json' "$label risk"
+
+  assert_contains "$mechanic" 'BASELINE_PATH="${ARTIFACT_ROOT}baseline.json"' "$label mechanic"
+  assert_not_contains "$mechanic" '.signum/baseline.json' "$label mechanic"
+
+  assert_contains "$policy_scan" 'COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"' "$label policy scan"
+  assert_contains "$policy_scan" 'POLICY_SCAN_PATH="${ARTIFACT_ROOT}policy_scan.json"' "$label policy scan"
+  assert_not_contains "$policy_scan" '.signum/combined.patch' "$label policy scan"
+  assert_not_contains "$policy_scan" '.signum/policy_scan.json' "$label policy scan"
+
+  assert_contains "$holdout" 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$label holdout"
+  assert_contains "$holdout" 'HOLDOUT_REPORT_PATH="${ARTIFACT_ROOT}holdout_report.json"' "$label holdout"
+  assert_not_contains "$holdout" '.signum/contract.json' "$label holdout"
+  assert_not_contains "$holdout" '.signum/holdout_report.json' "$label holdout"
+}
+
+check_file "$ROOT_CMD" "root"
+check_file "$OVERLAY_CMD" "overlay"
+
+echo "ok: execute policy and holdout flow use canonical artifact-root paths"

--- a/tests/test-extractable-checks-research-canonical-paths.sh
+++ b/tests/test-extractable-checks-research-canonical-paths.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# test-extractable-checks-research-canonical-paths.sh -- keep extractable-checks research doc aligned with canonical contract-root storage
+set -euo pipefail
+
+DOC="$(cd "$(dirname "$0")/.." && pwd)/docs/research/2026-03-15-extractable-checks-architecture.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Extractable checks research canonical paths ==="
+
+assert_contains 'CONTRACT_PATH=".signum/contracts/<contractId>/contract.json"' "research doc introduces canonical contract path variable"
+assert_contains 'RESULT=$(lib/glossary-check.sh "$CONTRACT_PATH" "$GLOSSARY_PATH" 2>/dev/null || echo '\''{}'\'')' "research doc uses canonical contract path in glossary-check example"
+assert_not_contains 'RESULT=$(lib/glossary-check.sh .signum/contract.json "$GLOSSARY_PATH" 2>/dev/null || echo '\''{}'\'')' "old root contract path example removed"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-final-output-canonical-paths.sh
+++ b/tests/test-final-output-canonical-paths.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# test-final-output-canonical-paths.sh -- ensure final output references canonical artifact root
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_COMMAND="$SCRIPT_DIR/../commands/signum.md"
+OVERLAY_COMMAND="$SCRIPT_DIR/../platforms/claude-code/commands/signum.md"
+
+passed=0
+failed=0
+
+assert_pass() {
+  local name="$1"; shift
+  local output
+  if output=$("$@" 2>&1); then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s — exited non-zero: %s\n' "$name" "$output"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_absent() {
+  local name="$1"; shift
+  local pattern="$1"; shift
+  local file="$1"
+  if grep -Fq "$pattern" "$file"; then
+    printf '  FAIL: %s — found forbidden pattern: %s\n' "$name" "$pattern"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Final output canonical paths ==="
+
+for command in "$ROOT_COMMAND" "$OVERLAY_COMMAND"; do
+  label="$(basename "$(dirname "$command")")"
+  assert_pass "command exists for ${label}" test -f "$command"
+  assert_pass "final output uses active_artifact_root for ${label}" \
+    grep -Fq 'ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"' "$command"
+  assert_pass "final output shows canonical artifact root banner for ${label}" \
+    grep -Fq 'echo "=== Canonical artifact root ==="' "$command"
+  assert_pass "final output instructs users to use canonical artifact root for ${label}" \
+    grep -Fq 'canonical artifact root shown above' "$command"
+done
+
+assert_absent "root command removed old .signum artifact banner" \
+  'echo "=== Artifacts in .signum/ ==="' "$ROOT_COMMAND"
+assert_absent "overlay command removed old .signum artifact banner" \
+  'echo "=== Artifacts in .signum/ ==="' "$OVERLAY_COMMAND"
+assert_absent "root next steps no longer point at .signum/combined.patch" \
+  'Review `.signum/combined.patch`' "$ROOT_COMMAND"
+assert_absent "root next steps no longer point at .signum/audit_summary.json" \
+  'Review `.signum/audit_summary.json`' "$ROOT_COMMAND"
+assert_absent "overlay next steps no longer point at .signum/combined.patch" \
+  'Review `.signum/combined.patch`' "$OVERLAY_COMMAND"
+assert_absent "overlay next steps no longer point at .signum/audit_summary.json" \
+  'Review `.signum/audit_summary.json`' "$OVERLAY_COMMAND"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+fi

--- a/tests/test-helper-output-paths.sh
+++ b/tests/test-helper-output-paths.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+POLICY_ROOT="$ROOT_DIR/lib/policy-scanner.sh"
+POLICY_OVERLAY="$ROOT_DIR/platforms/claude-code/lib/policy-scanner.sh"
+MECHANIC_ROOT="$ROOT_DIR/lib/mechanic-parser.sh"
+MECHANIC_OVERLAY="$ROOT_DIR/platforms/claude-code/lib/mechanic-parser.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+run_policy_case() {
+  local script="$1"
+  local label="$2"
+  local case_dir="$WORK/$label-policy"
+  mkdir -p "$case_dir/artifacts"
+  cat > "$case_dir/artifacts/combined.patch" <<'EOF'
+diff --git a/src/demo.py b/src/demo.py
+@@ -0,0 +1,2 @@
++def handler():
++    return None
+EOF
+  (
+    cd "$case_dir"
+    "$script" "$case_dir/artifacts/combined.patch" >/dev/null
+  )
+  test -f "$case_dir/artifacts/policy_scan.json"
+  test ! -f "$case_dir/.signum/policy_scan.json"
+}
+
+run_mechanic_case() {
+  local script="$1"
+  local label="$2"
+  local case_dir="$WORK/$label-mechanic"
+  mkdir -p "$case_dir/artifacts"
+  cat > "$case_dir/artifacts/baseline.json" <<'EOF'
+{"lint":0,"typecheck":0,"tests":{"exit_code":0,"failing":[]}}
+EOF
+  (
+    cd "$case_dir"
+    "$script" "$case_dir/artifacts/baseline.json" >/dev/null
+  )
+  test -f "$case_dir/artifacts/mechanic_report.json"
+  jq -e '.hasRegressions == false' "$case_dir/artifacts/mechanic_report.json" >/dev/null
+  test ! -f "$case_dir/.signum/mechanic_report.json"
+}
+
+run_policy_case "$POLICY_ROOT" "root"
+run_policy_case "$POLICY_OVERLAY" "overlay"
+run_mechanic_case "$MECHANIC_ROOT" "root"
+run_mechanic_case "$MECHANIC_OVERLAY" "overlay"
+
+echo "ok: helper scripts write outputs next to canonical input artifacts"

--- a/tests/test-intentional-root-compatibility-mentions.sh
+++ b/tests/test-intentional-root-compatibility-mentions.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# test-intentional-root-compatibility-mentions.sh -- keep remaining root-path mentions explicit and intentional
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local file="$1" needle="$2" label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_no_matches() {
+  local label="$1"
+  shift
+  if "$@" >/tmp/test_out.$$ 2>&1; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s\n' "$label"
+    sed 's/^/    /' /tmp/test_out.$$
+    failed=$((failed + 1))
+  fi
+  rm -f /tmp/test_out.$$
+}
+
+assert_exact_file_set() {
+  local label="$1"
+  local actual expected
+  actual="$2"
+  expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s\n' "$label"
+    printf '    expected:\n%s\n' "$expected"
+    printf '    actual:\n%s\n' "$actual"
+    failed=$((failed + 1))
+  fi
+}
+
+echo "=== Intentional root compatibility mentions ==="
+
+CONTRACT_HITS="$(
+  cd "$ROOT_DIR" && \
+  rg -l '\.signum/contract\.json' \
+    --glob '!**/tests/**' \
+    --glob '!commands/signum.md' \
+    --glob '!platforms/claude-code/commands/signum.md' \
+    --glob '!lib/contract-injection-scan.sh' \
+    --glob '!platforms/claude-code/lib/signum-ci.sh' \
+    --glob '!lib/signum-ci.sh' \
+    --glob '!lib/snapshot-tree.sh' \
+    --glob '!lib/proofpack-index.sh' \
+    . | sort
+)"
+
+EXPECTED_CONTRACT_HITS=$'./README.md\n./agents/contractor.md\n./docs/reference.md\n./platforms/claude-code/agents/contractor.md'
+
+assert_exact_file_set \
+  "only intentional non-test root contract mentions remain" \
+  "$CONTRACT_HITS" \
+  "$EXPECTED_CONTRACT_HITS"
+
+assert_contains "$ROOT_DIR/README.md" \
+  'resume checks should use the registry first, not root `.signum/contract.json`' \
+  "README frames root contract path as non-primary resume fallback"
+assert_contains "$ROOT_DIR/docs/reference.md" \
+  'with a root `.signum/contract.json` compatibility path during the migration' \
+  "reference doc frames root contract path as compatibility path"
+assert_contains "$ROOT_DIR/agents/contractor.md" \
+  '`.signum/contract.json` is only a compatibility view pointing at that canonical file' \
+  "root contractor prompt frames root contract path as compatibility view"
+assert_contains "$ROOT_DIR/platforms/claude-code/agents/contractor.md" \
+  '`.signum/contract.json` is only a compatibility view pointing at that canonical file' \
+  "overlay contractor prompt frames root contract path as compatibility view"
+
+assert_no_matches \
+  "no stray root proofpack path remains outside legacy helpers and tests" \
+  bash -lc "cd '$ROOT_DIR' && ! rg -n '\\.signum/proofpack\\.json' \
+    --glob '!**/tests/**' \
+    --glob '!commands/signum.md' \
+    --glob '!platforms/claude-code/commands/signum.md' \
+    --glob '!lib/signum-ci.sh' \
+    --glob '!platforms/claude-code/lib/signum-ci.sh' \
+    --glob '!lib/proofpack-index.sh' \
+    ."
+
+assert_no_matches \
+  "no stray root audit-summary path remains outside commands and tests" \
+  bash -lc "cd '$ROOT_DIR' && ! rg -n '\\.signum/audit_summary\\.json' \
+    --glob '!**/tests/**' \
+    --glob '!commands/signum.md' \
+    --glob '!platforms/claude-code/commands/signum.md' \
+    ."
+
+assert_no_matches \
+  "no stray root baseline path remains outside commands and tests" \
+  bash -lc "cd '$ROOT_DIR' && ! rg -n '\\.signum/baseline\\.json' \
+    --glob '!**/tests/**' \
+    --glob '!commands/signum.md' \
+    --glob '!platforms/claude-code/commands/signum.md' \
+    ."
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [[ "$failed" -gt 0 ]]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-iterative-audit-canonical-paths.sh
+++ b/tests/test-iterative-audit-canonical-paths.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_CMD="/Users/vi/personal/heurema/signum/commands/signum.md"
+OVERLAY_CMD="/Users/vi/personal/heurema/signum/platforms/claude-code/commands/signum.md"
+
+extract_iterative_audit_section() {
+  local file="$1"
+  awk '
+    /^### Step 3\.5: Synthesizer \(agent\)/ { capture=1 }
+    capture { print }
+    /^## Phase 4: PACK/ && capture { exit }
+  ' "$file"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if ! grep -Fq "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to contain: $needle" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to not contain: $needle" >&2
+    exit 1
+  fi
+}
+
+ROOT_SECTION="$(extract_iterative_audit_section "$ROOT_CMD")"
+OVERLAY_SECTION="$(extract_iterative_audit_section "$OVERLAY_CMD")"
+
+for label in ROOT_SECTION OVERLAY_SECTION; do
+  section="${!label}"
+  assert_contains "$section" 'The canonical artifact root for this synthesis is `.signum/contracts/<activeContractId>/`.' "$label"
+  assert_contains "$section" 'REVIEWS_DIR="${ARTIFACT_ROOT}reviews"' "$label"
+  assert_contains "$section" 'AUDIT_SUMMARY_PATH="${ARTIFACT_ROOT}audit_summary.json"' "$label"
+  assert_contains "$section" 'AUDIT_ITERATION_LOG_PATH="${ARTIFACT_ROOT}audit_iteration_log.json"' "$label"
+  assert_contains "$section" 'REPAIR_BRIEF_PATH="${ARTIFACT_ROOT}repair_brief.json"' "$label"
+  assert_contains "$section" 'The canonical artifact root in this lane is `.signum/contracts/<activeContractId>/`.' "$label"
+  assert_not_contains "$section" '.signum/reviews/' "$label"
+  assert_not_contains "$section" '.signum/audit_summary.json' "$label"
+  assert_not_contains "$section" '.signum/audit_iteration_log.json' "$label"
+  assert_not_contains "$section" '.signum/repair_brief.json' "$label"
+  assert_not_contains "$section" 'Read .signum/mechanic_report.json' "$label"
+done
+
+echo "ok: iterative audit flow uses canonical artifact-root paths"

--- a/tests/test-iterative-audit-design-doc-canonical-paths.sh
+++ b/tests/test-iterative-audit-design-doc-canonical-paths.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# test-iterative-audit-design-doc-canonical-paths.sh -- keep the iterative audit design doc aligned with canonical contract-root storage
+set -euo pipefail
+
+DOC="$(cd "$(dirname "$0")/.." && pwd)/docs/plans/2026-03-15-iterative-audit-design.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Iterative audit design canonical paths ==="
+
+assert_contains 'active contract artifact root (`$ARTIFACT_ROOT`)' "repair brief section introduces canonical artifact root"
+assert_contains 'Read $ARTIFACT_ROOT/contract-engineer.json' "engineer invocation reads canonical contract-engineer path"
+assert_contains '.signum/contracts/<contractId>/' "per-iteration storage tree uses canonical contract root"
+assert_contains 'Full per-iteration artifacts are stored under the active contract artifact root in `iterations/`' "proofpack note uses canonical iteration storage"
+assert_contains 'Persist in `$ARTIFACT_ROOT/flaky_tests.json`' "flaky tracker uses canonical artifact root"
+
+assert_not_contains 'Read .signum/contract-engineer.json' "old root contract-engineer read removed"
+assert_not_contains 'Write .signum/combined.patch and .signum/execute_log.json.' "old root execute outputs removed"
+assert_not_contains 'Full per-iteration artifacts stored in `.signum/iterations/`' "old root iteration storage wording removed"
+assert_not_contains 'Persist in `.signum/flaky_tests.json`' "old root flaky storage wording removed"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-metric-ratchet.sh
+++ b/tests/test-metric-ratchet.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# test-metric-ratchet.sh -- project-root-aware path behavior for lib/metric-ratchet.sh
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+RATCHET_SCRIPT="$ROOT_DIR/lib/metric-ratchet.sh"
+
+passed=0
+failed=0
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+assert_ok() {
+  local name="$1"
+  shift
+  if "$@" >/tmp/test_out.$$ 2>&1; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s\n' "$name"
+    sed 's/^/    /' /tmp/test_out.$$
+    failed=$((failed + 1))
+  fi
+  rm -f /tmp/test_out.$$
+}
+
+make_dates() {
+  python3 - <<'PY'
+from datetime import datetime, timedelta, timezone
+now = datetime.now(timezone.utc)
+print((now - timedelta(days=1)).strftime('%Y-%m-%dT%H:%M:%SZ'))
+print((now - timedelta(days=10)).strftime('%Y-%m-%dT%H:%M:%SZ'))
+PY
+}
+
+scenario_project_root_env() {
+  local repo outside current_ts previous_ts report_file
+  repo="$WORK/repo"
+  outside="$WORK/outside"
+  report_file="$repo/.signum/metrics/ratchet-report.json"
+  mkdir -p "$repo/.signum" "$outside"
+  read -r current_ts previous_ts < <(make_dates | tr '\n' ' ')
+  cat > "$repo/.signum/proofpack-index.jsonl" <<EOFJSON
+{"runId":"sig-run-current","contractId":"sig-current","createdAt":"$current_ts","decision":"AUTO_OK","releaseVerdict":"PROMOTE","riskLevel":"low","confidence":92,"reviewCoverage":2,"schemaVersion":"4.7","summary":"ok","proofpack_sha256":"abc","prev_hash":"genesis","chain_hash":"def"}
+{"runId":"sig-run-previous","contractId":"sig-previous","createdAt":"$previous_ts","decision":"AUTO_BLOCK","releaseVerdict":"HOLD","riskLevel":"low","confidence":40,"reviewCoverage":1,"schemaVersion":"4.7","summary":"blocked","proofpack_sha256":"ghi","prev_hash":"def","chain_hash":"jkl"}
+EOFJSON
+
+  (
+    cd "$outside"
+    SIGNUM_PROJECT_ROOT="$repo" "$RATCHET_SCRIPT" 7 7 >/dev/null
+  )
+
+  test -f "$report_file"
+  test ! -f "$outside/.signum/metrics/ratchet-report.json"
+  [[ "$(jq -r '.current.count' "$report_file")" == "1" ]]
+  [[ "$(jq -r '.previous.count' "$report_file")" == "1" ]]
+}
+
+scenario_inside_repo_still_works() {
+  local repo current_ts previous_ts report_file
+  repo="$WORK/repo-inside"
+  report_file="$repo/.signum/metrics/ratchet-report.json"
+  mkdir -p "$repo/.signum"
+  read -r current_ts previous_ts < <(make_dates | tr '\n' ' ')
+  cat > "$repo/.signum/proofpack-index.jsonl" <<EOFJSON
+{"runId":"sig-run-current-2","contractId":"sig-current-2","createdAt":"$current_ts","decision":"HUMAN_REVIEW","releaseVerdict":"HOLD","riskLevel":"medium","confidence":55,"reviewCoverage":2,"schemaVersion":"4.7","summary":"review","proofpack_sha256":"aaa","prev_hash":"genesis","chain_hash":"bbb"}
+{"runId":"sig-run-previous-2","contractId":"sig-previous-2","createdAt":"$previous_ts","decision":"AUTO_OK","releaseVerdict":"PROMOTE","riskLevel":"low","confidence":80,"reviewCoverage":2,"schemaVersion":"4.7","summary":"ok","proofpack_sha256":"ccc","prev_hash":"bbb","chain_hash":"ddd"}
+EOFJSON
+
+  (
+    cd "$repo"
+    "$RATCHET_SCRIPT" 7 7 >/dev/null
+  )
+
+  test -f "$report_file"
+  [[ -n "$(jq -r '.status' "$report_file")" ]]
+}
+
+echo "=== Metric ratchet paths ==="
+assert_ok "metric-ratchet honors SIGNUM_PROJECT_ROOT for project-level outputs" scenario_project_root_env
+assert_ok "metric-ratchet still works when run inside the repo" scenario_inside_repo_still_works
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+if [[ "$failed" -gt 0 ]]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-overlay-changelog-canonical-storage-wording.sh
+++ b/tests/test-overlay-changelog-canonical-storage-wording.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# test-overlay-changelog-canonical-storage-wording.sh -- keep overlay changelog iteration wording aligned with canonical contract-root storage
+set -euo pipefail
+
+CHANGELOG="$(cd "$(dirname "$0")/.." && pwd)/platforms/claude-code/CHANGELOG.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$CHANGELOG"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$CHANGELOG"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Overlay changelog canonical storage wording ==="
+
+assert_contains 'Lane artifacts in `iterations/NN/lanes/A|B/` under the active contract artifact root' "overlay changelog uses canonical lane artifact wording"
+assert_contains 'Per-iteration artifact storage in `iterations/NN/` under the active contract artifact root' "overlay changelog uses canonical iteration wording"
+
+assert_not_contains 'Lane artifacts in `.signum/iterations/NN/lanes/A|B/`' "overlay changelog no longer teaches root lane paths"
+assert_not_contains 'Per-iteration artifact storage in `.signum/iterations/NN/`' "overlay changelog no longer teaches root iteration paths"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-overlay-how-it-works-canonical-paths.sh
+++ b/tests/test-overlay-how-it-works-canonical-paths.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# test-overlay-how-it-works-canonical-paths.sh -- ensure Claude overlay how-it-works doc teaches canonical contract-root storage
+set -euo pipefail
+
+DOC="$(cd "$(dirname "$0")/.." && pwd)/platforms/claude-code/docs/how-it-works.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Overlay how-it-works canonical paths ==="
+
+assert_contains 'saves exit codes to `baseline.json` under the active contract artifact root' "overlay how-it-works uses canonical baseline wording"
+assert_contains 'Canonical run artifacts live under the active contract artifact root `.signum/contracts/<contractId>/`.' "overlay how-it-works mentions canonical contract root"
+assert_contains '`anti_entropy_report.json`' "overlay how-it-works includes anti-entropy artifact"
+assert_contains '`reviews/`' "overlay how-it-works lists canonical reviews dir in durable snapshots"
+assert_contains '`iterations/`' "overlay how-it-works lists canonical iterations dir in durable snapshots"
+
+assert_not_contains 'saves exit codes to `.signum/baseline.json`' "overlay how-it-works no longer teaches root baseline path"
+assert_not_contains 'Live working-set artifacts are written to `.signum/`' "overlay how-it-works no longer teaches root live-working-set model"
+assert_not_contains 'mirrors durable per-contract snapshots into `.signum/contracts/<contractId>/` for history/archive flows. That per-contract directory is not the active workspace while a run is in flight.' "overlay how-it-works no longer teaches mirror-only contract dir model"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-overlay-reference-canonical-paths.sh
+++ b/tests/test-overlay-reference-canonical-paths.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# test-overlay-reference-canonical-paths.sh -- keep Claude overlay reference doc aligned with canonical contract-root storage
+set -euo pipefail
+
+DOC="$(cd "$(dirname "$0")/.." && pwd)/platforms/claude-code/docs/reference.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Overlay reference canonical paths ==="
+
+assert_contains '.signum/contracts/<contractId>/' "overlay reference mentions canonical contract artifact root"
+assert_contains 'Outputs: `baseline.json`, `combined.patch`, `execute_log.json` under the active contract artifact root.' "overlay execute outputs use canonical wording"
+assert_contains 'Iteration artifacts are stored under the active contract artifact root' "overlay iterative audit uses canonical storage wording"
+assert_contains 'contracts/index.json.activeContractId' "overlay resume wording uses registry-first state"
+assert_contains 'Check `reviews/` under the active contract artifact root for provider status.' "overlay provider status uses canonical reviews dir"
+
+assert_not_contains 'Signum detects .signum/contract.json' "overlay no longer teaches root resume path"
+assert_not_contains 'produces `.signum/contract.json`' "overlay no longer teaches root contract path"
+assert_not_contains 'saves to `.signum/baseline.json`' "overlay no longer teaches root baseline path"
+assert_not_contains 'Outputs: `.signum/baseline.json`, `.signum/combined.patch`, `.signum/execute_log.json`.' "overlay no longer lists root execute outputs"
+assert_not_contains 'Assembles `.signum/proofpack.json`' "overlay no longer teaches root proofpack path"
+assert_not_contains 'Check `.signum/reviews/` for provider status.' "overlay no longer teaches root reviews dir"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-pack-anti-entropy.sh
+++ b/tests/test-pack-anti-entropy.sh
@@ -36,11 +36,16 @@ assert_equals() {
 
 setup_project() {
   local dir="$1"
-  mkdir -p "$dir/.signum"
-  cat > "$dir/.signum/contract.json" <<'EOF'
+  local contract_id="sig-20260410-1000-test"
+  local artifact_root="$dir/.signum/contracts/$contract_id"
+  mkdir -p "$artifact_root" "$dir/.signum/contracts"
+  cat > "$dir/.signum/contracts/index.json" <<EOF
+{"activeContractId":"$contract_id","contracts":[{"contractId":"$contract_id","status":"auditing","directory":".signum/contracts/$contract_id"}]}
+EOF
+  cat > "$artifact_root/contract.json" <<'EOF'
 {"schemaVersion":"3.8","cleanupObligations":[],"removals":[]}
 EOF
-  cat > "$dir/.signum/proofpack.json" <<'EOF'
+  cat > "$artifact_root/proofpack.json" <<'EOF'
 {
   "schemaVersion":"4.7",
   "signumVersion":"4.19.1",
@@ -55,6 +60,16 @@ EOF
 EOF
 }
 
+artifact_report() {
+  local dir="$1"
+  printf '%s\n' "$dir/.signum/contracts/sig-20260410-1000-test/anti_entropy_report.json"
+}
+
+artifact_contract() {
+  local dir="$1"
+  printf '%s\n' "$dir/.signum/contracts/sig-20260410-1000-test/contract.json"
+}
+
 echo "=== Packer existence ==="
 assert_pass "packer file exists" test -f "$PACKER"
 assert_pass "packer is executable after chmod" chmod +x "$PACKER"
@@ -64,17 +79,17 @@ echo "=== Success path ==="
 SUCCESS="$WORK/success"
 setup_project "$SUCCESS"
 assert_pass "packer exits 0 on success" "$PACKER" --project-root "$SUCCESS" --as-of 2026-04-10
-assert_pass "report artifact written" test -f "$SUCCESS/.signum/anti_entropy_report.json"
-assert_equals "report artifact status ok" "$(jq -r '.status' "$SUCCESS/.signum/anti_entropy_report.json")" "ok"
+assert_pass "report artifact written under active contract dir" test -f "$(artifact_report "$SUCCESS")"
+assert_equals "report artifact status ok" "$(jq -r '.status' "$(artifact_report "$SUCCESS")")" "ok"
 
 echo ""
 echo "=== Fallback path ==="
 FAILCASE="$WORK/fail"
 setup_project "$FAILCASE"
-printf '{bad json\n' > "$FAILCASE/.signum/contract.json"
+printf '{bad json\n' > "$(artifact_contract "$FAILCASE")"
 assert_pass "packer still exits 0 on reporter failure" "$PACKER" --project-root "$FAILCASE" --as-of 2026-04-10
-assert_pass "fallback report artifact written" test -f "$FAILCASE/.signum/anti_entropy_report.json"
-assert_equals "fallback report status error" "$(jq -r '.status' "$FAILCASE/.signum/anti_entropy_report.json")" "error"
+assert_pass "fallback report artifact written in active contract dir" test -f "$(artifact_report "$FAILCASE")"
+assert_equals "fallback report status error" "$(jq -r '.status' "$(artifact_report "$FAILCASE")")" "error"
 
 echo ""
 echo "=== Auto-import metric ratchet ==="
@@ -95,9 +110,9 @@ cat > "$METRICCASE/.signum/metrics/ratchet-report.json" <<'EOF'
 }
 EOF
 assert_pass "packer exits 0 with auto-discovered metrics" "$PACKER" --project-root "$METRICCASE" --as-of 2026-04-10
-assert_equals "metric case report status warn" "$(jq -r '.status' "$METRICCASE/.signum/anti_entropy_report.json")" "warn"
-assert_equals "metric ratchet source imported" "$(jq -r '.sources | index("metric_ratchet") != null' "$METRICCASE/.signum/anti_entropy_report.json")" "true"
-assert_equals "metric regression finding present" "$(jq -r '[.findings[] | select(.category=="metric_regression")] | length' "$METRICCASE/.signum/anti_entropy_report.json")" "1"
+assert_equals "metric case report status warn" "$(jq -r '.status' "$(artifact_report "$METRICCASE")")" "warn"
+assert_equals "metric ratchet source imported" "$(jq -r '.sources | index("metric_ratchet") != null' "$(artifact_report "$METRICCASE")")" "true"
+assert_equals "metric regression finding present" "$(jq -r '[.findings[] | select(.category=="metric_regression")] | length' "$(artifact_report "$METRICCASE")")" "1"
 
 echo ""
 echo "=== Explicit doc parity import ==="
@@ -117,10 +132,20 @@ cat > "$DOCCASE/doc-parity.json" <<'EOF'
 }
 EOF
 assert_pass "packer exits 0 with explicit doc parity JSON" "$PACKER" --project-root "$DOCCASE" --doc-parity-json "$DOCCASE/doc-parity.json" --as-of 2026-04-10
-assert_equals "doc parity case report status warn" "$(jq -r '.status' "$DOCCASE/.signum/anti_entropy_report.json")" "warn"
-assert_equals "doc parity source imported" "$(jq -r '.sources | index("doc_parity") != null' "$DOCCASE/.signum/anti_entropy_report.json")" "true"
-assert_equals "docs sync finding present" "$(jq -r '[.findings[] | select(.category=="docs_sync")] | length' "$DOCCASE/.signum/anti_entropy_report.json")" "1"
-assert_equals "docs sync target file propagated" "$(jq -r '.findings[] | select(.category=="docs_sync") | .target' "$DOCCASE/.signum/anti_entropy_report.json")" "docs/reference.md"
+assert_equals "doc parity case report status warn" "$(jq -r '.status' "$(artifact_report "$DOCCASE")")" "warn"
+assert_equals "doc parity source imported" "$(jq -r '.sources | index("doc_parity") != null' "$(artifact_report "$DOCCASE")")" "true"
+assert_equals "docs sync finding present" "$(jq -r '[.findings[] | select(.category=="docs_sync")] | length' "$(artifact_report "$DOCCASE")")" "1"
+assert_equals "docs sync target file propagated" "$(jq -r '.findings[] | select(.category=="docs_sync") | .target' "$(artifact_report "$DOCCASE")")" "docs/reference.md"
+
+echo ""
+echo "=== Output path infers canonical inputs ==="
+OUTPUTCASE="$WORK/output"
+setup_project "$OUTPUTCASE"
+OUTPUT_PATH="$OUTPUTCASE/.signum/contracts/sig-20260410-1000-test/anti_entropy_report.json"
+rm -f "$OUTPUT_PATH"
+assert_pass "packer infers contract and proofpack from output dir" "$PACKER" --project-root "$OUTPUTCASE" --output "$OUTPUT_PATH" --as-of 2026-04-10
+assert_pass "explicit output path created" test -f "$OUTPUT_PATH"
+assert_equals "explicit output status ok" "$(jq -r '.status' "$OUTPUT_PATH")" "ok"
 
 echo ""
 echo "=== Results ==="

--- a/tests/test-pack-canonical-paths.sh
+++ b/tests/test-pack-canonical-paths.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# test-pack-canonical-paths.sh -- ensure PACK phase reads and writes via canonical artifact root
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_COMMAND="$SCRIPT_DIR/../commands/signum.md"
+OVERLAY_COMMAND="$SCRIPT_DIR/../platforms/claude-code/commands/signum.md"
+
+passed=0
+failed=0
+
+assert_pass() {
+  local name="$1"; shift
+  local output
+  if output=$("$@" 2>&1); then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s | %s\n' "$name" "$output"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_section_absent() {
+  local name="$1"
+  local pattern="$2"
+  local file="$3"
+  local section
+  section=$(awk '
+    /^## Phase 4: PACK$/ { in_pack=1 }
+    /^## Final Output$/ { in_pack=0 }
+    /^## Phase 5:/ { in_pack=0 }
+    in_pack { print }
+  ' "$file")
+  if grep -Fq "$pattern" <<<"$section"; then
+    printf '  FAIL: %s | found forbidden pattern: %s\n' "$name" "$pattern"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== PACK canonical paths ==="
+
+for command in "$ROOT_COMMAND" "$OVERLAY_COMMAND"; do
+  if [[ "$command" == *"/platforms/claude-code/"* ]]; then
+    label="claude-overlay"
+  else
+    label="root"
+  fi
+  assert_pass "command exists for ${label}" test -f "$command"
+  assert_pass "PACK Step 4.0 uses active_artifact_root for ${label}" \
+    grep -Fq 'ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"' "$command"
+  assert_pass "PACK defines CONTRACT_PATH for ${label}" \
+    grep -Fq 'CONTRACT_PATH="${ARTIFACT_ROOT}contract.json"' "$command"
+  assert_pass "PACK defines PROOFPACK_PATH for ${label}" \
+    grep -Fq 'PROOFPACK_PATH="${ARTIFACT_ROOT}proofpack.json"' "$command"
+  assert_pass "PACK writes proofpack via canonical path for ${label}" \
+    grep -Fq "' > \"\$PROOFPACK_PATH\"" "$command"
+  assert_pass "PACK anti-entropy reads canonical proofpack for ${label}" \
+    grep -Fq -- '--proofpack "$PROOFPACK_PATH"' "$command"
+  assert_section_absent "PACK no root contract.json path for ${label}" '.signum/contract.json' "$command"
+  assert_section_absent "PACK no root proofpack.json path for ${label}" '.signum/proofpack.json' "$command"
+  assert_section_absent "PACK no root anti_entropy_report.json path for ${label}" '.signum/anti_entropy_report.json' "$command"
+  assert_section_absent "PACK no root audit_summary.json path for ${label}" '.signum/audit_summary.json' "$command"
+  assert_section_absent "PACK no root execute_log.json path for ${label}" '.signum/execute_log.json' "$command"
+  assert_section_absent "PACK no root audit_iteration_log.json path for ${label}" '.signum/audit_iteration_log.json' "$command"
+  assert_section_absent "PACK no root reviews dir path for ${label}" '.signum/reviews/' "$command"
+  assert_section_absent "PACK no root receipts execute path for ${label}" '.signum/receipts/execute.json' "$command"
+done
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+fi

--- a/tests/test-phase1-project-intent-doc-canonical-paths.sh
+++ b/tests/test-phase1-project-intent-doc-canonical-paths.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# test-phase1-project-intent-doc-canonical-paths.sh -- keep project-intent planning docs aligned with canonical contract-root storage
+set -euo pipefail
+
+PLAN_DOC="$(cd "$(dirname "$0")/.." && pwd)/docs/plans/2026-03-15-phase1-project-intent-layer-plan.md"
+DESIGN_DOC="$(cd "$(dirname "$0")/.." && pwd)/docs/plans/2026-03-15-phase1-project-intent-layer-design.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Phase1 project-intent docs canonical paths ==="
+
+assert_contains "$PLAN_DOC" 'CONTRACT_PATH="$ARTIFACT_ROOT/contract.json"' "plan doc introduces canonical contract path"
+assert_contains "$PLAN_DOC" 'INTENT_CHECK_PATH="$ARTIFACT_ROOT/intent_check.json"' "plan doc introduces canonical intent-check path"
+assert_contains "$PLAN_DOC" 'Write result to `$INTENT_CHECK_PATH`.' "plan doc writes canonical intent-check artifact"
+assert_contains "$DESIGN_DOC" 'Assume `CONTRACT_PATH="$ARTIFACT_ROOT/contract.json"` and `INTENT_CHECK_PATH="$ARTIFACT_ROOT/intent_check.json"`' "design doc introduces canonical artifact paths"
+assert_contains "$DESIGN_DOC" 'Add `intent_check.json` under the active contract artifact root to:' "design doc cleanup uses canonical artifact root"
+
+assert_not_contains "$PLAN_DOC" '.signum/contract.json' "plan doc no longer teaches root contract path"
+assert_not_contains "$PLAN_DOC" '.signum/intent_check.json' "plan doc no longer teaches root intent-check path"
+assert_not_contains "$DESIGN_DOC" '.signum/contract.json' "design doc no longer teaches root contract path"
+assert_not_contains "$DESIGN_DOC" '.signum/intent_check.json' "design doc no longer teaches root intent-check path"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-phase23-canonical-artifact-paths.sh
+++ b/tests/test-phase23-canonical-artifact-paths.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# test-phase23-canonical-artifact-paths.sh -- ensure remaining Phase 2/3 aux artifacts use canonical artifact root
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_COMMAND="$SCRIPT_DIR/../commands/signum.md"
+OVERLAY_COMMAND="$SCRIPT_DIR/../platforms/claude-code/commands/signum.md"
+
+passed=0
+failed=0
+
+assert_pass() {
+  local name="$1"; shift
+  local output
+  if output=$("$@" 2>&1); then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s | %s\n' "$name" "$output"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_section_absent() {
+  local name="$1"
+  local pattern="$2"
+  local section="$3"
+  if grep -Fq "$pattern" <<<"$section"; then
+    printf '  FAIL: %s | found forbidden pattern: %s\n' "$name" "$pattern"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+phase_section() {
+  local file="$1"
+  awk '
+    /If `repo-contract.json` exists in the project root, also capture invariant baseline/ { in_scope=1 }
+    /^### Step 3\.3:/ { in_scope=0 }
+    in_scope { print }
+  ' "$file"
+}
+
+echo "=== Phase 2/3 canonical artifact paths ==="
+
+for command in "$ROOT_COMMAND" "$OVERLAY_COMMAND"; do
+  if [[ "$command" == *"/platforms/claude-code/"* ]]; then
+    label="claude-overlay"
+  else
+    label="root"
+  fi
+  section=$(phase_section "$command")
+
+  assert_pass "${label} links repo contract baseline view" \
+    grep -Fq 'link_active_artifact "repo_contract_baseline.json"' "$command"
+  assert_pass "${label} links repo contract violations view" \
+    grep -Fq 'link_active_artifact "repo_contract_violations.json"' "$command"
+  assert_pass "${label} links review context view" \
+    grep -Fq 'link_active_artifact "review_context.json"' "$command"
+  assert_pass "${label} links codex review prompt view" \
+    grep -Fq 'link_active_artifact "review_prompt_codex.txt"' "$command"
+  assert_pass "${label} links gemini review prompt view" \
+    grep -Fq 'link_active_artifact "review_prompt_gemini.txt"' "$command"
+
+  assert_pass "${label} declares repo baseline canonical path" \
+    grep -Fq 'REPO_CONTRACT_BASELINE_PATH="${ARTIFACT_ROOT}repo_contract_baseline.json"' "$command"
+  assert_pass "${label} declares repo violations canonical path" \
+    grep -Fq 'REPO_CONTRACT_VIOLATIONS_PATH="${ARTIFACT_ROOT}repo_contract_violations.json"' "$command"
+  assert_pass "${label} declares review context canonical path" \
+    grep -Fq 'REVIEW_CONTEXT_PATH="${ARTIFACT_ROOT}review_context.json"' "$command"
+  assert_pass "${label} declares codex prompt canonical path" \
+    grep -Fq 'REVIEW_PROMPT_CODEX_PATH="${ARTIFACT_ROOT}review_prompt_codex.txt"' "$command"
+  assert_pass "${label} declares gemini prompt canonical path" \
+    grep -Fq 'REVIEW_PROMPT_GEMINI_PATH="${ARTIFACT_ROOT}review_prompt_gemini.txt"' "$command"
+
+  assert_section_absent "${label} no root repo baseline path in phase section" '.signum/repo_contract_baseline.json' "$section"
+  assert_section_absent "${label} no root repo violations path in phase section" '.signum/repo_contract_violations.json' "$section"
+  assert_section_absent "${label} no root review context path in phase section" '.signum/review_context.json' "$section"
+  assert_section_absent "${label} no root codex prompt path in phase section" '.signum/review_prompt_codex.txt' "$section"
+  assert_section_absent "${label} no root gemini prompt path in phase section" '.signum/review_prompt_gemini.txt' "$section"
+done
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+fi

--- a/tests/test-phase3-review-paths.sh
+++ b/tests/test-phase3-review-paths.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_CMD="/Users/vi/personal/heurema/signum/commands/signum.md"
+OVERLAY_CMD="/Users/vi/personal/heurema/signum/platforms/claude-code/commands/signum.md"
+
+extract_phase3_review_section() {
+  local file="$1"
+  awk '
+    /^### Step 3\.2\.5: Launch reviews/ { capture=1 }
+    capture { print }
+    /^### Step 3\.5: Synthesizer \(agent\)/ && capture { exit }
+  ' "$file"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if ! grep -Fq "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to contain: $needle" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to not contain: $needle" >&2
+    exit 1
+  fi
+}
+
+ROOT_SECTION="$(extract_phase3_review_section "$ROOT_CMD")"
+OVERLAY_SECTION="$(extract_phase3_review_section "$OVERLAY_CMD")"
+
+for label in ROOT_SECTION OVERLAY_SECTION; do
+  section="${!label}"
+  assert_contains "$section" 'REVIEWS_DIR="${ARTIFACT_ROOT}reviews"' "$label"
+  assert_contains "$section" 'CODEX_EXTRACTED_PATH="${ARTIFACT_ROOT}codex_extracted.json"' "$label"
+  assert_contains "$section" 'GEMINI_EXTRACTED_PATH="${ARTIFACT_ROOT}gemini_extracted.json"' "$label"
+  assert_not_contains "$section" '.signum/reviews/' "$label"
+  assert_not_contains "$section" '.signum/codex_extracted.json' "$label"
+  assert_not_contains "$section" '.signum/gemini_extracted.json' "$label"
+done
+
+echo "ok: Phase 3 review launch/parse paths use canonical artifact-root helpers"

--- a/tests/test-policy-scanner.sh
+++ b/tests/test-policy-scanner.sh
@@ -6,9 +6,9 @@ SCRIPT="$ROOT_DIR/lib/policy-scanner.sh"
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 cd "$WORK"
-mkdir -p .signum
+mkdir -p artifacts
 
-cat > combined.patch <<'EOF2'
+cat > artifacts/combined.patch <<'EOF2'
 diff --git a/src/demo.py b/src/demo.py
 @@ -0,0 +1,3 @@
 +def handler():
@@ -16,8 +16,8 @@ diff --git a/src/demo.py b/src/demo.py
 +    return None
 EOF2
 
-"$SCRIPT" combined.patch >/dev/null
-jq -e '.summaryCounts.critical == 1' .signum/policy_scan.json >/dev/null
-jq -e '.findings[0].pattern == "incomplete_implementation"' .signum/policy_scan.json >/dev/null
+"$SCRIPT" artifacts/combined.patch >/dev/null
+jq -e '.summaryCounts.critical == 1' artifacts/policy_scan.json >/dev/null
+jq -e '.findings[0].pattern == "incomplete_implementation"' artifacts/policy_scan.json >/dev/null
 
 echo "PASS: policy scanner flags TODO as CRITICAL incomplete implementation"

--- a/tests/test-proofpack-index.sh
+++ b/tests/test-proofpack-index.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# test-proofpack-index.sh -- canonical and legacy path behavior for lib/proofpack-index.sh
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+INDEX_LIB="$ROOT_DIR/lib/proofpack-index.sh"
+
+passed=0
+failed=0
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+assert_ok() {
+  local name="$1"
+  shift
+  if "$@" >/tmp/test_out.$$ 2>&1; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s\n' "$name"
+    sed 's/^/    /' /tmp/test_out.$$
+    failed=$((failed + 1))
+  fi
+  rm -f /tmp/test_out.$$
+}
+
+assert_equals() {
+  local name="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- expected "%s", got "%s"\n' "$name" "$expected" "$actual"
+    failed=$((failed + 1))
+  fi
+}
+
+make_proofpack() {
+  local path="$1"
+  local run_id="$2"
+  local contract_id="$3"
+  cat > "$path" <<EOFJSON
+{
+  "schemaVersion": "4.7",
+  "createdAt": "2026-04-21T12:30:00Z",
+  "runId": "$run_id",
+  "contractId": "$contract_id",
+  "decision": "AUTO_OK",
+  "releaseVerdict": "GO",
+  "riskLevel": "low",
+  "confidence": {"overall": 93},
+  "reviewCoverage": {"availableReviews": 2},
+  "summary": "ok"
+}
+EOFJSON
+}
+
+scenario_canonical_append_from_outside() {
+  local repo outside canonical_pp index_file
+  repo="$WORK/canonical-repo"
+  outside="$WORK/outside"
+  canonical_pp="$repo/.signum/contracts/sig-20260421-1230-abcd/proofpack.json"
+  index_file="$repo/.signum/proofpack-index.jsonl"
+  mkdir -p "$(dirname "$canonical_pp")" "$outside"
+  make_proofpack "$canonical_pp" "sig-run-001" "sig-20260421-1230-abcd"
+
+  (
+    cd "$outside"
+    source "$INDEX_LIB"
+    proofpack_index_append "$canonical_pp"
+  )
+
+  test -f "$index_file"
+  test ! -f "$outside/.signum/proofpack-index.jsonl"
+  local run_id contract_id
+  run_id="$(jq -r '.runId' "$index_file")"
+  contract_id="$(jq -r '.contractId' "$index_file")"
+  [[ "$run_id" == "sig-run-001" ]]
+  [[ "$contract_id" == "sig-20260421-1230-abcd" ]]
+
+  local verify_out
+  verify_out="$(SIGNUM_PROJECT_ROOT="$repo" bash -lc 'source "$1"; proofpack_index_verify' _ "$INDEX_LIB")"
+  [[ "$verify_out" == OK:* ]]
+}
+
+scenario_legacy_root_append() {
+  local repo legacy_pp index_file query_count
+  repo="$WORK/legacy-repo"
+  legacy_pp="$repo/.signum/proofpack.json"
+  index_file="$repo/.signum/proofpack-index.jsonl"
+  mkdir -p "$repo/.signum"
+  make_proofpack "$legacy_pp" "sig-run-legacy" "sig-legacy-001"
+
+  (
+    cd "$repo"
+    source "$INDEX_LIB"
+    proofpack_index_append ".signum/proofpack.json"
+  )
+
+  test -f "$index_file"
+  query_count="$(SIGNUM_PROJECT_ROOT="$repo" bash -lc 'source "$1"; proofpack_index_query --last 1 | jq length' _ "$INDEX_LIB")"
+  [[ "$query_count" == "1" ]]
+  [[ "$(jq -r '.runId' "$index_file")" == "sig-run-legacy" ]]
+}
+
+scenario_canonical_relative_append_inside_contract_dir() {
+  local repo contract_dir canonical_pp index_file query_count verify_out
+  repo="$WORK/inside-contract-dir"
+  contract_dir="$repo/.signum/contracts/sig-20260421-1240-beef"
+  canonical_pp="$contract_dir/proofpack.json"
+  index_file="$repo/.signum/proofpack-index.jsonl"
+  mkdir -p "$contract_dir"
+  make_proofpack "$canonical_pp" "sig-run-002" "sig-20260421-1240-beef"
+
+  (
+    cd "$contract_dir"
+    source "$INDEX_LIB"
+    proofpack_index_append "proofpack.json"
+  )
+
+  test -f "$index_file"
+  test ! -f "$contract_dir/.signum/proofpack-index.jsonl"
+  [[ "$(jq -r '.runId' "$index_file")" == "sig-run-002" ]]
+
+  query_count="$(
+    cd "$contract_dir" && \
+    bash -lc 'source "$1"; proofpack_index_query --last 1 | jq length' _ "$INDEX_LIB"
+  )"
+  [[ "$query_count" == "1" ]]
+
+  verify_out="$(
+    cd "$contract_dir" && \
+    bash -lc 'source "$1"; proofpack_index_verify' _ "$INDEX_LIB"
+  )"
+  [[ "$verify_out" == OK:* ]]
+}
+
+echo "=== Proofpack index paths ==="
+assert_ok "canonical proofpack append resolves project-level index from proofpack path" scenario_canonical_append_from_outside
+assert_ok "canonical relative proofpack append from inside contract dir still resolves project-level index" scenario_canonical_relative_append_inside_contract_dir
+assert_ok "legacy root proofpack append still works" scenario_legacy_root_append
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+if [[ "$failed" -gt 0 ]]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-quickstart-canonical-paths.sh
+++ b/tests/test-quickstart-canonical-paths.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# test-quickstart-canonical-paths.sh -- ensure root and overlay quickstarts teach canonical contract-root artifact paths
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DOC="$SCRIPT_DIR/../QUICKSTART.md"
+OVERLAY_DOC="$SCRIPT_DIR/../platforms/claude-code/QUICKSTART.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Quickstart canonical paths ==="
+
+assert_contains "$ROOT_DOC" '.signum/contracts/<contractId>/' "root quickstart mentions canonical contract root"
+assert_contains "$ROOT_DOC" 'jq '\''.decision, .confidence.overall'\'' "$ARTIFACT_ROOT/proofpack.json"' "root quickstart reads proofpack from artifact root"
+assert_contains "$ROOT_DOC" 'Check `audit_summary.json` under the active contract artifact root.' "root quickstart points findings to canonical audit summary"
+assert_contains "$OVERLAY_DOC" '.signum/contracts/<contractId>/' "overlay quickstart mentions canonical contract root"
+assert_contains "$OVERLAY_DOC" 'jq '\''.decision, .confidence.overall'\'' "$ARTIFACT_ROOT/proofpack.json"' "overlay quickstart reads proofpack from artifact root"
+assert_contains "$OVERLAY_DOC" 'Check `audit_summary.json` under the active contract artifact root.' "overlay quickstart points findings to canonical audit summary"
+
+assert_not_contains "$ROOT_DOC" "jq '.decision, .confidence.overall' .signum/proofpack.json" "root quickstart no longer teaches root proofpack path"
+assert_not_contains "$ROOT_DOC" 'Check `.signum/audit_summary.json`.' "root quickstart no longer teaches root audit summary path"
+assert_not_contains "$ROOT_DOC" 'Check `.signum/proofpack.json` for the result' "root checklist no longer teaches root proofpack path"
+assert_not_contains "$OVERLAY_DOC" "jq '.decision, .confidence.overall' .signum/proofpack.json" "overlay quickstart no longer teaches root proofpack path"
+assert_not_contains "$OVERLAY_DOC" 'Check `.signum/audit_summary.json`.' "overlay quickstart no longer teaches root audit summary path"
+assert_not_contains "$OVERLAY_DOC" 'Check `.signum/proofpack.json` for the result' "overlay checklist no longer teaches root proofpack path"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-receipt-chain-canonical-paths.sh
+++ b/tests/test-receipt-chain-canonical-paths.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_CMD="/Users/vi/personal/heurema/signum/commands/signum.md"
+OVERLAY_CMD="/Users/vi/personal/heurema/signum/platforms/claude-code/commands/signum.md"
+
+extract_receipt_chain_section() {
+  local file="$1"
+  awk '
+    /\*\*Launch repair engineer \(parallel lanes\):\*\*/ { capture=1 }
+    capture { print }
+    /\*\*Clean up worktrees after boundary verification:\*\*/ && capture { exit }
+  ' "$file"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if ! grep -Fq "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to contain: $needle" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to not contain: $needle" >&2
+    exit 1
+  fi
+}
+
+ROOT_SECTION="$(extract_receipt_chain_section "$ROOT_CMD")"
+OVERLAY_SECTION="$(extract_receipt_chain_section "$OVERLAY_CMD")"
+
+for label in ROOT_SECTION OVERLAY_SECTION; do
+  section="${!label}"
+  assert_contains "$section" 'ITERATIONS_DIR="${ARTIFACT_ROOT}iterations"' "$label"
+  assert_contains "$section" 'EXECUTION_CONTEXT_PATH="${ARTIFACT_ROOT}execution_context.json"' "$label"
+  assert_contains "$section" 'LANE_SELECTED_DIR="${ITERATIONS_DIR}/${ITER_PAD}/lanes"' "$label"
+  assert_contains "$section" 'SNAPSHOTS_DIR="${ARTIFACT_ROOT}snapshots"' "$label"
+  assert_contains "$section" 'RECEIPTS_DIR="${ARTIFACT_ROOT}receipts"' "$label"
+  assert_contains "$section" 'RUNS_DIR="${ARTIFACT_ROOT}runs"' "$label"
+  assert_contains "$section" 'WINNER_ARTIFACT_ROOT="${WINNER_SIGNUM_DIR}/contracts/${WINNER_ACTIVE_CONTRACT_ID}/"' "$label"
+  assert_not_contains "$section" '.signum/execution_context.json' "$label"
+  assert_not_contains "$section" '.signum/iterations/$ITER_PAD/lanes' "$label"
+  assert_not_contains "$section" '.signum/snapshots/execute-attempt-' "$label"
+  assert_not_contains "$section" '.signum/receipts' "$label"
+  assert_not_contains "$section" '.signum/runs/' "$label"
+  assert_not_contains "$section" '$WINNER_DIR/.signum/contract-engineer.json' "$label"
+  assert_not_contains "$section" '$WINNER_DIR/.signum/contract.json' "$label"
+done
+
+echo "ok: repair receipt-chain flow uses canonical artifact-root paths"

--- a/tests/test-reconcile-canonical-paths.sh
+++ b/tests/test-reconcile-canonical-paths.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# test-reconcile-canonical-paths.sh -- ensure Claude overlay RECONCILE uses canonical artifact root
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COMMAND="$SCRIPT_DIR/../platforms/claude-code/commands/signum.md"
+
+passed=0
+failed=0
+
+assert_pass() {
+  local name="$1"; shift
+  local output
+  if output=$("$@" 2>&1); then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s | %s\n' "$name" "$output"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_section_absent() {
+  local name="$1"
+  local pattern="$2"
+  local section
+  section=$(awk '
+    /^## Phase 5: RECONCILE$/ { in_reconcile=1 }
+    /^## Final Output$/ { in_reconcile=0 }
+    in_reconcile { print }
+  ' "$COMMAND")
+  if grep -Fq "$pattern" <<<"$section"; then
+    printf '  FAIL: %s | found forbidden pattern: %s\n' "$name" "$pattern"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== RECONCILE canonical paths ==="
+assert_pass "overlay command exists" test -f "$COMMAND"
+assert_pass "RECONCILE uses active_artifact_root" \
+  grep -Fq 'ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"' "$COMMAND"
+assert_pass "RECONCILE prompt mentions canonical artifact root" \
+  grep -Fq 'The canonical artifact root for the active contract is `.signum/contracts/<activeContractId>/`.' "$COMMAND"
+assert_pass "RECONCILE writes reconcile report via canonical path" \
+  grep -Fq 'RECONCILE_REPORT_PATH="${ARTIFACT_ROOT}reconcile_report.json"' "$COMMAND"
+assert_pass "RECONCILE writes retro via canonical path" \
+  grep -Fq 'RETRO_PATH="${ARTIFACT_ROOT}retro.json"' "$COMMAND"
+assert_section_absent "RECONCILE no root contract path" '.signum/contract.json'
+assert_section_absent "RECONCILE no root proofpack path" '.signum/proofpack.json'
+assert_section_absent "RECONCILE no root reconcile_report path" '.signum/reconcile_report.json'
+assert_section_absent "RECONCILE no root audit_summary path" '.signum/audit_summary.json'
+assert_section_absent "RECONCILE no root execute_log path" '.signum/execute_log.json'
+assert_section_absent "RECONCILE no root retro path" '.signum/retro.json'
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+fi

--- a/tests/test-repair-snapshot-seed-canonical-paths.sh
+++ b/tests/test-repair-snapshot-seed-canonical-paths.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_CMD="/Users/vi/personal/heurema/signum/commands/signum.md"
+OVERLAY_CMD="/Users/vi/personal/heurema/signum/platforms/claude-code/commands/signum.md"
+
+extract_section() {
+  local file="$1"
+  local start="$2"
+  local end="$3"
+  awk -v start="$start" -v end="$end" '
+    $0 ~ start { capture=1 }
+    capture { print }
+    $0 ~ end && capture { exit }
+  ' "$file"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if ! grep -Fq -- "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to contain: $needle" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" <<<"$haystack"; then
+    echo "FAIL: expected ${label} to not contain: $needle" >&2
+    exit 1
+  fi
+}
+
+ROOT_SNAPSHOT="$(extract_section "$ROOT_CMD" '^\\*\\*Capture pre-repair snapshot \\(receipt chain\\):\\*\\*$' '^\\*\\*Clear stale engineer artifacts before launching repair:\\*\\*$')"
+ROOT_SEED="$(extract_section "$ROOT_CMD" '^\\*\\*Clear stale engineer artifacts before launching repair:\\*\\*$' '^\\*\\*Launch repair engineer \\(parallel lanes\\):\\*\\*$')"
+OVERLAY_SEED="$(extract_section "$OVERLAY_CMD" '^\\*\\*Clear stale engineer artifacts before launching repair:\\*\\*$' '^\\*\\*Launch repair engineer \\(parallel lanes\\):\\*\\*$')"
+OVERLAY_SNAPSHOT="$(extract_section "$OVERLAY_CMD" '^\\*\\*Capture pre-repair snapshot \\(receipt chain\\):\\*\\*$' '^If `WORKTREE_OK` is `false`')"
+
+for label in ROOT_SNAPSHOT OVERLAY_SNAPSHOT; do
+  section="${!label}"
+  assert_contains "$section" 'ARTIFACT_ROOT="$(active_artifact_root 2>/dev/null || echo .signum/)"' "$label"
+  assert_contains "$section" '--workspace-root "$PWD" --signum-dir "$ARTIFACT_ROOT"' "$label"
+done
+
+for label in ROOT_SEED OVERLAY_SEED; do
+  section="${!label}"
+  assert_contains "$section" 'COMBINED_PATCH_PATH="${ARTIFACT_ROOT}combined.patch"' "$label"
+  assert_contains "$section" 'cp "$COMBINED_PATCH_PATH" "$_SEED_PATCH"' "$label"
+  assert_not_contains "$section" '.signum/combined.patch' "$label"
+done
+
+echo "ok: repair snapshot and seed patch flow use canonical artifact-root paths"

--- a/tests/test-resume-detection-parity.sh
+++ b/tests/test-resume-detection-parity.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# test-resume-detection-parity.sh -- ensure resume detection uses activeContractId/index with legacy fallback
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_COMMAND="$SCRIPT_DIR/../commands/signum.md"
+OVERLAY_COMMAND="$SCRIPT_DIR/../platforms/claude-code/commands/signum.md"
+
+passed=0
+failed=0
+
+assert_pass() {
+  local name="$1"; shift
+  local output
+  if output=$("$@" 2>&1); then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s — exited non-zero: %s\n' "$name" "$output"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_absent() {
+  local name="$1"; shift
+  local pattern="$1"; shift
+  local file="$1"
+  if grep -Fq "$pattern" "$file"; then
+    printf '  FAIL: %s — found forbidden pattern: %s\n' "$name" "$pattern"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Resume detection parity ==="
+
+assert_pass "root command exists" test -f "$ROOT_COMMAND"
+assert_pass "overlay command exists" test -f "$OVERLAY_COMMAND"
+
+for command in "$ROOT_COMMAND" "$OVERLAY_COMMAND"; do
+  assert_pass "command uses describe_active_contract_state in $(basename "$(dirname "$command")")" \
+    grep -Fq 'describe_active_contract_state' "$command"
+  assert_pass "command has legacy resumable fallback in $(basename "$(dirname "$command")")" \
+    grep -Fq 'LEGACY_RESUMABLE' "$command"
+  assert_pass "command has legacy contract-only fallback in $(basename "$(dirname "$command")")" \
+    grep -Fq 'LEGACY_CONTRACT_ONLY' "$command"
+  assert_pass "command has legacy migration path in $(basename "$(dirname "$command")")" \
+    grep -Fq 'set_active_contract "$LEGACY_CONTRACT_ID"' "$command"
+  assert_pass "command clears active contract through helper on restart in $(basename "$(dirname "$command")")" \
+    grep -Fq 'clear_active_contract >/dev/null 2>&1 || true' "$command"
+done
+
+assert_absent "root command removed direct root resumable heuristic" \
+  'if [ -f .signum/contract.json ] && [ -f .signum/execution_context.json ]; then' "$ROOT_COMMAND"
+assert_absent "overlay command removed direct root EXISTS heuristic" \
+  'test -f .signum/contract.json && echo "EXISTS" || echo "NONE"' "$OVERLAY_COMMAND"
+assert_absent "root command removed direct activeContractId jq mutation" \
+  "jq '.activeContractId = null'" "$ROOT_COMMAND"
+assert_absent "overlay command removed direct activeContractId jq mutation" \
+  "jq '.activeContractId = null'" "$OVERLAY_COMMAND"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+fi

--- a/tests/test-reviewer-prompt-canonical-paths.sh
+++ b/tests/test-reviewer-prompt-canonical-paths.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# test-reviewer-prompt-canonical-paths.sh -- keep reviewer prompts aligned with canonical contract-root storage
+set -euo pipefail
+
+ROOT_PROMPT="$(cd "$(dirname "$0")/.." && pwd)/agents/reviewer-claude.md"
+OVERLAY_PROMPT="$(cd "$(dirname "$0")/.." && pwd)/platforms/claude-code/agents/reviewer-claude.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+check_prompt() {
+  local file="$1"
+  local label="$2"
+
+  assert_contains "$file" '.signum/contracts/<contractId>/' "$label mentions canonical artifact root"
+  assert_contains "$file" '.signum/contracts/<contractId>/contract.json' "$label uses canonical contract path"
+  assert_contains "$file" '.signum/contracts/<contractId>/combined.patch' "$label uses canonical diff path"
+  assert_contains "$file" '.signum/contracts/<contractId>/mechanic_report.json' "$label uses canonical mechanic path"
+  assert_contains "$file" '.signum/contracts/<contractId>/reviews/claude.json' "$label uses canonical review output path"
+
+  assert_not_contains "$file" '`{contract_json}` = contents of `.signum/contract.json`' "$label removes root contract input"
+  assert_not_contains "$file" '`{diff}` = contents of `.signum/combined.patch`' "$label removes root diff input"
+  assert_not_contains "$file" 'Write your review result to `.signum/reviews/claude.json`' "$label removes root review output"
+}
+
+echo "=== Reviewer prompt canonical paths ==="
+check_prompt "$ROOT_PROMPT" "root prompt"
+check_prompt "$OVERLAY_PROMPT" "overlay prompt"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-root-anti-entropy-design-canonical-paths.sh
+++ b/tests/test-root-anti-entropy-design-canonical-paths.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# test-root-anti-entropy-design-canonical-paths.sh -- keep the anti-entropy/reconcile design note aligned with canonical contract-root storage
+set -euo pipefail
+
+DOC="$(cd "$(dirname "$0")/.." && pwd)/docs/plans/2026-04-10-root-anti-entropy-reconcile-design.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Root anti-entropy design canonical paths ==="
+
+assert_contains 'active contract artifact root (`.signum/contracts/<contractId>/anti_entropy_report.json`)' "design note uses canonical anti-entropy artifact path"
+assert_contains 'reads canonical `contract.json`, `proofpack.json`, `modules.yaml`' "stage 1 reads canonical artifacts"
+assert_contains 'emits `anti_entropy_report.json` under the active contract artifact root' "stage 1 emits canonical anti-entropy artifact"
+assert_contains 'mutates canonical `contract.json` metadata after audit' "reconcile critique mentions canonical contract metadata"
+
+assert_not_contains 'mutates `.signum/contract.json` timestamps after audit' "design note no longer teaches root contract mutation"
+assert_not_contains '- `.signum/anti_entropy_report.json`' "design note no longer teaches root anti-entropy artifact path"
+assert_not_contains 'emits `.signum/anti_entropy_report.json`' "design note no longer teaches root anti-entropy emit path"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-self-contained-proofpack-plan-canonical-paths.sh
+++ b/tests/test-self-contained-proofpack-plan-canonical-paths.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# test-self-contained-proofpack-plan-canonical-paths.sh -- keep self-contained proofpack plan examples aligned with canonical contract-root storage
+set -euo pipefail
+
+ROOT_DOC="$(cd "$(dirname "$0")/.." && pwd)/docs/plans/2026-03-04-self-contained-proofpack-plan.md"
+OVERLAY_DOC="$(cd "$(dirname "$0")/.." && pwd)/platforms/claude-code/docs/plans/2026-03-04-self-contained-proofpack-plan.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+check_doc() {
+  local file="$1"
+  local label="$2"
+
+  assert_contains "$file" 'ARTIFACT_ROOT=".signum/contracts/<contractId>"' "$label introduces canonical artifact root"
+  assert_contains "$file" 'CONTRACT_PATH="$ARTIFACT_ROOT/contract.json"' "$label uses canonical contract path"
+  assert_contains "$file" 'PROOFPACK_PATH="$ARTIFACT_ROOT/proofpack.json"' "$label uses canonical proofpack path"
+  assert_contains "$file" 'ARTIFACT_ROOT=/tmp/signum-test/.signum/contracts/sig-test' "$label dry-run uses canonical contract dir"
+  assert_contains "$file" "jq '.schemaVersion' \"\$ARTIFACT_ROOT/proofpack.json\"" "$label dry-run reads canonical proofpack path"
+
+  assert_not_contains "$file" "DECISION=\$(jq -r '.decision' .signum/audit_summary.json)" "$label removes root audit summary read"
+  assert_not_contains "$file" '# Reviews (dynamic — enumerate .signum/reviews/)' "$label removes root reviews dir comment"
+  assert_not_contains "$file" "}' > .signum/proofpack.json" "$label removes root proofpack write"
+  assert_not_contains "$file" "echo '{\"goal\":\"test\",\"riskLevel\":\"low\"}' > /tmp/signum-test/.signum/contract.json" "$label removes root dry-run contract path"
+}
+
+echo "=== Self-contained proofpack plan canonical paths ==="
+check_doc "$ROOT_DOC" "root plan"
+check_doc "$OVERLAY_DOC" "overlay plan"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-semantic-drift-research-canonical-paths.sh
+++ b/tests/test-semantic-drift-research-canonical-paths.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# test-semantic-drift-research-canonical-paths.sh -- keep semantic drift research doc aligned with canonical contract-root storage
+set -euo pipefail
+
+DOC="$(cd "$(dirname "$0")/.." && pwd)/docs/research/2026-03-15-signum-codex-semantic-drift-across-contracts.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Semantic drift research canonical paths ==="
+
+assert_contains '.signum/contracts/<contractId>/contract.json' "research doc uses canonical task contract path"
+assert_not_contains '.signum/contract.json' "old root task contract path removed"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-signum-ci.sh
+++ b/tests/test-signum-ci.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CI_SCRIPT="$SCRIPT_DIR/../lib/signum-ci.sh"
+source "$CI_SCRIPT"
 
 passed=0
 failed=0
@@ -35,6 +36,17 @@ assert_contains() {
     passed=$((passed + 1))
   else
     printf '  FAIL: %s — output missing "%s"\n' "$name" "$expected"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_equals() {
+  local name="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s — expected \"%s\", got \"%s\"\n' "$name" "$expected" "$actual"
     failed=$((failed + 1))
   fi
 }
@@ -91,6 +103,100 @@ set -e
 
 assert_contains "shows header" "=== Signum CI ===" "$output"
 assert_contains "shows contract path" "valid.json" "$output"
+
+echo ""
+echo "=== Canonical file-mode seeding ==="
+
+assert_contains "CI script documents Phase 1 file import mode" \
+  'Contract mode: file (Phase 1 imports SIGNUM_CONTRACT_PATH into canonical artifact root)' \
+  "$(cat "$CI_SCRIPT")"
+
+if grep -Fq 'cp "$contract" "$project_root/.signum/contract.json"' "$CI_SCRIPT"; then
+  printf '  FAIL: CI script still copies pre-approved contract into root .signum/contract.json\n'
+  failed=$((failed + 1))
+else
+  printf '  PASS: CI script no longer copies pre-approved contract into root .signum/contract.json\n'
+  passed=$((passed + 1))
+fi
+
+echo ""
+echo "=== Artifact discovery ==="
+
+CANONICAL="$WORK/canonical"
+mkdir -p "$CANONICAL/.signum/contracts/sig-ci-001"
+cat > "$CANONICAL/.signum/contracts/index.json" <<'EOF'
+{
+  "activeContractId": null,
+  "contracts": [
+    {
+      "contractId": "sig-ci-001",
+      "status": "completed",
+      "directory": ".signum/contracts/sig-ci-001/"
+    }
+  ]
+}
+EOF
+cat > "$CANONICAL/.signum/contracts/sig-ci-001/proofpack.json" <<'EOF'
+{"runId":"sig-ci-001","decision":"AUTO_OK","confidence":{"overall":91}}
+EOF
+
+assert_equals "resolver prefers canonical contract dir by contract id" \
+  "$(resolve_ci_artifact_root "$CANONICAL" "sig-ci-001")" \
+  "$CANONICAL/.signum/contracts/sig-ci-001"
+assert_equals "proofpack resolver prefers canonical contract dir" \
+  "$(resolve_ci_proofpack_path "$CANONICAL" "sig-ci-001")" \
+  "$CANONICAL/.signum/contracts/sig-ci-001/proofpack.json"
+
+INDEX_FALLBACK="$WORK/index-fallback"
+mkdir -p "$INDEX_FALLBACK/.signum/contracts/sig-ci-002"
+cat > "$INDEX_FALLBACK/.signum/contracts/index.json" <<'EOF'
+{
+  "activeContractId": null,
+  "contracts": [
+    {
+      "contractId": "sig-ci-002",
+      "status": "completed",
+      "directory": ".signum/contracts/sig-ci-002/"
+    }
+  ]
+}
+EOF
+cat > "$INDEX_FALLBACK/.signum/contracts/sig-ci-002/proofpack.json" <<'EOF'
+{"runId":"sig-ci-002","decision":"AUTO_BLOCK","confidence":{"overall":65}}
+EOF
+
+assert_equals "resolver falls back to last indexed contract dir" \
+  "$(resolve_ci_artifact_root "$INDEX_FALLBACK" "")" \
+  "$INDEX_FALLBACK/.signum/contracts/sig-ci-002"
+assert_equals "proofpack resolver falls back to last indexed contract proofpack" \
+  "$(resolve_ci_proofpack_path "$INDEX_FALLBACK" "")" \
+  "$INDEX_FALLBACK/.signum/contracts/sig-ci-002/proofpack.json"
+
+SINGLE_CANONICAL="$WORK/single-canonical"
+mkdir -p "$SINGLE_CANONICAL/.signum/contracts/sig-ci-003"
+cat > "$SINGLE_CANONICAL/.signum/contracts/sig-ci-003/proofpack.json" <<'EOF'
+{"runId":"sig-ci-003","decision":"AUTO_OK","confidence":{"overall":88}}
+EOF
+
+assert_equals "resolver falls back to single canonical contract dir without index" \
+  "$(resolve_ci_artifact_root "$SINGLE_CANONICAL" "")" \
+  "$SINGLE_CANONICAL/.signum/contracts/sig-ci-003"
+assert_equals "proofpack resolver falls back to single canonical contract proofpack without index" \
+  "$(resolve_ci_proofpack_path "$SINGLE_CANONICAL" "")" \
+  "$SINGLE_CANONICAL/.signum/contracts/sig-ci-003/proofpack.json"
+
+ROOT_FALLBACK="$WORK/root-fallback"
+mkdir -p "$ROOT_FALLBACK/.signum"
+cat > "$ROOT_FALLBACK/.signum/proofpack.json" <<'EOF'
+{"runId":"legacy","decision":"HUMAN_REVIEW","confidence":{"overall":50}}
+EOF
+
+assert_equals "resolver keeps legacy root artifact dir as final fallback" \
+  "$(resolve_ci_artifact_root "$ROOT_FALLBACK" "")" \
+  "$ROOT_FALLBACK/.signum"
+assert_equals "proofpack resolver keeps legacy root proofpack as final fallback" \
+  "$(resolve_ci_proofpack_path "$ROOT_FALLBACK" "")" \
+  "$ROOT_FALLBACK/.signum/proofpack.json"
 
 echo ""
 echo "=== Exit code mapping (direct test) ==="

--- a/tests/test-signum-gate-canonical-paths.sh
+++ b/tests/test-signum-gate-canonical-paths.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# test-signum-gate-canonical-paths.sh -- regression checks for canonical proofpack paths in gate templates
+set -euo pipefail
+
+ROOT_TEMPLATE="$(cd "$(dirname "$0")/.." && pwd)/lib/templates/signum-gate.yml"
+OVERLAY_TEMPLATE="$(cd "$(dirname "$0")/.." && pwd)/platforms/claude-code/lib/templates/signum-gate.yml"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local file="$1" needle="$2" label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" needle="$2" label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+check_template() {
+  local file="$1"
+  local label="$2"
+
+  printf '=== %s ===\n' "$label"
+  assert_contains "$file" 'source lib/signum-ci.sh' "$label sources CI helper"
+  assert_contains "$file" 'ARTIFACT_ROOT=$(resolve_ci_artifact_root "$SIGNUM_PROJECT_ROOT" "$INPUT_CONTRACT_ID" 2>/dev/null || true)' "$label resolves canonical artifact root"
+  assert_contains "$file" 'PROOFPACK_PATH=$(resolve_ci_proofpack_path "$SIGNUM_PROJECT_ROOT" "$INPUT_CONTRACT_ID" 2>/dev/null || true)' "$label resolves canonical proofpack path"
+  assert_contains "$file" 'echo "proofpack_path=$PROOFPACK_PATH" >> "$GITHUB_OUTPUT"' "$label exports proofpack path"
+  assert_contains "$file" 'echo "proofpack_upload_path=$PROOFPACK_UPLOAD_PATH" >> "$GITHUB_OUTPUT"' "$label exports proofpack upload path"
+  assert_contains "$file" 'echo "artifact_upload_path=$ARTIFACT_UPLOAD_PATH" >> "$GITHUB_OUTPUT"' "$label exports artifact upload path"
+  assert_contains "$file" "path: \${{ steps.signum.outputs.proofpack_upload_path }}" "$label uploads proofpack via resolved upload path"
+  assert_contains "$file" "path: \${{ steps.signum.outputs.artifact_upload_path }}" "$label uploads audit directory via resolved upload path"
+  assert_not_contains "$file" 'if [ -f .signum/proofpack.json ]; then' "$label removes direct root proofpack probe"
+  assert_not_contains "$file" "DECISION=\$(jq -r '.decision' .signum/proofpack.json)" "$label removes direct root decision read"
+  assert_not_contains "$file" "path: \${{ steps.signum.outputs.proofpack_path || '.signum/proofpack.json' }}" "$label removes raw root proofpack fallback"
+  assert_not_contains "$file" "path: \${{ steps.signum.outputs.artifact_root || '.signum/' }}" "$label removes raw root artifact-root fallback"
+  printf '\n'
+}
+
+check_template "$ROOT_TEMPLATE" "root template"
+check_template "$OVERLAY_TEMPLATE" "overlay template"
+
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-snapshot-tree-default-paths.sh
+++ b/tests/test-snapshot-tree-default-paths.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# test-snapshot-tree-default-paths.sh -- default path discovery for lib/snapshot-tree.sh
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+SNAPSHOT_SCRIPT="$ROOT_DIR/lib/snapshot-tree.sh"
+
+passed=0
+failed=0
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+assert_ok() {
+  local name="$1"
+  shift
+  if "$@" >/tmp/test_out.$$ 2>&1; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s\n' "$name"
+    sed 's/^/    /' /tmp/test_out.$$
+    failed=$((failed + 1))
+  fi
+  rm -f /tmp/test_out.$$
+}
+
+assert_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$name" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$name" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+scenario_canonical_default() {
+  local repo contract_id output summary_path manifest_path signum_dir
+  repo="$WORK/canonical"
+  contract_id="sig-20260421-1245-abcd"
+  mkdir -p "$repo/.signum/contracts/$contract_id" "$repo/src"
+  printf 'hello\n' > "$repo/src/greeting.txt"
+  cat > "$repo/.signum/contracts/index.json" <<EOFJSON
+{
+  "activeContractId": "$contract_id",
+  "contracts": [
+    {
+      "contractId": "$contract_id",
+      "status": "executing",
+      "directory": ".signum/contracts/$contract_id/"
+    }
+  ]
+}
+EOFJSON
+
+  output=$(cd "$repo" && "$SNAPSHOT_SCRIPT" pre-execute)
+  summary_path="$repo/.signum/contracts/$contract_id/snapshots/pre-execute.json"
+  manifest_path="$repo/.signum/contracts/$contract_id/snapshots/pre-execute.manifest"
+  signum_dir=$(jq -r '.signum_dir' "$summary_path")
+
+  [[ "$output" == "$summary_path" ]]
+  [[ -f "$summary_path" ]]
+  [[ -f "$manifest_path" ]]
+  [[ "$signum_dir" == "$repo/.signum/contracts/$contract_id" ]]
+}
+
+scenario_legacy_fallback() {
+  local repo output summary_path manifest_path signum_dir
+  repo="$WORK/legacy"
+  mkdir -p "$repo/.signum" "$repo/src"
+  printf 'hello\n' > "$repo/src/greeting.txt"
+
+  output=$(cd "$repo" && "$SNAPSHOT_SCRIPT" pre-execute)
+  summary_path="$repo/.signum/snapshots/pre-execute.json"
+  manifest_path="$repo/.signum/snapshots/pre-execute.manifest"
+  signum_dir=$(jq -r '.signum_dir' "$summary_path")
+
+  [[ "$output" == "$summary_path" ]]
+  [[ -f "$summary_path" ]]
+  [[ -f "$manifest_path" ]]
+  [[ "$signum_dir" == "$repo/.signum" ]]
+}
+
+scenario_single_contract_dir_without_index() {
+  local repo contract_id output summary_path manifest_path signum_dir
+  repo="$WORK/single-canonical"
+  contract_id="sig-20260421-1305-ef01"
+  mkdir -p "$repo/.signum/contracts/$contract_id" "$repo/src"
+  printf 'hello\n' > "$repo/src/greeting.txt"
+
+  output=$(cd "$repo" && "$SNAPSHOT_SCRIPT" pre-execute)
+  summary_path="$repo/.signum/contracts/$contract_id/snapshots/pre-execute.json"
+  manifest_path="$repo/.signum/contracts/$contract_id/snapshots/pre-execute.manifest"
+  signum_dir=$(jq -r '.signum_dir' "$summary_path")
+
+  [[ "$output" == "$summary_path" ]]
+  [[ -f "$summary_path" ]]
+  [[ -f "$manifest_path" ]]
+  [[ "$signum_dir" == "$repo/.signum/contracts/$contract_id" ]]
+}
+
+echo "=== Snapshot tree default paths ==="
+SCRIPT_TEXT="$(cat "$SNAPSHOT_SCRIPT")"
+assert_contains "snapshot-tree example uses canonical artifact root variable" 'ARTIFACT_ROOT=".signum/contracts/<contractId>"' "$SCRIPT_TEXT"
+assert_contains "snapshot-tree example uses canonical iterations lane path" 'lib/snapshot-tree.sh lane-A --workspace-root "$ARTIFACT_ROOT/iterations/01/lanes/A" \' "$SCRIPT_TEXT"
+assert_contains "snapshot-tree example uses canonical signum-dir path" '--signum-dir "$ARTIFACT_ROOT"' "$SCRIPT_TEXT"
+assert_not_contains "snapshot-tree example no longer uses root .signum lane dir" '--signum-dir .signum/iterations/01/lanes/A/.signum' "$SCRIPT_TEXT"
+assert_ok "snapshot-tree defaults to canonical active contract root" scenario_canonical_default
+assert_ok "snapshot-tree defaults to single canonical contract dir without index" scenario_single_contract_dir_without_index
+assert_ok "snapshot-tree still falls back to legacy root .signum" scenario_legacy_fallback
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+if [[ "$failed" -gt 0 ]]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-synthesizer-prompt-canonical-paths.sh
+++ b/tests/test-synthesizer-prompt-canonical-paths.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# test-synthesizer-prompt-canonical-paths.sh -- keep synthesizer prompts aligned with canonical contract-root storage
+set -euo pipefail
+
+ROOT_PROMPT="$(cd "$(dirname "$0")/.." && pwd)/agents/synthesizer.md"
+OVERLAY_PROMPT="$(cd "$(dirname "$0")/.." && pwd)/platforms/claude-code/agents/synthesizer.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+check_prompt() {
+  local file="$1"
+  local label="$2"
+
+  assert_contains "$file" '.signum/contracts/<contractId>/' "$label mentions canonical artifact root"
+  assert_contains "$file" '.signum/contracts/<contractId>/contract.json' "$label uses canonical contract path"
+  assert_contains "$file" '.signum/contracts/<contractId>/mechanic_report.json' "$label uses canonical mechanic path"
+  assert_contains "$file" '.signum/contracts/<contractId>/receipts/execute.json' "$label uses canonical receipt path"
+  assert_contains "$file" '.signum/contracts/<contractId>/audit_summary.json' "$label uses canonical audit summary output"
+
+  assert_not_contains "$file" '- `.signum/contract.json` -- contract' "$label removes root contract input"
+  assert_not_contains "$file" 'Read from `.signum/execute_log.json`' "$label removes root execute log reference"
+  assert_not_contains "$file" 'Write `.signum/audit_summary.json`:' "$label removes root audit summary output"
+}
+
+echo "=== Synthesizer prompt canonical paths ==="
+check_prompt "$ROOT_PROMPT" "root prompt"
+check_prompt "$OVERLAY_PROMPT" "overlay prompt"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-verifier-default-paths.sh
+++ b/tests/test-verifier-default-paths.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# test-verifier-default-paths.sh -- default path discovery for boundary/transition verifiers
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+LIB_SRC="$ROOT_DIR/lib"
+export SIGNUM_TRUST_LOCAL=1
+
+passed=0
+failed=0
+
+assert_ok() {
+  local name="$1"
+  shift
+  if "$@" >/tmp/test_out.$$ 2>&1; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s\n' "$name"
+    sed 's/^/    /' /tmp/test_out.$$
+    failed=$((failed + 1))
+  fi
+  rm -f /tmp/test_out.$$
+}
+
+make_repo() {
+  local dir
+  dir=$(mktemp -d)
+  mkdir -p "$dir/lib" "$dir/src" "$dir/.signum"
+  cp "$LIB_SRC"/*.sh "$dir/lib/"
+  chmod +x "$dir/lib/"*.sh
+  cat > "$dir/.gitignore" <<'GITEOF'
+.signum/
+GITEOF
+  git -C "$dir" init >/dev/null 2>&1
+  printf 'baseline\n' > "$dir/README.md"
+  git -C "$dir" add README.md .gitignore >/dev/null 2>&1
+  printf '%s\n' "$dir"
+}
+
+write_contract_pair() {
+  local contract_path="$1"
+  local engineer_path="$2"
+  local context_path="$3"
+  cat > "$contract_path" <<'EOFJSON'
+{
+  "schemaVersion": "3.8",
+  "contractId": "sig-20260421-1215-test",
+  "goal": "Create a greeting artifact with deterministic receipt verification.",
+  "inScope": ["src/greeting.txt"],
+  "acceptanceCriteria": [
+    {
+      "id": "AC01",
+      "description": "Greeting file exists",
+      "visibility": "visible",
+      "verify": {
+        "steps": [
+          {"exec": {"argv": ["test", "-f", "src/greeting.txt"]}}
+        ],
+        "timeout_ms": 5000
+      }
+    },
+    {
+      "id": "AC02",
+      "description": "Greeting file contains hello",
+      "visibility": "visible",
+      "verify": {
+        "steps": [
+          {"exec": {"argv": ["cat", "src/greeting.txt"]}, "capture": "greeting"},
+          {"expect": {"stdout_contains": "hello", "source": "greeting"}}
+        ],
+        "timeout_ms": 5000
+      }
+    }
+  ],
+  "riskLevel": "medium"
+}
+EOFJSON
+  cp "$contract_path" "$engineer_path"
+  cat > "$context_path" <<'EOFJSON'
+{"base_commit":"no-git","started_at":"2026-04-21T12:15:00Z","run_id":"sig-20260421-1215-test"}
+EOFJSON
+}
+
+simulate_engineer_success() {
+  local workspace="$1"
+  local signum_dir="$2"
+  mkdir -p "$workspace/src"
+  printf 'hello world\n' > "$workspace/src/greeting.txt"
+  printf 'diff --git a/src/greeting.txt b/src/greeting.txt\n' > "$signum_dir/combined.patch"
+  cat > "$signum_dir/execute_log.json" <<'EOFJSON'
+{"status":"SUCCESS","totalAttempts":1,"maxAttempts":3}
+EOFJSON
+}
+
+scenario_canonical_defaults() {
+  local dir artifact_root
+  dir=$(make_repo)
+  artifact_root="$dir/.signum/contracts/sig-20260421-1215-test"
+  mkdir -p "$artifact_root" "$dir/.signum/contracts"
+  cat > "$dir/.signum/contracts/index.json" <<'EOFJSON'
+{
+  "activeContractId": "sig-20260421-1215-test",
+  "contracts": [
+    {
+      "contractId": "sig-20260421-1215-test",
+      "status": "executing",
+      "directory": ".signum/contracts/sig-20260421-1215-test/"
+    }
+  ]
+}
+EOFJSON
+  write_contract_pair "$artifact_root/contract.json" "$artifact_root/contract-engineer.json" "$artifact_root/execution_context.json"
+  (cd "$dir" && lib/snapshot-tree.sh pre-execute --signum-dir "$artifact_root" >/dev/null)
+  simulate_engineer_success "$dir" "$artifact_root"
+  (cd "$dir" && lib/boundary-verifier.sh execute >/dev/null)
+  (cd "$dir" && lib/transition-verifier.sh execute audit >/dev/null)
+  test -f "$artifact_root/receipts/execute.json"
+  test -f "$artifact_root/runs/sig-20260421-1215-test/execute-01.json"
+}
+
+scenario_legacy_fallback() {
+  local dir
+  dir=$(make_repo)
+  mkdir -p "$dir/.signum"
+  write_contract_pair "$dir/.signum/contract.json" "$dir/.signum/contract-engineer.json" "$dir/.signum/execution_context.json"
+  (cd "$dir" && lib/snapshot-tree.sh pre-execute >/dev/null)
+  simulate_engineer_success "$dir" "$dir/.signum"
+  (cd "$dir" && lib/boundary-verifier.sh execute >/dev/null)
+  (cd "$dir" && lib/transition-verifier.sh execute audit >/dev/null)
+  test -f "$dir/.signum/receipts/execute.json"
+  test -f "$dir/.signum/runs/sig-20260421-1215-test/execute-01.json"
+}
+
+echo "=== Verifier default paths ==="
+assert_ok "boundary/transition default to canonical active contract root" scenario_canonical_defaults
+assert_ok "boundary/transition still fall back to legacy root .signum" scenario_legacy_fallback
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+if [[ "$failed" -gt 0 ]]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- adopt `.signum/contracts/<contractId>/` as the canonical active artifact root across runtime helpers, commands, docs, prompts, overlays, and CI/template surfaces
- keep legacy root `.signum/...` references only where they are intentional compatibility wording or explicit fallback logic
- bump Signum to 4.20.0 in plugin metadata, command surfaces, and changelog

## Issue
- #22

## Test Plan
- bash /Users/vi/personal/heurema/signum/tests/test-pack-canonical-paths.sh
- bash /Users/vi/personal/heurema/signum/tests/test-claude-overlay-pack-parity.sh
- bash /Users/vi/personal/heurema/signum/tests/test-changelog-canonical-storage-wording.sh
- bash /Users/vi/personal/heurema/signum/tests/test-overlay-changelog-canonical-storage-wording.sh
- bash /Users/vi/personal/heurema/signum/tests/test-doc-parity.sh
- bash /Users/vi/personal/heurema/signum/tests/test-intentional-root-compatibility-mentions.sh
- bash /Users/vi/personal/heurema/signum/tests/test-doc-canonical-artifact-root.sh
- bash /Users/vi/personal/heurema/signum/tests/test-quickstart-canonical-paths.sh
- bash /Users/vi/personal/heurema/signum/tests/test-architecture-canonical-artifact-root.sh
- bash /Users/vi/personal/heurema/signum/tests/test-codex-skill-canonical-paths.sh
- bash /Users/vi/personal/heurema/signum/tests/test-contractor-prompt-canonical-paths.sh
- bash /Users/vi/personal/heurema/signum/tests/test-reviewer-prompt-canonical-paths.sh
- bash /Users/vi/personal/heurema/signum/tests/test-synthesizer-prompt-canonical-paths.sh
- bash /Users/vi/personal/heurema/signum/tests/test-engineer-prompt-canonical-paths.sh
- bash /Users/vi/personal/heurema/signum/tests/test-overlay-reference-canonical-paths.sh
- bash /Users/vi/personal/heurema/signum/tests/test-overlay-how-it-works-canonical-paths.sh
- bash /Users/vi/personal/heurema/signum/tests/test-signum-gate-canonical-paths.sh
- bash /Users/vi/personal/heurema/signum/tests/test-signum-ci.sh
- bash /Users/vi/personal/heurema/signum/platforms/claude-code/tests/test-signum-ci.sh
- bash /Users/vi/personal/heurema/signum/tests/test-proofpack-index.sh
- bash /Users/vi/personal/heurema/signum/tests/test-snapshot-tree-default-paths.sh
- bash /Users/vi/personal/heurema/signum/tests/test-contract-injection-scan.sh
