### PR TITLE
Use dedicated SSH key for Emporium sync

### DIFF
--- a/.github/workflows/release-guardrails.yml
+++ b/.github/workflows/release-guardrails.yml
@@ -49,6 +49,8 @@ jobs:
           repository: ${{ github.event.inputs.emporium_repo || 'heurema/emporium' }}
           ref: ${{ github.event.inputs.emporium_ref || 'main' }}
           path: _external/emporium
+          ssh-key: ${{ secrets.EMPORIUM_SSH_KEY }}
+          persist-credentials: true
 
       - name: Sync Emporium marketplace entry
         env:
@@ -56,7 +58,7 @@ jobs:
           EMPORIUM_GIT_REF: ${{ github.event.inputs.emporium_ref || 'main' }}
           EMPORIUM_PATH: ${{ github.event.inputs.emporium_path || '.claude-plugin/marketplace.json' }}
           EMPORIUM_MARKETPLACE_PATH: ${{ format('{0}/_external/emporium/{1}', github.workspace, github.event.inputs.emporium_path || '.claude-plugin/marketplace.json') }}
-          EMPORIUM_PUSH_TOKEN: ${{ secrets.EMPORIUM_PUSH_TOKEN }}
+          EMPORIUM_SSH_KEY: ${{ secrets.EMPORIUM_SSH_KEY }}
         run: |
           set -euo pipefail
 
@@ -67,9 +69,9 @@ jobs:
             exit 0
           fi
 
-          if [ -z "${EMPORIUM_PUSH_TOKEN:-}" ]; then
-            echo "ERROR: EMPORIUM_PUSH_TOKEN secret is required to update ${EMPORIUM_REPO}/${EMPORIUM_PATH}." >&2
-            echo "Add a write-capable cross-repo token for heurema/emporium, or update the marketplace manually." >&2
+          if [ -z "${EMPORIUM_SSH_KEY:-}" ]; then
+            echo "ERROR: EMPORIUM_SSH_KEY secret is required to update ${EMPORIUM_REPO}/${EMPORIUM_PATH}." >&2
+            echo "Add a write-capable SSH key for a GitHub account that can push to heurema/emporium, or update the marketplace manually." >&2
             exit 1
           fi
 
@@ -83,7 +85,7 @@ jobs:
           git -C _external/emporium config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git -C _external/emporium add "${EMPORIUM_PATH}"
           git -C _external/emporium commit -m "Sync Signum marketplace version to ${LOCAL_VERSION}"
-          git -C _external/emporium remote set-url origin "https://x-access-token:${EMPORIUM_PUSH_TOKEN}@github.com/${EMPORIUM_REPO}.git"
+          git -C _external/emporium remote set-url origin "git@github.com:${EMPORIUM_REPO}.git"
           git -C _external/emporium push origin "HEAD:${EMPORIUM_GIT_REF}"
 
       - name: Run release smoke path

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ When cutting a Signum release:
 
 1. Let `.github/workflows/release-guardrails.yml` sync `heurema/emporium/.claude-plugin/marketplace.json` for `signum` so both `version` and `source.ref` point to the local `.claude-plugin/plugin.json` release version.
    - The workflow step is named `Sync Emporium marketplace entry`.
-   - For actual cross-repo writes, configure the `EMPORIUM_PUSH_TOKEN` repo secret in `heurema/signum` with write access to `heurema/emporium`.
+   - For actual cross-repo writes, configure the `EMPORIUM_SSH_KEY` repo secret in `heurema/signum` with the private half of a dedicated GitHub SSH key whose account can push to `heurema/emporium`.
    - If that secret is absent and drift exists, the workflow fails loudly instead of silently shipping a stale marketplace entry.
 2. Run the maintainer smoke path locally when changing the release wiring itself:
 

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -49,4 +49,4 @@ review_cadence: quarterly
 - There is now a maintainer-facing release smoke path, but there is still no single runtime end-to-end CI smoke test for `/signum <task>`.
 - Most reliability evidence is still shell-script unit coverage plus documentation, not integrated scenario runs.
 - Anti-entropy / recurring cleanup mode is planned but not yet a canonical root feature.
-- Cross-repo marketplace writes require the `EMPORIUM_PUSH_TOKEN` secret in `heurema/signum`; without it, guardrails still fail loudly on drift but cannot self-heal.
+- Cross-repo marketplace writes require the `EMPORIUM_SSH_KEY` secret in `heurema/signum`; without it, guardrails still fail loudly on drift but cannot self-heal.

