### PR TITLE
Add release guardrails for Emporium sync

### DIFF
--- a/.github/workflows/release-guardrails.yml
+++ b/.github/workflows/release-guardrails.yml
@@ -1,0 +1,59 @@
+name: Release Guardrails
+
+on:
+  workflow_dispatch:
+    inputs:
+      emporium_repo:
+        description: Emporium repository to inspect
+        required: false
+        default: heurema/emporium
+      emporium_ref:
+        description: Emporium git ref to inspect
+        required: false
+        default: main
+      emporium_path:
+        description: Marketplace file path inside Emporium
+        required: false
+        default: .claude-plugin/marketplace.json
+  release:
+    types:
+      - published
+  push:
+    branches:
+      - main
+    paths:
+      - .claude-plugin/plugin.json
+      - README.md
+      - CHANGELOG.md
+      - docs/RELIABILITY.md
+      - .github/workflows/release-guardrails.yml
+      - lib/check-emporium-sync.sh
+      - lib/release-smoke.sh
+
+permissions:
+  contents: read
+
+jobs:
+  release-guardrails:
+    if: github.repository == 'heurema/signum'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout Signum
+        uses: actions/checkout@v4
+
+      - name: Checkout Emporium registry
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.inputs.emporium_repo || 'heurema/emporium' }}
+          ref: ${{ github.event.inputs.emporium_ref || 'main' }}
+          path: _external/emporium
+
+      - name: Run release smoke path
+        env:
+          EMPORIUM_REPO: ${{ github.event.inputs.emporium_repo || 'heurema/emporium' }}
+          EMPORIUM_GIT_REF: ${{ github.event.inputs.emporium_ref || 'main' }}
+          EMPORIUM_PATH: ${{ github.event.inputs.emporium_path || '.claude-plugin/marketplace.json' }}
+          EMPORIUM_MARKETPLACE_PATH: ${{ format('{0}/_external/emporium/{1}', github.workspace, github.event.inputs.emporium_path || '.claude-plugin/marketplace.json') }}
+        run: bash lib/release-smoke.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+- Release guardrails for marketplace sync:
+  - `lib/check-emporium-sync.sh` — fail-loud check that compares local Signum release metadata against the `signum` entry in `heurema/emporium/.claude-plugin/marketplace.json`
+  - `lib/release-smoke.sh` — maintainer smoke path that runs the Emporium sync check plus `/signum:init --harness` coverage
+  - `.github/workflows/release-guardrails.yml` — CI workflow that checks out Emporium and runs the same release smoke path on `workflow_dispatch`, published releases, and release-related pushes to `main`, while skipping fork/canonical-repo mismatches
+  - `tests/test-emporium-sync.sh`, `tests/test-release-smoke.sh` — regression coverage for the sync check and smoke/workflow wiring
+
+### Documentation
+- `README.md`, `docs/RELIABILITY.md` now document the Emporium update step for Signum releases and point maintainers at `bash lib/release-smoke.sh`
+
 ### Fixed
 - `/signum init` now treats root `ARCHITECTURE.md` as an authoritative input alongside legacy `docs/architecture.md`, so harness-generated architecture docs are actually read back by the scanner
 - Claude overlay PACK parity test now follows the current `sync_contract_artifacts` implementation instead of the removed direct `cp` command

--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ python3 evals/run.py
 
 It is fixture-driven and snapshot-based by design. It does not call live providers and it does not extend the runtime pipeline.
 
