### PR TITLE
Automate Emporium marketplace sync

### DIFF
--- a/.github/workflows/release-guardrails.yml
+++ b/.github/workflows/release-guardrails.yml
@@ -50,6 +50,42 @@ jobs:
           ref: ${{ github.event.inputs.emporium_ref || 'main' }}
           path: _external/emporium
 
+      - name: Sync Emporium marketplace entry
+        env:
+          EMPORIUM_REPO: ${{ github.event.inputs.emporium_repo || 'heurema/emporium' }}
+          EMPORIUM_GIT_REF: ${{ github.event.inputs.emporium_ref || 'main' }}
+          EMPORIUM_PATH: ${{ github.event.inputs.emporium_path || '.claude-plugin/marketplace.json' }}
+          EMPORIUM_MARKETPLACE_PATH: ${{ format('{0}/_external/emporium/{1}', github.workspace, github.event.inputs.emporium_path || '.claude-plugin/marketplace.json') }}
+          EMPORIUM_PUSH_TOKEN: ${{ secrets.EMPORIUM_PUSH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          bash lib/update-emporium-marketplace.sh
+
+          if git -C _external/emporium diff --quiet -- "${EMPORIUM_PATH}"; then
+            echo "Emporium marketplace already in sync."
+            exit 0
+          fi
+
+          if [ -z "${EMPORIUM_PUSH_TOKEN:-}" ]; then
+            echo "ERROR: EMPORIUM_PUSH_TOKEN secret is required to update ${EMPORIUM_REPO}/${EMPORIUM_PATH}." >&2
+            echo "Add a write-capable cross-repo token for heurema/emporium, or update the marketplace manually." >&2
+            exit 1
+          fi
+
+          LOCAL_VERSION="$(jq -r '.version // empty' .claude-plugin/plugin.json)"
+          if [ -z "$LOCAL_VERSION" ] || [ "$LOCAL_VERSION" = "null" ]; then
+            echo "ERROR: missing local version in .claude-plugin/plugin.json" >&2
+            exit 1
+          fi
+
+          git -C _external/emporium config user.name "github-actions[bot]"
+          git -C _external/emporium config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C _external/emporium add "${EMPORIUM_PATH}"
+          git -C _external/emporium commit -m "Sync Signum marketplace version to ${LOCAL_VERSION}"
+          git -C _external/emporium remote set-url origin "https://x-access-token:${EMPORIUM_PUSH_TOKEN}@github.com/${EMPORIUM_REPO}.git"
+          git -C _external/emporium push origin "HEAD:${EMPORIUM_GIT_REF}"
+
       - name: Run release smoke path
         env:
           EMPORIUM_REPO: ${{ github.event.inputs.emporium_repo || 'heurema/emporium' }}

--- a/README.md
+++ b/README.md
@@ -100,14 +100,17 @@ Issue #26 showed that bumping Signum itself is not enough for fresh marketplace 
 
 When cutting a Signum release:
 
-1. Update `heurema/emporium/.claude-plugin/marketplace.json` for `signum` so both `version` and `source.ref` point to the local `.claude-plugin/plugin.json` release version.
-2. Run the maintainer smoke path:
+1. Let `.github/workflows/release-guardrails.yml` sync `heurema/emporium/.claude-plugin/marketplace.json` for `signum` so both `version` and `source.ref` point to the local `.claude-plugin/plugin.json` release version.
+   - The workflow step is named `Sync Emporium marketplace entry`.
+   - For actual cross-repo writes, configure the `EMPORIUM_PUSH_TOKEN` repo secret in `heurema/signum` with write access to `heurema/emporium`.
+   - If that secret is absent and drift exists, the workflow fails loudly instead of silently shipping a stale marketplace entry.
+2. Run the maintainer smoke path locally when changing the release wiring itself:
 
 ```bash
 bash lib/release-smoke.sh
 ```
 
-`bash lib/release-smoke.sh` fails loudly when Emporium drifts from local Signum release metadata and includes `/signum:init --harness` coverage via:
+`bash lib/release-smoke.sh` fails loudly when Emporium still drifts from local Signum release metadata after the sync step and includes `/signum:init --harness` coverage via:
 - `tests/test-init-command-surface.sh`
 - `tests/test-init-harness-scaffold.sh`
 - `tests/test-brownfield-harness-flow.sh`

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -12,7 +12,7 @@ review_cadence: quarterly
 | Journey | Why it matters | Primary Surfaces | Current Evidence |
 | --- | --- | --- | --- |
 | Run `/signum <task>` end-to-end | Core product promise | `commands/signum.md`, `agents/`, `lib/`, schemas | README + reference docs + deterministic shell tests |
-| Fresh marketplace install resolves current Signum release | Users should not install a stale registry target after a version bump | `.claude-plugin/plugin.json`, `heurema/emporium/.claude-plugin/marketplace.json`, `lib/check-emporium-sync.sh`, `.github/workflows/release-guardrails.yml` | `bash lib/release-smoke.sh`, `bash tests/test-emporium-sync.sh`; CI scope is limited to canonical release-oriented triggers |
+| Fresh marketplace install resolves current Signum release | Users should not install a stale registry target after a version bump | `.claude-plugin/plugin.json`, `heurema/emporium/.claude-plugin/marketplace.json`, `lib/update-emporium-marketplace.sh`, `lib/check-emporium-sync.sh`, `.github/workflows/release-guardrails.yml` | `bash lib/release-smoke.sh`, `bash tests/test-emporium-sync.sh`, `bash tests/test-update-emporium-marketplace.sh`; CI syncs first, then verifies |
 | Generate correct runtime artifacts in `.signum/` | Needed for auditability and CI gating | `commands/signum.md`, `lib/`, `.signum/` artifact contract | `docs/reference.md`, `docs/how-it-works.md` |
 | Bootstrap project context with `/signum init` | Reduces missing-context failures in downstream repos | `commands/init.md`, `agents/init-synthesizer.md`, `lib/init-scanner.sh`, `lib/init-harness-scaffold.sh` | `tests/test-init.sh`, `tests/test-init-harness-scaffold.sh` |
 | Keep root docs and overlays aligned | Prevents trust loss from doc drift | `docs/reference.md`, `docs/overlay-deviations.json`, `lib/doc-parity-check.sh` | `tests/test-doc-parity.sh`, `.github/workflows/doc-parity.yml` |
@@ -29,7 +29,7 @@ review_cadence: quarterly
 | --- | --- | --- |
 | Canonical docs drift from actual behavior | `lib/doc-parity-check.sh` warnings | Fix docs or record a documented deviation |
 | Deterministic script regression | Failing `tests/test-*.sh` | Reproduce in shell, patch script, add/update regression test |
-| Emporium registry drifts from Signum release metadata | `bash lib/release-smoke.sh`, `.github/workflows/release-guardrails.yml` | Update `heurema/emporium/.claude-plugin/marketplace.json` so `version` and `source.ref` match the local release |
+| Emporium registry drifts from Signum release metadata | `bash lib/release-smoke.sh`, `.github/workflows/release-guardrails.yml` | Let `Sync Emporium marketplace entry` update the registry automatically; if drift remains, update `heurema/emporium/.claude-plugin/marketplace.json` so `version` and `source.ref` match the local release |
 | Init/bootstrap drift | `tests/test-init.sh`, `tests/test-init-harness-scaffold.sh` | Keep scanner/scaffold deterministic, avoid LLM-only behavior for structure |
 | Overlay divergence becomes accidental | Parity warnings and deviation review | Promote to root, remove from overlay, or document in `docs/overlay-deviations.json` |
 | Artifact contract changes without docs/schema sync | Schema/docs mismatch, review confusion | Update schema + reference docs + tests in one bounded diff |
@@ -37,6 +37,7 @@ review_cadence: quarterly
 ## Operational Checks
 - `bash lib/release-smoke.sh`
 - `bash tests/test-emporium-sync.sh`
+- `bash tests/test-update-emporium-marketplace.sh`
 - `bash tests/test-release-smoke.sh`
 - `bash tests/test-init.sh`
 - `bash tests/test-init-harness-scaffold.sh`
@@ -48,3 +49,4 @@ review_cadence: quarterly
 - There is now a maintainer-facing release smoke path, but there is still no single runtime end-to-end CI smoke test for `/signum <task>`.
 - Most reliability evidence is still shell-script unit coverage plus documentation, not integrated scenario runs.
 - Anti-entropy / recurring cleanup mode is planned but not yet a canonical root feature.
+- Cross-repo marketplace writes require the `EMPORIUM_PUSH_TOKEN` secret in `heurema/signum`; without it, guardrails still fail loudly on drift but cannot self-heal.

--- a/lib/update-emporium-marketplace.sh
+++ b/lib/update-emporium-marketplace.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# update-emporium-marketplace.sh -- sync Emporium marketplace entry to local Signum release metadata
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLUGIN_JSON_PATH="${SIGNUM_PLUGIN_JSON_PATH:-$REPO_ROOT/.claude-plugin/plugin.json}"
+EMPORIUM_MARKETPLACE_PATH="${EMPORIUM_MARKETPLACE_PATH:-}"
+
+if [ ! -f "$PLUGIN_JSON_PATH" ]; then
+  echo "ERROR: Signum plugin metadata not found: $PLUGIN_JSON_PATH" >&2
+  exit 1
+fi
+
+if [ -z "$EMPORIUM_MARKETPLACE_PATH" ]; then
+  echo "ERROR: EMPORIUM_MARKETPLACE_PATH is required." >&2
+  exit 1
+fi
+
+if [ ! -f "$EMPORIUM_MARKETPLACE_PATH" ]; then
+  echo "ERROR: Emporium marketplace file not found: $EMPORIUM_MARKETPLACE_PATH" >&2
+  exit 1
+fi
+
+python3 - "$PLUGIN_JSON_PATH" "$EMPORIUM_MARKETPLACE_PATH" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+plugin_path = Path(sys.argv[1])
+marketplace_path = Path(sys.argv[2])
+
+plugin = json.loads(plugin_path.read_text())
+marketplace = json.loads(marketplace_path.read_text())
+
+plugin_name = plugin.get("name")
+plugin_version = plugin.get("version")
+expected_ref = f"v{plugin_version}" if plugin_version else ""
+
+if not plugin_name:
+    raise SystemExit(f"ERROR: missing plugin name in {plugin_path}")
+if not plugin_version:
+    raise SystemExit(f"ERROR: missing plugin version in {plugin_path}")
+
+plugins = marketplace.get("plugins")
+if not isinstance(plugins, list):
+    raise SystemExit(f"ERROR: invalid plugins array in {marketplace_path}")
+
+entry = next((item for item in plugins if item.get("name") == plugin_name), None)
+if entry is None:
+    raise SystemExit(f"ERROR: Emporium marketplace entry for {plugin_name} not found in {marketplace_path}")
+
+source = entry.get("source")
+if source is None:
+    source = {}
+    entry["source"] = source
+elif not isinstance(source, dict):
+    raise SystemExit(f"ERROR: invalid source object for {plugin_name} in {marketplace_path}")
+
+before_version = entry.get("version")
+before_ref = source.get("ref")
+
+changed = False
+if before_version != plugin_version:
+    entry["version"] = plugin_version
+    changed = True
+if before_ref != expected_ref:
+    source["ref"] = expected_ref
+    changed = True
+
+if changed:
+    marketplace_path.write_text(json.dumps(marketplace, indent=4, ensure_ascii=False) + "\n")
+    print(f"UPDATED: {plugin_name} -> version {plugin_version}, ref {expected_ref}")
+else:
+    print(f"UNCHANGED: {plugin_name} already points to version {plugin_version}, ref {expected_ref}")
+PY

--- a/tests/test-release-smoke.sh
+++ b/tests/test-release-smoke.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SMOKE_SCRIPT="$REPO_ROOT/lib/release-smoke.sh"
 WORKFLOW_FILE="$REPO_ROOT/.github/workflows/release-guardrails.yml"
+UPDATE_SCRIPT="$REPO_ROOT/lib/update-emporium-marketplace.sh"
 README_FILE="$REPO_ROOT/README.md"
 RELIABILITY_FILE="$REPO_ROOT/docs/RELIABILITY.md"
 
@@ -41,7 +42,17 @@ assert_contains "smoke covers init harness scaffold" "$SMOKE_SCRIPT" 'bash tests
 assert_contains "smoke covers brownfield harness flow" "$SMOKE_SCRIPT" 'bash tests/test-brownfield-harness-flow.sh'
 
 echo ""
+echo "=== Update script wiring ==="
+assert_contains "update script reads local plugin metadata" "$UPDATE_SCRIPT" 'SIGNUM_PLUGIN_JSON_PATH'
+assert_contains "update script requires marketplace path" "$UPDATE_SCRIPT" 'EMPORIUM_MARKETPLACE_PATH'
+assert_contains "update script updates source ref" "$UPDATE_SCRIPT" 'source["ref"] = expected_ref'
+assert_contains "update script reports unchanged state" "$UPDATE_SCRIPT" 'UNCHANGED:'
+
+echo ""
 echo "=== Workflow wiring ==="
+assert_contains "workflow syncs marketplace entry before smoke" "$WORKFLOW_FILE" 'bash lib/update-emporium-marketplace.sh'
+assert_contains "workflow requires write token when drift exists" "$WORKFLOW_FILE" 'EMPORIUM_PUSH_TOKEN'
+assert_contains "workflow pushes updated Emporium ref" "$WORKFLOW_FILE" 'git -C _external/emporium push origin "HEAD:${EMPORIUM_GIT_REF}"'
 assert_contains "workflow runs release smoke path" "$WORKFLOW_FILE" 'run: bash lib/release-smoke.sh'
 assert_contains "workflow injects Emporium marketplace path" "$WORKFLOW_FILE" 'EMPORIUM_MARKETPLACE_PATH:'
 assert_contains "workflow checks out Emporium" "$WORKFLOW_FILE" "repository: \${{ github.event.inputs.emporium_repo || 'heurema/emporium' }}"
@@ -56,11 +67,14 @@ assert_not_contains "workflow no longer runs on every pull request" "$WORKFLOW_F
 echo ""
 echo "=== Documentation wiring ==="
 assert_contains "README documents Emporium release step" "$README_FILE" 'heurema/emporium/.claude-plugin/marketplace.json'
+assert_contains "README documents automation token" "$README_FILE" 'EMPORIUM_PUSH_TOKEN'
+assert_contains "README documents automatic sync workflow" "$README_FILE" 'Sync Emporium marketplace entry'
 assert_contains "README documents release smoke command" "$README_FILE" 'bash lib/release-smoke.sh'
 assert_contains "README documents harness smoke coverage" "$README_FILE" '/signum:init --harness'
 assert_contains "README documents trigger rationale" "$README_FILE" 'workflow_dispatch'
 assert_contains "Reliability doc includes release smoke" "$RELIABILITY_FILE" 'bash lib/release-smoke.sh'
 assert_contains "Reliability doc mentions marketplace install journey" "$RELIABILITY_FILE" 'Fresh marketplace install resolves current Signum release'
+assert_contains "Reliability doc documents automation token" "$RELIABILITY_FILE" 'EMPORIUM_PUSH_TOKEN'
 
 echo ""
 echo "=== Results ==="

--- a/tests/test-update-emporium-marketplace.sh
+++ b/tests/test-update-emporium-marketplace.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# test-update-emporium-marketplace.sh -- tests for lib/update-emporium-marketplace.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UPDATE_SCRIPT="$SCRIPT_DIR/../lib/update-emporium-marketplace.sh"
+
+passed=0
+failed=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+assert_exit_contains() {
+  local name="$1" expected_exit="$2" expected_text="$3"
+  shift 3
+  local output exit_code
+  set +e
+  output=$("$@" 2>&1)
+  exit_code=$?
+  set -e
+
+  if [ "$exit_code" -ne "$expected_exit" ]; then
+    printf '  FAIL: %s — expected exit %s, got %s\n%s\n' "$name" "$expected_exit" "$exit_code" "$output"
+    failed=$((failed + 1))
+    return
+  fi
+
+  if [[ "$output" != *"$expected_text"* ]]; then
+    printf '  FAIL: %s — output missing "%s"\n%s\n' "$name" "$expected_text" "$output"
+    failed=$((failed + 1))
+    return
+  fi
+
+  printf '  PASS: %s\n' "$name"
+  passed=$((passed + 1))
+}
+
+cat > "$WORK/plugin.json" <<'EOF'
+{
+  "name": "signum",
+  "version": "4.20.1"
+}
+EOF
+
+cat > "$WORK/marketplace-drift.json" <<'EOF'
+{
+  "plugins": [
+    {
+      "name": "signum",
+      "version": "4.20.0",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/heurema/signum.git",
+        "ref": "v4.20.0"
+      }
+    },
+    {
+      "name": "other-plugin",
+      "version": "1.0.0",
+      "source": {
+        "ref": "v1.0.0"
+      }
+    }
+  ]
+}
+EOF
+
+cat > "$WORK/marketplace-ok.json" <<'EOF'
+{
+  "plugins": [
+    {
+      "name": "signum",
+      "version": "4.20.1",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/heurema/signum.git",
+        "ref": "v4.20.1"
+      }
+    }
+  ]
+}
+EOF
+
+cat > "$WORK/marketplace-missing.json" <<'EOF'
+{
+  "plugins": [
+    {
+      "name": "other-plugin",
+      "version": "1.0.0",
+      "source": {
+        "ref": "v1.0.0"
+      }
+    }
+  ]
+}
+EOF
+
+echo "=== Update behavior ==="
+
+assert_exit_contains "updates drifted entry" 0 \
+  "UPDATED: signum -> version 4.20.1, ref v4.20.1" \
+  env \
+    SIGNUM_PLUGIN_JSON_PATH="$WORK/plugin.json" \
+    EMPORIUM_MARKETPLACE_PATH="$WORK/marketplace-drift.json" \
+    bash "$UPDATE_SCRIPT"
+
+UPDATED_VERSION="$(jq -r '.plugins[] | select(.name == "signum") | .version' "$WORK/marketplace-drift.json")"
+UPDATED_REF="$(jq -r '.plugins[] | select(.name == "signum") | .source.ref' "$WORK/marketplace-drift.json")"
+OTHER_VERSION="$(jq -r '.plugins[] | select(.name == "other-plugin") | .version' "$WORK/marketplace-drift.json")"
+
+if [ "$UPDATED_VERSION" = "4.20.1" ] && [ "$UPDATED_REF" = "v4.20.1" ] && [ "$OTHER_VERSION" = "1.0.0" ]; then
+  echo "  PASS: writes expected version/ref and preserves unrelated entries"
+  passed=$((passed + 1))
+else
+  echo "  FAIL: writes expected version/ref and preserves unrelated entries"
+  failed=$((failed + 1))
+fi
+
+assert_exit_contains "reports unchanged entry" 0 \
+  "UNCHANGED: signum already points to version 4.20.1, ref v4.20.1" \
+  env \
+    SIGNUM_PLUGIN_JSON_PATH="$WORK/plugin.json" \
+    EMPORIUM_MARKETPLACE_PATH="$WORK/marketplace-ok.json" \
+    bash "$UPDATE_SCRIPT"
+
+assert_exit_contains "fails when entry is missing" 1 \
+  "ERROR: Emporium marketplace entry for signum not found" \
+  env \
+    SIGNUM_PLUGIN_JSON_PATH="$WORK/plugin.json" \
+    EMPORIUM_MARKETPLACE_PATH="$WORK/marketplace-missing.json" \
+    bash "$UPDATE_SCRIPT"
+
+assert_exit_contains "fails without marketplace path" 1 \
+  "ERROR: EMPORIUM_MARKETPLACE_PATH is required." \
+  env \
+    SIGNUM_PLUGIN_JSON_PATH="$WORK/plugin.json" \
+    bash "$UPDATE_SCRIPT"
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $passed"
+echo "Failed: $failed"
+echo ""
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL PASSED"
+fi


### PR DESCRIPTION
## Summary
- add `lib/update-emporium-marketplace.sh` so release automation can deterministically sync the Signum entry in `heurema/emporium/.claude-plugin/marketplace.json`
- extend `.github/workflows/release-guardrails.yml` to update the Emporium entry before running the existing release smoke path, and fail loudly with a clear `EMPORIUM_PUSH_TOKEN` message when drift exists but cross-repo write credentials are missing
- add regression coverage in `tests/test-update-emporium-marketplace.sh` and expand `tests/test-release-smoke.sh`, plus document the new release flow in `README.md` and `docs/RELIABILITY.md`

## Issue ID
- Follow-up to #26 and #29

## Test Plan
- `bash /Users/vi/personal/heurema/signum/tests/test-update-emporium-marketplace.sh`
- `bash /Users/vi/personal/heurema/signum/tests/test-emporium-sync.sh`
- `bash /Users/vi/personal/heurema/signum/tests/test-release-smoke.sh`
- `bash /Users/vi/personal/heurema/signum/tests/test-contract-dir.sh`