--- a/tests/test-release-smoke.sh
+++ b/tests/test-release-smoke.sh
@@ -51,8 +51,9 @@ assert_contains "update script reports unchanged state" "$UPDATE_SCRIPT" 'UNCHAN
 echo ""
 echo "=== Workflow wiring ==="
 assert_contains "workflow syncs marketplace entry before smoke" "$WORKFLOW_FILE" 'bash lib/update-emporium-marketplace.sh'
-assert_contains "workflow requires write token when drift exists" "$WORKFLOW_FILE" 'EMPORIUM_PUSH_TOKEN'
+assert_contains "workflow requires ssh key when drift exists" "$WORKFLOW_FILE" 'EMPORIUM_SSH_KEY'
 assert_contains "workflow pushes updated Emporium ref" "$WORKFLOW_FILE" 'git -C _external/emporium push origin "HEAD:${EMPORIUM_GIT_REF}"'
+assert_contains "workflow checks out Emporium with ssh key" "$WORKFLOW_FILE" 'ssh-key: ${{ secrets.EMPORIUM_SSH_KEY }}'
 assert_contains "workflow runs release smoke path" "$WORKFLOW_FILE" 'run: bash lib/release-smoke.sh'
 assert_contains "workflow injects Emporium marketplace path" "$WORKFLOW_FILE" 'EMPORIUM_MARKETPLACE_PATH:'
 assert_contains "workflow checks out Emporium" "$WORKFLOW_FILE" "repository: \${{ github.event.inputs.emporium_repo || 'heurema/emporium' }}"
@@ -63,18 +64,19 @@ assert_contains "workflow is canonical-repo only" "$WORKFLOW_FILE" "if: github.r
 assert_contains "workflow parameterizes Emporium git ref" "$WORKFLOW_FILE" 'EMPORIUM_GIT_REF:'
 assert_contains "workflow parameterizes Emporium path" "$WORKFLOW_FILE" 'EMPORIUM_PATH:'
 assert_not_contains "workflow no longer runs on every pull request" "$WORKFLOW_FILE" 'pull_request:'
+assert_not_contains "workflow no longer depends on push token" "$WORKFLOW_FILE" 'EMPORIUM_PUSH_TOKEN'
 
 echo ""
 echo "=== Documentation wiring ==="
 assert_contains "README documents Emporium release step" "$README_FILE" 'heurema/emporium/.claude-plugin/marketplace.json'
-assert_contains "README documents automation token" "$README_FILE" 'EMPORIUM_PUSH_TOKEN'
+assert_contains "README documents automation ssh key" "$README_FILE" 'EMPORIUM_SSH_KEY'
 assert_contains "README documents automatic sync workflow" "$README_FILE" 'Sync Emporium marketplace entry'
 assert_contains "README documents release smoke command" "$README_FILE" 'bash lib/release-smoke.sh'
 assert_contains "README documents harness smoke coverage" "$README_FILE" '/signum:init --harness'
 assert_contains "README documents trigger rationale" "$README_FILE" 'workflow_dispatch'
 assert_contains "Reliability doc includes release smoke" "$RELIABILITY_FILE" 'bash lib/release-smoke.sh'
 assert_contains "Reliability doc mentions marketplace install journey" "$RELIABILITY_FILE" 'Fresh marketplace install resolves current Signum release'
-assert_contains "Reliability doc documents automation token" "$RELIABILITY_FILE" 'EMPORIUM_PUSH_TOKEN'
+assert_contains "Reliability doc documents automation ssh key" "$RELIABILITY_FILE" 'EMPORIUM_SSH_KEY'
 
 echo ""
 echo "=== Results ==="


### PR DESCRIPTION
## Summary
- switch `release-guardrails.yml` from `EMPORIUM_PUSH_TOKEN` to `EMPORIUM_SSH_KEY` for cross-repo writes
- checkout Emporium over SSH and push back over `git@github.com:` instead of embedding an HTTPS token in the remote URL
- update release smoke wiring/docs to reflect the SSH-key credential path

## Issue
- #29

## Test Plan
- `bash /Users/vi/personal/heurema/signum/tests/test-release-smoke.sh`
- `bash /Users/vi/personal/heurema/signum/tests/test-update-emporium-marketplace.sh`
- `bash /Users/vi/personal/heurema/signum/tests/test-emporium-sync.sh`
- `bash /Users/vi/personal/heurema/signum/lib/release-smoke.sh`
- `gh workflow run .github/workflows/release-guardrails.yml --repo heurema/signum --ref codex/emporium-deploy-key`
- `gh run watch 24822419731 --repo heurema/signum --exit-status`