+## Release guardrails (maintainers)
+
+Issue #26 showed that bumping Signum itself is not enough for fresh marketplace installs. Emporium is a separate registry surface.
+
+When cutting a Signum release:
+
+1. Update `heurema/emporium/.claude-plugin/marketplace.json` for `signum` so both `version` and `source.ref` point to the local `.claude-plugin/plugin.json` release version.
+2. Run the maintainer smoke path:
+
+```bash
+bash lib/release-smoke.sh
+```
+
+`bash lib/release-smoke.sh` fails loudly when Emporium drifts from local Signum release metadata and includes `/signum:init --harness` coverage via:
+- `tests/test-init-command-surface.sh`
+- `tests/test-init-harness-scaffold.sh`
+- `tests/test-brownfield-harness-flow.sh`
+
+CI runs the same smoke path in `.github/workflows/release-guardrails.yml`, so marketplace drift is visible before users install the wrong version.
+To keep normal contributor flows stable, the cross-repo check is scoped to `workflow_dispatch`, published `release` events, and `push` to `main` only when release-guardrail files changed. The workflow also only runs in the canonical `heurema/signum` repo, avoiding fork PR brittleness.
+For manual runs, the workflow accepts `EMPORIUM_REPO`, `EMPORIUM_GIT_REF`, and `EMPORIUM_PATH` equivalents as dispatch inputs so maintainers can inspect a different registry repo/ref/path without changing the script.
+
 ## Features
 
 **Spec quality gate** — Before implementation starts, your spec is scored across seven dimensions: Testability, Negative coverage, Clarity, Scope boundedness, Completeness, Boundary cases, NL Consistency. Grade D (below 60) is a hard stop with specific feedback on what's missing. The gate runs on the specification, not the code.

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -12,6 +12,7 @@ review_cadence: quarterly
 | Journey | Why it matters | Primary Surfaces | Current Evidence |
 | --- | --- | --- | --- |
 | Run `/signum <task>` end-to-end | Core product promise | `commands/signum.md`, `agents/`, `lib/`, schemas | README + reference docs + deterministic shell tests |
+| Fresh marketplace install resolves current Signum release | Users should not install a stale registry target after a version bump | `.claude-plugin/plugin.json`, `heurema/emporium/.claude-plugin/marketplace.json`, `lib/check-emporium-sync.sh`, `.github/workflows/release-guardrails.yml` | `bash lib/release-smoke.sh`, `bash tests/test-emporium-sync.sh`; CI scope is limited to canonical release-oriented triggers |
 | Generate correct runtime artifacts in `.signum/` | Needed for auditability and CI gating | `commands/signum.md`, `lib/`, `.signum/` artifact contract | `docs/reference.md`, `docs/how-it-works.md` |
 | Bootstrap project context with `/signum init` | Reduces missing-context failures in downstream repos | `commands/init.md`, `agents/init-synthesizer.md`, `lib/init-scanner.sh`, `lib/init-harness-scaffold.sh` | `tests/test-init.sh`, `tests/test-init-harness-scaffold.sh` |
 | Keep root docs and overlays aligned | Prevents trust loss from doc drift | `docs/reference.md`, `docs/overlay-deviations.json`, `lib/doc-parity-check.sh` | `tests/test-doc-parity.sh`, `.github/workflows/doc-parity.yml` |
@@ -28,11 +29,15 @@ review_cadence: quarterly
 | --- | --- | --- |
 | Canonical docs drift from actual behavior | `lib/doc-parity-check.sh` warnings | Fix docs or record a documented deviation |
 | Deterministic script regression | Failing `tests/test-*.sh` | Reproduce in shell, patch script, add/update regression test |
+| Emporium registry drifts from Signum release metadata | `bash lib/release-smoke.sh`, `.github/workflows/release-guardrails.yml` | Update `heurema/emporium/.claude-plugin/marketplace.json` so `version` and `source.ref` match the local release |
 | Init/bootstrap drift | `tests/test-init.sh`, `tests/test-init-harness-scaffold.sh` | Keep scanner/scaffold deterministic, avoid LLM-only behavior for structure |
 | Overlay divergence becomes accidental | Parity warnings and deviation review | Promote to root, remove from overlay, or document in `docs/overlay-deviations.json` |
 | Artifact contract changes without docs/schema sync | Schema/docs mismatch, review confusion | Update schema + reference docs + tests in one bounded diff |
 
 ## Operational Checks
+- `bash lib/release-smoke.sh`
+- `bash tests/test-emporium-sync.sh`
+- `bash tests/test-release-smoke.sh`
 - `bash tests/test-init.sh`
 - `bash tests/test-init-harness-scaffold.sh`
 - `bash tests/test-doc-parity.sh`
@@ -40,6 +45,6 @@ review_cadence: quarterly
 - Other deterministic checks under `tests/` should be run when changing matching `lib/` surfaces.
 
 ## Current Gaps
-- There is no single repo-wide smoke test that exercises the full `/signum` product flow end-to-end in CI.
+- There is now a maintainer-facing release smoke path, but there is still no single runtime end-to-end CI smoke test for `/signum <task>`.
 - Most reliability evidence is still shell-script unit coverage plus documentation, not integrated scenario runs.
 - Anti-entropy / recurring cleanup mode is planned but not yet a canonical root feature.

--- a/lib/check-emporium-sync.sh
+++ b/lib/check-emporium-sync.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# check-emporium-sync.sh -- fail loudly when Signum release metadata drifts from Emporium
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLUGIN_JSON_PATH="${SIGNUM_PLUGIN_JSON_PATH:-$REPO_ROOT/.claude-plugin/plugin.json}"
+EMPORIUM_REPO="${EMPORIUM_REPO:-heurema/emporium}"
+EMPORIUM_GIT_REF="${EMPORIUM_GIT_REF:-main}"
+EMPORIUM_PATH="${EMPORIUM_PATH:-.claude-plugin/marketplace.json}"
+EMPORIUM_MARKETPLACE_PATH="${EMPORIUM_MARKETPLACE_PATH:-}"
+EMPORIUM_MARKETPLACE_URL="${EMPORIUM_MARKETPLACE_URL:-https://raw.githubusercontent.com/${EMPORIUM_REPO}/${EMPORIUM_GIT_REF}/${EMPORIUM_PATH}}"
+
+if [ ! -f "$PLUGIN_JSON_PATH" ]; then
+  echo "ERROR: Signum plugin metadata not found: $PLUGIN_JSON_PATH" >&2
+  exit 1
+fi
+
+PLUGIN_NAME="$(jq -r '.name // empty' "$PLUGIN_JSON_PATH")"
+LOCAL_VERSION="$(jq -r '.version // empty' "$PLUGIN_JSON_PATH")"
+
+if [ -z "$PLUGIN_NAME" ] || [ "$PLUGIN_NAME" = "null" ]; then
+  echo "ERROR: missing plugin name in $PLUGIN_JSON_PATH" >&2
+  exit 1
+fi
+
+if [ -z "$LOCAL_VERSION" ] || [ "$LOCAL_VERSION" = "null" ]; then
+  echo "ERROR: missing plugin version in $PLUGIN_JSON_PATH" >&2
+  exit 1
+fi
+
+EXPECTED_REF="v$LOCAL_VERSION"
+
+TMP_MARKETPLACE="$(mktemp)"
+trap 'rm -f "$TMP_MARKETPLACE"' EXIT
+
+if [ -n "$EMPORIUM_MARKETPLACE_PATH" ]; then
+  if [ ! -f "$EMPORIUM_MARKETPLACE_PATH" ]; then
+    echo "ERROR: Emporium marketplace file not found: $EMPORIUM_MARKETPLACE_PATH" >&2
+    exit 1
+  fi
+  cp "$EMPORIUM_MARKETPLACE_PATH" "$TMP_MARKETPLACE"
+else
+  python3 - "$EMPORIUM_MARKETPLACE_URL" "$TMP_MARKETPLACE" <<'PY'
+import sys
+import urllib.request
+
+url, out_path = sys.argv[1], sys.argv[2]
+with urllib.request.urlopen(url, timeout=20) as response:
+    body = response.read()
+with open(out_path, "wb") as handle:
+    handle.write(body)
+PY
+fi
+
+ENTRY_JSON="$(jq -c --arg name "$PLUGIN_NAME" '.plugins[]? | select(.name == $name)' "$TMP_MARKETPLACE")"
+
+if [ -z "$ENTRY_JSON" ]; then
+  echo "ERROR: Emporium marketplace entry for $PLUGIN_NAME not found." >&2
+  echo "Update ${EMPORIUM_REPO}/${EMPORIUM_PATH} at ref ${EMPORIUM_GIT_REF} before shipping this release." >&2
+  exit 1
+fi
+
+EMPORIUM_VERSION="$(printf '%s\n' "$ENTRY_JSON" | jq -r '.version // empty')"
+EMPORIUM_ENTRY_REF="$(printf '%s\n' "$ENTRY_JSON" | jq -r '.source.ref // empty')"
+
+echo "Local $PLUGIN_NAME version: $LOCAL_VERSION"
+echo "Emporium source repo: $EMPORIUM_REPO"
+echo "Emporium source git ref: $EMPORIUM_GIT_REF"
+echo "Emporium source path: $EMPORIUM_PATH"
+echo "Emporium $PLUGIN_NAME version: ${EMPORIUM_VERSION:-missing}"
+echo "Emporium $PLUGIN_NAME ref: ${EMPORIUM_ENTRY_REF:-missing}"
+
+if [ "$EMPORIUM_VERSION" != "$LOCAL_VERSION" ] || [ "$EMPORIUM_ENTRY_REF" != "$EXPECTED_REF" ]; then
+  echo "ERROR: Emporium drift detected for $PLUGIN_NAME." >&2
+  echo "  Expected version: $LOCAL_VERSION" >&2
+  echo "  Expected ref:     $EXPECTED_REF" >&2
+  echo "  Emporium version: ${EMPORIUM_VERSION:-missing}" >&2
+  echo "  Emporium ref:     ${EMPORIUM_ENTRY_REF:-missing}" >&2
+  echo "Update ${EMPORIUM_REPO}/${EMPORIUM_PATH} at ref ${EMPORIUM_GIT_REF} before shipping this release." >&2
+  exit 1
+fi
+
+echo "OK: Emporium entry matches local Signum release metadata."

--- a/lib/release-smoke.sh
+++ b/lib/release-smoke.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# release-smoke.sh -- maintainer smoke path for release-time guardrails
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+run_step() {
+  local label="$1"
+  shift
+  echo "== $label =="
+  "$@"
+  echo ""
+}
+
+cd "$REPO_ROOT"
+
+run_step "Emporium sync check" bash lib/check-emporium-sync.sh
+run_step "/signum:init --harness command surface" bash tests/test-init-command-surface.sh
+run_step "/signum:init --harness scaffold coverage" bash tests/test-init-harness-scaffold.sh
+run_step "/signum:init --harness brownfield smoke" bash tests/test-brownfield-harness-flow.sh
+
+echo "Release smoke passed."

--- a/tests/test-emporium-sync.sh
+++ b/tests/test-emporium-sync.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# test-emporium-sync.sh -- tests for lib/check-emporium-sync.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SYNC_CHECK="$SCRIPT_DIR/../lib/check-emporium-sync.sh"
+
+passed=0
+failed=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+assert_exit_contains() {
+  local name="$1" expected_exit="$2" expected_text="$3"
+  shift 3
+  local output exit_code
+  set +e
+  output=$("$@" 2>&1)
+  exit_code=$?
+  set -e
+
+  if [ "$exit_code" -ne "$expected_exit" ]; then
+    printf '  FAIL: %s — expected exit %s, got %s\n%s\n' "$name" "$expected_exit" "$exit_code" "$output"
+    failed=$((failed + 1))
+    return
+  fi
+
+  if [[ "$output" != *"$expected_text"* ]]; then
+    printf '  FAIL: %s — output missing "%s"\n%s\n' "$name" "$expected_text" "$output"
+    failed=$((failed + 1))
+    return
+  fi
+
+  printf '  PASS: %s\n' "$name"
+  passed=$((passed + 1))
+}
+
+cat > "$WORK/plugin.json" <<'EOF'
+{
+  "name": "signum",
+  "version": "4.20.0"
+}
+EOF
+
+cat > "$WORK/marketplace-ok.json" <<'EOF'
+{
+  "plugins": [
+    {
+      "name": "signum",
+      "version": "4.20.0",
+      "source": {
+        "ref": "v4.20.0"
+      }
+    }
+  ]
+}
+EOF
+
+cat > "$WORK/marketplace-version-drift.json" <<'EOF'
+{
+  "plugins": [
+    {
+      "name": "signum",
+      "version": "4.19.2",
+      "source": {
+        "ref": "v4.20.0"
+      }
+    }
+  ]
+}
+EOF
+
+cat > "$WORK/marketplace-ref-drift.json" <<'EOF'
+{
+  "plugins": [
+    {
+      "name": "signum",
+      "version": "4.20.0",
+      "source": {
+        "ref": "v4.19.2"
+      }
+    }
+  ]
+}
+EOF
+
+cat > "$WORK/marketplace-missing-entry.json" <<'EOF'
+{
+  "plugins": [
+    {
+      "name": "other-plugin",
+      "version": "1.0.0",
+      "source": {
+        "ref": "v1.0.0"
+      }
+    }
+  ]
+}
+EOF
+
+echo "=== Sync check behavior ==="
+
+assert_exit_contains "passes when Emporium version and ref match" 0 \
+  "OK: Emporium entry matches local Signum release metadata." \
+  env \
+    SIGNUM_PLUGIN_JSON_PATH="$WORK/plugin.json" \
+    EMPORIUM_REPO="example/emporium" \
+    EMPORIUM_GIT_REF="release-test" \
+    EMPORIUM_PATH="registry/marketplace.json" \
+    EMPORIUM_MARKETPLACE_PATH="$WORK/marketplace-ok.json" \
+    bash "$SYNC_CHECK"
+
+assert_exit_contains "reports parameterized Emporium source" 0 \
+  "Emporium source repo: example/emporium" \
+  env \
+    SIGNUM_PLUGIN_JSON_PATH="$WORK/plugin.json" \
+    EMPORIUM_REPO="example/emporium" \
+    EMPORIUM_GIT_REF="release-test" \
+    EMPORIUM_PATH="registry/marketplace.json" \
+    EMPORIUM_MARKETPLACE_PATH="$WORK/marketplace-ok.json" \
+    bash "$SYNC_CHECK"
+
+assert_exit_contains "fails on version drift" 1 \
+  "ERROR: Emporium drift detected for signum." \
+  env \
+    SIGNUM_PLUGIN_JSON_PATH="$WORK/plugin.json" \
+    EMPORIUM_REPO="example/emporium" \
+    EMPORIUM_GIT_REF="release-test" \
+    EMPORIUM_PATH="registry/marketplace.json" \
+    EMPORIUM_MARKETPLACE_PATH="$WORK/marketplace-version-drift.json" \
+    bash "$SYNC_CHECK"
+
+assert_exit_contains "fails on ref drift" 1 \
+  "ERROR: Emporium drift detected for signum." \
+  env \
+    SIGNUM_PLUGIN_JSON_PATH="$WORK/plugin.json" \
+    EMPORIUM_REPO="example/emporium" \
+    EMPORIUM_GIT_REF="release-test" \
+    EMPORIUM_PATH="registry/marketplace.json" \
+    EMPORIUM_MARKETPLACE_PATH="$WORK/marketplace-ref-drift.json" \
+    bash "$SYNC_CHECK"
+
+assert_exit_contains "fails when signum entry is missing" 1 \
+  "ERROR: Emporium marketplace entry for signum not found." \
+  env \
+    SIGNUM_PLUGIN_JSON_PATH="$WORK/plugin.json" \
+    EMPORIUM_REPO="example/emporium" \
+    EMPORIUM_GIT_REF="release-test" \
+    EMPORIUM_PATH="registry/marketplace.json" \
+    EMPORIUM_MARKETPLACE_PATH="$WORK/marketplace-missing-entry.json" \
+    bash "$SYNC_CHECK"
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $passed"
+echo "Failed: $failed"
+echo ""
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+fi

--- a/tests/test-release-smoke.sh
+++ b/tests/test-release-smoke.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# test-release-smoke.sh -- verifies release smoke path and docs stay wired
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SMOKE_SCRIPT="$REPO_ROOT/lib/release-smoke.sh"
+WORKFLOW_FILE="$REPO_ROOT/.github/workflows/release-guardrails.yml"
+README_FILE="$REPO_ROOT/README.md"
+RELIABILITY_FILE="$REPO_ROOT/docs/RELIABILITY.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local name="$1" file="$2" expected="$3"
+  if grep -Fq "$expected" "$file"; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s — missing "%s" in %s\n' "$name" "$expected" "$file"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" file="$2" unexpected="$3"
+  if grep -Fq "$unexpected" "$file"; then
+    printf '  FAIL: %s — unexpected "%s" in %s\n' "$name" "$unexpected" "$file"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Release smoke wiring ==="
+assert_contains "smoke runs Emporium sync check" "$SMOKE_SCRIPT" 'bash lib/check-emporium-sync.sh'
+assert_contains "smoke covers init command surface" "$SMOKE_SCRIPT" 'bash tests/test-init-command-surface.sh'
+assert_contains "smoke covers init harness scaffold" "$SMOKE_SCRIPT" 'bash tests/test-init-harness-scaffold.sh'
+assert_contains "smoke covers brownfield harness flow" "$SMOKE_SCRIPT" 'bash tests/test-brownfield-harness-flow.sh'
+
+echo ""
+echo "=== Workflow wiring ==="
+assert_contains "workflow runs release smoke path" "$WORKFLOW_FILE" 'run: bash lib/release-smoke.sh'
+assert_contains "workflow injects Emporium marketplace path" "$WORKFLOW_FILE" 'EMPORIUM_MARKETPLACE_PATH:'
+assert_contains "workflow checks out Emporium" "$WORKFLOW_FILE" "repository: \${{ github.event.inputs.emporium_repo || 'heurema/emporium' }}"
+assert_contains "workflow supports manual dispatch" "$WORKFLOW_FILE" 'workflow_dispatch:'
+assert_contains "workflow runs on release publish" "$WORKFLOW_FILE" 'published'
+assert_contains "workflow limits push scope" "$WORKFLOW_FILE" 'paths:'
+assert_contains "workflow is canonical-repo only" "$WORKFLOW_FILE" "if: github.repository == 'heurema/signum'"
+assert_contains "workflow parameterizes Emporium git ref" "$WORKFLOW_FILE" 'EMPORIUM_GIT_REF:'
+assert_contains "workflow parameterizes Emporium path" "$WORKFLOW_FILE" 'EMPORIUM_PATH:'
+assert_not_contains "workflow no longer runs on every pull request" "$WORKFLOW_FILE" 'pull_request:'
+
+echo ""
+echo "=== Documentation wiring ==="
+assert_contains "README documents Emporium release step" "$README_FILE" 'heurema/emporium/.claude-plugin/marketplace.json'
+assert_contains "README documents release smoke command" "$README_FILE" 'bash lib/release-smoke.sh'
+assert_contains "README documents harness smoke coverage" "$README_FILE" '/signum:init --harness'
+assert_contains "README documents trigger rationale" "$README_FILE" 'workflow_dispatch'
+assert_contains "Reliability doc includes release smoke" "$RELIABILITY_FILE" 'bash lib/release-smoke.sh'
+assert_contains "Reliability doc mentions marketplace install journey" "$RELIABILITY_FILE" 'Fresh marketplace install resolves current Signum release'
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $passed"
+echo "Failed: $failed"
+echo ""
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+fi


### PR DESCRIPTION
## Summary
- add a fail-loud `lib/check-emporium-sync.sh` check plus `lib/release-smoke.sh` so Signum release metadata is compared against the Emporium registry before users hit marketplace drift
- document the Emporium update step in `/Users/vi/personal/heurema/signum/README.md` and `/Users/vi/personal/heurema/signum/docs/RELIABILITY.md`, and add regression coverage in `/Users/vi/personal/heurema/signum/tests/test-emporium-sync.sh` and `/Users/vi/personal/heurema/signum/tests/test-release-smoke.sh`
- scope the cross-repo workflow to `workflow_dispatch`, published releases, and release-related pushes to `main`, and restrict it to the canonical `heurema/signum` repo to avoid making normal PR/fork flows brittle

## Issue ID
- Closes #29

## Test Plan
- `bash tests/test-emporium-sync.sh`
- `bash tests/test-release-smoke.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-guardrails.yml"); puts "workflow yaml ok"'`
- `bash lib/release-smoke.sh`
