### PR TITLE
Add PR intake gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,55 +7,29 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for filing a bug report.
+        Thanks for filing a bug report. Please keep it bounded and reproducible.
 
-        Please keep it bounded and concrete. Include the exact command, artifact path, or file surface when possible.
-
-  - type: input
-    id: summary
+  - type: textarea
+    id: what_happened
     attributes:
-      label: Summary
-      placeholder: A short one-line summary
-    validations:
-      required: true
-
-  - type: dropdown
-    id: area
-    attributes:
-      label: Affected area
-      options:
-        - commands/signum.md pipeline
-        - commands/init.md / harness bootstrap
-        - deterministic lib/ behavior
-        - schemas / compatibility
-        - tests / evals
-        - release / marketplace wiring
-        - docs / parity
-        - other
+      label: What happened
+      description: Describe the observed behavior.
     validations:
       required: true
 
   - type: textarea
-    id: current
-    attributes:
-      label: Current behavior
-      placeholder: What happened?
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected
+    id: expected_behavior
     attributes:
       label: Expected behavior
-      placeholder: What should have happened instead?
+      description: What should have happened instead?
     validations:
       required: true
 
   - type: textarea
-    id: repro
+    id: reproduction_steps
     attributes:
-      label: Reproduction
-      description: Commands, steps, fixtures, contract paths, screenshots, or logs
+      label: Reproduction steps
+      description: Include exact commands, files, fixtures, or links where possible.
       placeholder: |
         1. Run ...
         2. Open ...
@@ -64,7 +38,31 @@ body:
       required: true
 
   - type: textarea
-    id: context
+    id: environment
     attributes:
-      label: Extra context
-      description: Version, OS, shell, relevant files, branch, screenshots, logs, etc.
+      label: Environment
+      description: OS, shell, Signum version/ref, relevant tool versions, and any important context.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Regression or not
+      options:
+        - Yes, this worked before
+        - No, this never worked for me
+        - Unsure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: willingness_to_pr
+    attributes:
+      label: Willingness to submit PR
+      options:
+        - I can submit a PR if maintainers accept the intent
+        - I can help test or review
+        - I am only reporting the bug
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Support and usage questions
+  - name: Discussions
     url: https://github.com/heurema/signum/discussions
-    about: Use Discussions for setup help, usage questions, and broader product discussion.
+    about: Use Discussions for design questions, contribution intent, setup help, and broader product discussion.
   - name: Contribution guide
     url: https://github.com/heurema/signum/blob/main/CONTRIBUTING.md
-    about: Read contribution rules, validation expectations, and DCO requirements first.
+    about: Read contribution rules, intake expectations, validation expectations, and DCO requirements first.
   - name: Security policy
     url: https://github.com/heurema/signum/blob/main/SECURITY.md
     about: Do not use public issues for vulnerabilities. Follow the private reporting guidance in SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,53 +3,69 @@ description: Propose a bounded improvement that fits current Signum scope
 title: "[Feature]: "
 labels:
   - enhancement
+  - intake/needs-maintainer-decision
 body:
   - type: markdown
     attributes:
       value: |
-        Please ground proposals in Signum's current scope as a contract-first development pipeline.
-
-  - type: input
-    id: summary
-    attributes:
-      label: Summary
-      placeholder: A short one-line proposal
-    validations:
-      required: true
+        Please describe the intent before opening a non-trivial PR.
 
   - type: textarea
     id: problem
     attributes:
-      label: Problem / opportunity
-      placeholder: Describe the user or maintainer problem first
+      label: Problem
+      description: What user, maintainer, or project problem should be solved?
+      placeholder: Describe the problem before describing code.
     validations:
       required: true
 
   - type: textarea
-    id: proposal
+    id: expected_outcome
     attributes:
-      label: Proposed change
-      placeholder: Describe the bounded change
+      label: Expected outcome
+      description: What should be true after this is solved?
     validations:
       required: true
 
   - type: textarea
-    id: fit
+    id: current_workaround
     attributes:
-      label: Why this fits Signum now
-      description: Explain how this stays within the current product/repo shape
-      placeholder: Reference README, AGENTS.md, docs/how-it-works.md, or docs/reference.md
+      label: Current workaround
+      description: How can users or maintainers handle this today?
     validations:
       required: true
 
   - type: textarea
-    id: non_goals
+    id: insufficiency
     attributes:
-      label: Out of scope / non-goals
-      placeholder: What this request should explicitly not become
+      label: Why current behavior/options are insufficient
+      description: Explain why existing behavior, docs, configuration, or process is not enough.
+    validations:
+      required: true
 
   - type: textarea
-    id: proof
+    id: minimal_solution
     attributes:
-      label: Supporting material
-      description: Related issues, repros, design notes, examples, or references
+      label: Minimal acceptable solution
+      description: What is the smallest useful change?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Include no-code, docs-only, process, or configuration alternatives.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: willingness_to_pr
+    attributes:
+      label: Willingness to submit PR
+      options:
+        - I can submit a PR if maintainers accept the intent
+        - I can help test or review
+        - I am only reporting the request
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,32 @@
+## Linked intent
+
+Link the Issue or Discussion this PR implements.
+
+- Issue / Discussion:
+- Closes/Fixes/Resolves:
+
+For non-trivial changes, open an Issue or Discussion before code review. Direct PRs are intended only for typo/docs fixes, small test-only changes, clearly scoped bug fixes, or maintainer-approved work.
+
+## Problem
+
+What problem does this solve?
+
+## Why now
+
+Why is this needed now?
+
+## Existing options
+
+Why are existing options or current behavior insufficient?
+
+## Alternatives considered
+
+What alternatives did you consider?
+
+## No-code alternative
+
+Why cannot this be solved without code?
+
 ## Summary
 
 Describe the change in 2-5 bullets.
@@ -20,32 +49,31 @@ Mark all that apply.
 - [ ] refactor
 - [ ] other
 
-## Goal / intent
-
-What problem does this PR solve? Why now?
-
 ## Scope
 
 In:
-- 
+-
 
 Out:
-- 
+-
 
-## Linked issue
-
-Closes #
-
-## Sensitive surfaces
+## Risk areas
 
 Mark anything touched in this PR.
 
+- [ ] public API
+- [ ] dependency change
+- [ ] CI/workflow change
+- [ ] auth/security
+- [ ] database/schema
+- [ ] runtime behavior
+- [ ] docs-only
+- [ ] test-only
 - [ ] `commands/signum.md`
 - [ ] `commands/init.md`
 - [ ] `agents/*`
 - [ ] `lib/*`
 - [ ] `lib/schemas/*`
-- [ ] `.claude-plugin/*`
 - [ ] `.github/workflows/*`
 - [ ] none of the above
 
@@ -59,7 +87,7 @@ Mark anything touched in this PR.
 - [ ] follow-up docs work is needed
 
 Docs / rationale:
-- 
+-
 
 ## Validation / proof
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,28 +1,29 @@
-# Signum — AI Agent Instructions
+# Signum Copilot Review Instructions
 
-Signum is a Claude Code plugin that implements evidence-driven development:
-contract-first spec, multi-model audit (Claude + Codex + Gemini), and
-tamper-evident proofpacks.
+Review code only after the PR intake gate is satisfied (`intake/pass` or maintainer override). If intake is not satisfied, focus on the missing intent/risk signal instead of detailed code style.
 
-## Architecture
+Priorities, in order:
+1. Correctness and regressions.
+2. Security and trust boundaries.
+3. Maintainability and minimal scope.
+4. Minimal dependencies.
 
-- `commands/` — slash commands (entry points: `/signum`, `/signum:init`)
-- `agents/` — subagents (contractor, engineer, reviewer-claude, synthesizer)
-- `lib/` — shared shell modules (contract, audit, proofpack, policy scanner)
-- `tests/` — test suite (run with `bash tests/run.sh`)
-- `modules.yaml` — agent/skill/hook declarations
+Flag risky changes in:
+- `.github/workflows/**` and custom GitHub Actions.
+- Dependencies, lockfiles, install scripts, Docker files, and release wiring.
+- Auth, security, crypto, subprocess/shell/eval, and file-system execution paths.
+- Public APIs, schemas, command behavior, and runtime behavior.
 
-## Conventions
+Do not recommend new dependencies unless the benefit is explicit and smaller stdlib/built-in options are insufficient.
 
-- Shell (bash 4+) for all pipeline code — no external runtimes required
-- JSON for structured data (contract.json, proofpack manifests)
-- Deterministic outputs: same input must produce same contract hash
-- All file paths relative to project root
-- Error messages go to stderr, structured output to stdout
+Do not treat stylistic issues as blockers unless they affect correctness, security, maintainability, or contributor usability.
 
-## Contributing
+Keep public review comments concise, polite, and actionable. Do not publish contributor trust scores.
 
-- Bug fixes: include a failing test case
-- New agents: must declare tools explicitly in frontmatter
-- Security findings: open a private advisory, not a public issue
-- Keep shell portable — no bashisms beyond bash 4.0
+Repo map:
+- `commands/signum.md` is the canonical Signum pipeline surface.
+- `commands/init.md` is the canonical init/bootstrap surface.
+- `agents/` contains LLM prompt surfaces.
+- `lib/` contains deterministic behavior.
+- `lib/schemas/` is compatibility-sensitive.
+- `tests/` contains verification.

--- a/.github/pr-intake-gate.yml
+++ b/.github/pr-intake-gate.yml
@@ -23,7 +23,7 @@ high_risk_path_globs:
   - 'Dockerfile'
   - 'docker/**'
   - 'scripts/install*'
-  - 'scripts/**.sh'
+  - 'scripts/**/*.sh'
   - 'commands/**'
   - 'agents/**'
   - 'lib/**'

--- a/.github/pr-intake-gate.yml
+++ b/.github/pr-intake-gate.yml
@@ -1,0 +1,68 @@
+trivial:
+  max_changed_lines: 30
+  allowed_path_globs:
+    - 'README.md'
+    - 'QUICKSTART.md'
+    - 'docs/**'
+    - '*.md'
+    - 'tests/**'
+    - 'test/**'
+
+high_risk_path_globs:
+  - '.github/workflows/**'
+  - '.github/actions/**'
+  - '.github/pr-intake-gate.yml'
+  - 'scripts/pr_intake_gate.py'
+  - 'package.json'
+  - 'package-lock.json'
+  - 'pnpm-lock.yaml'
+  - 'yarn.lock'
+  - 'requirements*.txt'
+  - 'pyproject.toml'
+  - 'poetry.lock'
+  - 'Dockerfile'
+  - 'docker/**'
+  - 'scripts/install*'
+  - 'scripts/**.sh'
+  - 'commands/**'
+  - 'agents/**'
+  - 'lib/**'
+  - 'lib/schemas/**'
+  - 'evals/**'
+  - '**/auth/**'
+  - '**/security/**'
+  - '**/crypto/**'
+  - '**/migrations/**'
+
+labels:
+  pass: 'intake/pass'
+  needs_issue: 'intake/needs-issue'
+  needs_more_context: 'intake/needs-more-context'
+  no_code_alternative: 'intake/no-code-alternative'
+  high_risk: 'intake/high-risk'
+  needs_maintainer: 'intake/needs-maintainer-decision'
+  accepted_for_pr: 'intake/accepted-for-pr'
+  override: 'maintainer/override-intake'
+
+verdicts:
+  pass: 'pass'
+  needs_issue: 'needs-issue'
+  high_risk: 'high-risk'
+
+linked_intent:
+  accept_patterns:
+    - '#\d+'
+    - 'issues/\d+'
+    - 'discussions/\d+'
+    - '(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#\d+'
+    - 'https://github.com/[^/\s]+/[^/\s]+/(issues|discussions)/\d+'
+
+bot_comment:
+  marker: '<!-- pr-intake-gate -->'
+
+llm:
+  enabled: false
+  provider: 'openai'
+  model_fast: 'gpt-5.4-mini'
+  model_reasoning: 'gpt-5.5'
+  max_diff_chars: 30000

--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -1,0 +1,34 @@
+name: PR Intake Gate
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  pr-intake-gate:
+    name: pr-intake-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout trusted base code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Run PR intake gate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/pr_intake_gate.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,12 @@ review_cadence: quarterly
 - Update this file when a new agent-facing surface, canonical source, or high-risk path is introduced.
 - Keep this file short; move detailed rationale into `ARCHITECTURE.md`, `docs/SECURITY.md`, `docs/RELIABILITY.md`, or `docs/QUALITY_SCORE.md`.
 - Review after major pipeline, schema, or platform overlay changes.
+
+## Review guidelines
+- First check whether the PR should exist at all: non-trivial changes need linked Issue or Discussion intent before code review.
+- Prefer no-code alternatives when possible: docs, configuration, process changes, or clearer existing workflows beat new code.
+- Do not recommend adding dependencies unless the benefit is explicit and stdlib/built-in options are insufficient.
+- Treat workflow, dependency, auth, security, eval/subprocess/shell, install scripts, public API, schema, command behavior, and runtime behavior changes as high-risk.
+- For high-risk PRs, ask for maintainer attention instead of continuing ordinary review unless `maintainer/override-intake` is present.
+- Public comments must be polite, concise, and actionable.
+- Do not publish contributor trust scores.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,44 @@ Examples:
 
 For deterministic bug fixes, a failing test first is strongly preferred.
 
+
+## PR Intake Gate
+
+This repository uses a deterministic PR Intake Gate before ordinary code review.
+
+For non-trivial changes, open an Issue or Discussion first and link it from the PR body. The intent should explain:
+- the problem;
+- the expected outcome;
+- why existing behavior/options are insufficient;
+- alternatives considered;
+- why this cannot be solved without code.
+
+Direct PRs are allowed for:
+- typo/docs fixes;
+- small test-only changes;
+- clearly scoped bug fixes;
+- maintainer-approved changes.
+
+PRs touching security, auth, dependencies, workflows, public APIs, install scripts, schemas, command behavior, or runtime behavior require maintainer attention.
+
+Maintainers can bypass the intake gate with the `maintainer/override-intake` label. Use that label only when taking explicit responsibility for reviewing the PR without the normal intake path.
+
+### PR Intake Gate self-check
+
+Expected behavior:
+- docs-only PR: passes and receives `intake/pass`;
+- non-trivial PR without linked Issue/Discussion: fails with `intake/needs-issue` and a short bot comment;
+- PR touching `.github/workflows/**`: fails with `intake/high-risk` and a maintainer-review comment;
+- PR with `maintainer/override-intake`: passes.
+
+Local deterministic checks:
+
+```bash
+python3 -m py_compile scripts/pr_intake_gate.py
+bash tests/test-pr-intake-gate.sh
+```
+
+
 ## Commit sign-off (DCO)
 
 This repository uses the **Developer Certificate of Origin (DCO)** instead of a CLA.

--- a/scripts/pr_intake_gate.py
+++ b/scripts/pr_intake_gate.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Deterministic PR intake gate for GitHub pull_request_target workflows.
+
+Security model:
+- Reads the trusted script/config from the base checkout.
+- Fetches PR metadata and changed-file metadata through GitHub REST API.
+- Does not checkout, import, install, or execute PR head code.
+- Does not interpolate PR title/body into shell commands.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+from pathlib import PurePosixPath
+from typing import Any, Iterable
+
+ROOT = os.environ.get("GITHUB_WORKSPACE") or os.getcwd()
+CONFIG_PATH = os.path.join(ROOT, ".github", "pr-intake-gate.yml")
+DEFAULT_API_URL = "https://api.github.com"
+
+NEEDS_ISSUE_COMMENT = """<!-- pr-intake-gate -->
+
+## PR Intake Gate: Issue or Discussion needed
+
+Thanks for the contribution. Before code review, this PR needs a linked Issue or Discussion because it appears to be non-trivial.
+
+Please add a link to the relevant Issue/Discussion, or open one describing:
+
+1. The problem.
+2. The expected outcome.
+3. Why existing options are insufficient.
+4. Alternatives considered.
+5. Why this cannot be solved without code.
+
+A maintainer can bypass this gate by adding `maintainer/override-intake`.
+"""
+
+HIGH_RISK_COMMENT = """<!-- pr-intake-gate -->
+
+## PR Intake Gate: Maintainer review needed
+
+Thanks for the contribution. This PR touches high-risk areas, so it needs explicit maintainer attention before code review proceeds.
+
+High-risk areas may include workflows, dependencies, auth/security, install scripts, public APIs, or runtime behavior.
+
+A maintainer can bypass this gate by adding `maintainer/override-intake`.
+"""
+
+PASS_COMMENT = """<!-- pr-intake-gate -->
+
+## PR Intake Gate: Passed
+
+This PR passed the intake gate. Code review can proceed.
+"""
+
+
+class GateError(RuntimeError):
+    """Raised for configuration, event, or API errors."""
+
+
+@dataclass(frozen=True)
+class PullRequestContext:
+    repository: str
+    number: int
+    title: str
+    body: str
+    author_association: str
+    labels: set[str]
+    base_sha: str
+    head_sha: str
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    filename: str
+    additions: int
+    deletions: int
+
+
+@dataclass(frozen=True)
+class Verdict:
+    name: str
+    reason: str
+    next_step: str
+    label: str
+    should_comment: bool
+    comment_body: str | None
+    exit_code: int
+
+
+def parse_scalar(raw: str) -> Any:
+    raw = raw.strip()
+    if raw == "":
+        return ""
+    if (raw.startswith("'") and raw.endswith("'")) or (raw.startswith('"') and raw.endswith('"')):
+        return raw[1:-1]
+    if raw in {"true", "True"}:
+        return True
+    if raw in {"false", "False"}:
+        return False
+    if raw in {"null", "Null", "~"}:
+        return None
+    if re.fullmatch(r"-?\d+", raw):
+        return int(raw)
+    return raw
+
+
+def load_minimal_yaml(path: str) -> dict[str, Any]:
+    """Load the limited YAML subset used by .github/pr-intake-gate.yml.
+
+    Supported constructs: nested mappings, scalar lists, quoted/unquoted scalars,
+    booleans, nulls, and integers. This avoids a PyYAML dependency in Actions.
+    """
+
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            raw_lines = handle.readlines()
+    except FileNotFoundError as exc:
+        raise GateError(f"missing config file: {path}") from exc
+
+    lines: list[tuple[int, str]] = []
+    for line in raw_lines:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        lines.append((indent, line.strip()))
+
+    def parse_block(index: int, indent: int) -> tuple[Any, int]:
+        if index >= len(lines):
+            return {}, index
+
+        current_indent, current_text = lines[index]
+        if current_indent < indent:
+            return {}, index
+        is_list = current_text.startswith("- ")
+        if is_list:
+            values: list[Any] = []
+            while index < len(lines):
+                line_indent, text = lines[index]
+                if line_indent != indent or not text.startswith("- "):
+                    break
+                values.append(parse_scalar(text[2:].strip()))
+                index += 1
+            return values, index
+
+        values_dict: dict[str, Any] = {}
+        while index < len(lines):
+            line_indent, text = lines[index]
+            if line_indent < indent:
+                break
+            if line_indent != indent:
+                raise GateError(f"invalid indentation near: {text}")
+            if text.startswith("- "):
+                break
+            if ":" not in text:
+                raise GateError(f"invalid mapping line: {text}")
+            key, value = text.split(":", 1)
+            key = key.strip()
+            value = value.strip()
+            index += 1
+            if value:
+                values_dict[key] = parse_scalar(value)
+            else:
+                nested, index = parse_block(index, indent + 2)
+                values_dict[key] = nested
+        return values_dict, index
+
+    parsed, final_index = parse_block(0, 0)
+    if final_index != len(lines):
+        raise GateError("failed to parse complete YAML config")
+    if not isinstance(parsed, dict):
+        raise GateError("config root must be a mapping")
+    return parsed
+
+
+def env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def load_event() -> dict[str, Any]:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        raise GateError("GITHUB_EVENT_PATH is required")
+    with open(event_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def get_pr_context(event: dict[str, Any]) -> PullRequestContext:
+    pr = event.get("pull_request")
+    if not isinstance(pr, dict):
+        raise GateError("event does not contain pull_request")
+
+    repository = event.get("repository", {}).get("full_name") or os.environ.get("GITHUB_REPOSITORY")
+    if not repository:
+        raise GateError("repository full name is missing")
+
+    labels = {
+        label.get("name", "")
+        for label in pr.get("labels", [])
+        if isinstance(label, dict) and label.get("name")
+    }
+
+    return PullRequestContext(
+        repository=str(repository),
+        number=int(pr["number"]),
+        title=str(pr.get("title") or ""),
+        body=str(pr.get("body") or ""),
+        author_association=str(pr.get("author_association") or ""),
+        labels=labels,
+        base_sha=str(pr.get("base", {}).get("sha") or ""),
+        head_sha=str(pr.get("head", {}).get("sha") or ""),
+    )
+
+
+def api_request(method: str, path: str, token: str, body: Any | None = None, allow_404: bool = False) -> Any:
+    base_url = os.environ.get("GITHUB_API_URL", DEFAULT_API_URL).rstrip("/")
+    url = f"{base_url}{path}"
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(url, data=data, method=method)
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("User-Agent", "pr-intake-gate")
+    request.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if body is not None:
+        request.add_header("Content-Type", "application/json")
+
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = response.read()
+            if not payload:
+                return None
+            return json.loads(payload.decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        if allow_404 and exc.code == 404:
+            return None
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise GateError(f"GitHub API {method} {path} failed: HTTP {exc.code}: {detail}") from exc
+
+
+def get_token() -> str:
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise GateError("GITHUB_TOKEN is required unless PR_INTAKE_GATE_CHANGED_FILES_JSON is set")
+    return token
+
+
+def load_changed_files(ctx: PullRequestContext) -> list[ChangedFile]:
+    fixture = os.environ.get("PR_INTAKE_GATE_CHANGED_FILES_JSON")
+    if fixture:
+        raw_files = json.loads(fixture)
+    else:
+        token = get_token()
+        encoded_repo = urllib.parse.quote(ctx.repository, safe="/")
+        raw_files = []
+        page = 1
+        per_page = 100
+        while True:
+            page_files = api_request(
+                "GET",
+                f"/repos/{encoded_repo}/pulls/{ctx.number}/files?per_page={per_page}&page={page}",
+                token,
+            )
+            if not isinstance(page_files, list):
+                raise GateError("unexpected changed files response")
+            raw_files.extend(page_files)
+            if len(page_files) < per_page:
+                break
+            page += 1
+
+    changed: list[ChangedFile] = []
+    for item in raw_files:
+        changed.append(
+            ChangedFile(
+                filename=str(item.get("filename") or ""),
+                additions=int(item.get("additions") or 0),
+                deletions=int(item.get("deletions") or 0),
+            )
+        )
+    return changed
+
+
+def path_matches(path: str, pattern: str) -> bool:
+    normalized = path.strip("/")
+    pattern = pattern.strip("/")
+    pure = PurePosixPath(normalized)
+    if fnmatchcase(normalized, pattern):
+        return True
+    if pure.match(pattern):
+        return True
+    if pattern.startswith("**/") and (fnmatchcase(normalized, pattern[3:]) or pure.match(pattern[3:])):
+        return True
+    return False
+
+
+def matching_patterns(path: str, patterns: Iterable[str]) -> list[str]:
+    return [pattern for pattern in patterns if path_matches(path, pattern)]
+
+
+def has_linked_intent(text: str, patterns: Iterable[str]) -> bool:
+    for pattern in patterns:
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            return True
+    return False
+
+
+def managed_intake_labels(config: dict[str, Any]) -> set[str]:
+    labels = config.get("labels", {})
+    if not isinstance(labels, dict):
+        return set()
+    override = labels.get("override")
+    return {str(value) for value in labels.values() if value and value != override and str(value).startswith("intake/")}
+
+
+def dry_run() -> bool:
+    return env_flag("PR_INTAKE_GATE_DRY_RUN")
+
+
+def apply_label(ctx: PullRequestContext, label: str) -> None:
+    if not label:
+        return
+    if dry_run():
+        print(f"dry-run: apply label {label}", file=sys.stderr)
+        return
+    token = get_token()
+    repo = urllib.parse.quote(ctx.repository, safe="/")
+    api_request("POST", f"/repos/{repo}/issues/{ctx.number}/labels", token, {"labels": [label]})
+
+
+def remove_labels(ctx: PullRequestContext, labels: Iterable[str]) -> None:
+    if dry_run():
+        for label in labels:
+            print(f"dry-run: remove label {label}", file=sys.stderr)
+        return
+    token = get_token()
+    repo = urllib.parse.quote(ctx.repository, safe="/")
+    for label in labels:
+        encoded_label = urllib.parse.quote(label, safe="")
+        api_request("DELETE", f"/repos/{repo}/issues/{ctx.number}/labels/{encoded_label}", token, allow_404=True)
+
+
+def sync_labels(ctx: PullRequestContext, config: dict[str, Any], target_label: str) -> None:
+    stale = sorted((managed_intake_labels(config) - {target_label}) & ctx.labels)
+    apply_label(ctx, target_label)
+    remove_labels(ctx, stale)
+
+
+def list_comments(ctx: PullRequestContext) -> list[dict[str, Any]]:
+    if dry_run():
+        return []
+    token = get_token()
+    repo = urllib.parse.quote(ctx.repository, safe="/")
+    comments: list[dict[str, Any]] = []
+    page = 1
+    per_page = 100
+    while True:
+        page_comments = api_request(
+            "GET",
+            f"/repos/{repo}/issues/{ctx.number}/comments?per_page={per_page}&page={page}",
+            token,
+        )
+        if not isinstance(page_comments, list):
+            raise GateError("unexpected comments response")
+        comments.extend(page_comments)
+        if len(page_comments) < per_page:
+            break
+        page += 1
+    return comments
+
+
+def upsert_comment(ctx: PullRequestContext, marker: str, body: str) -> None:
+    if dry_run():
+        print("dry-run: upsert gate comment", file=sys.stderr)
+        return
+    token = get_token()
+    repo = urllib.parse.quote(ctx.repository, safe="/")
+    for comment in list_comments(ctx):
+        if marker in str(comment.get("body") or ""):
+            comment_id = comment.get("id")
+            if comment_id:
+                api_request("PATCH", f"/repos/{repo}/issues/comments/{comment_id}", token, {"body": body})
+                return
+    api_request("POST", f"/repos/{repo}/issues/{ctx.number}/comments", token, {"body": body})
+
+
+def update_existing_gate_comment(ctx: PullRequestContext, marker: str, body: str) -> None:
+    if dry_run():
+        return
+    token = get_token()
+    repo = urllib.parse.quote(ctx.repository, safe="/")
+    for comment in list_comments(ctx):
+        if marker in str(comment.get("body") or ""):
+            comment_id = comment.get("id")
+            if comment_id:
+                api_request("PATCH", f"/repos/{repo}/issues/comments/{comment_id}", token, {"body": body})
+            return
+
+
+def write_step_summary(summary: dict[str, Any]) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    high_risk_paths = summary.get("high_risk_paths") or []
+    if high_risk_paths:
+        high_risk_text = "\n".join(f"  - `{item}`" for item in high_risk_paths)
+    else:
+        high_risk_text = "  - none"
+
+    lines = [
+        "## PR Intake Gate",
+        "",
+        f"- Verdict: `{summary['verdict']}`",
+        f"- Changed lines: `{summary['changed_lines']}`",
+        f"- Linked intent: `{'yes' if summary['linked_intent'] else 'no'}`",
+        "- High-risk paths:",
+        high_risk_text,
+        f"- Reason: {summary['reason']}",
+        f"- Next step: {summary['next_step']}",
+        "",
+    ]
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines))
+
+
+def determine_verdict(
+    ctx: PullRequestContext,
+    config: dict[str, Any],
+    files: list[ChangedFile],
+) -> tuple[Verdict, dict[str, Any]]:
+    labels = config.get("labels", {})
+    if not isinstance(labels, dict):
+        raise GateError("config.labels must be a mapping")
+
+    override_label = str(labels.get("override") or "maintainer/override-intake")
+    pass_label = str(labels.get("pass") or "intake/pass")
+    needs_issue_label = str(labels.get("needs_issue") or "intake/needs-issue")
+    high_risk_label = str(labels.get("high_risk") or "intake/high-risk")
+
+    trivial_config = config.get("trivial", {})
+    max_changed_lines = int(trivial_config.get("max_changed_lines", 30))
+    allowed_path_globs = [str(item) for item in trivial_config.get("allowed_path_globs", [])]
+    high_risk_globs = [str(item) for item in config.get("high_risk_path_globs", [])]
+    accept_patterns = [str(item) for item in config.get("linked_intent", {}).get("accept_patterns", [])]
+
+    changed_lines = sum(item.additions + item.deletions for item in files)
+    changed_paths = [item.filename for item in files]
+    high_risk_paths = sorted(
+        path
+        for path in changed_paths
+        if matching_patterns(path, high_risk_globs)
+    )
+    all_paths_allowed = all(
+        any(path_matches(path, pattern) for pattern in allowed_path_globs)
+        for path in changed_paths
+    )
+    is_trivial = changed_lines <= max_changed_lines and all_paths_allowed and not high_risk_paths
+    linked = has_linked_intent(ctx.body, accept_patterns)
+
+    marker = str(config.get("bot_comment", {}).get("marker") or "<!-- pr-intake-gate -->")
+    details = {
+        "repository": ctx.repository,
+        "pull_request": ctx.number,
+        "author_association": ctx.author_association,
+        "base_sha": ctx.base_sha,
+        "head_sha": ctx.head_sha,
+        "changed_lines": changed_lines,
+        "changed_paths": changed_paths,
+        "high_risk_paths": high_risk_paths,
+        "linked_intent": linked,
+        "is_trivial": is_trivial,
+        "marker": marker,
+    }
+
+    if override_label in ctx.labels:
+        return (
+            Verdict(
+                name="pass",
+                reason="Maintainer override label is present.",
+                next_step="Code review can proceed; maintainer accepted intake responsibility.",
+                label=pass_label,
+                should_comment=False,
+                comment_body=None,
+                exit_code=0,
+            ),
+            details,
+        )
+
+    if high_risk_paths:
+        return (
+            Verdict(
+                name="high-risk",
+                reason="PR touches high-risk paths.",
+                next_step="Maintainer should review intent/risk or add maintainer override.",
+                label=high_risk_label,
+                should_comment=True,
+                comment_body=HIGH_RISK_COMMENT,
+                exit_code=1,
+            ),
+            details,
+        )
+
+    if is_trivial:
+        return (
+            Verdict(
+                name="pass",
+                reason="PR is within trivial direct-PR limits.",
+                next_step="Code review can proceed.",
+                label=pass_label,
+                should_comment=False,
+                comment_body=None,
+                exit_code=0,
+            ),
+            details,
+        )
+
+    if not linked:
+        return (
+            Verdict(
+                name="needs-issue",
+                reason="Non-trivial PR does not include linked Issue or Discussion intent.",
+                next_step="Add a linked Issue/Discussion or ask a maintainer for override.",
+                label=needs_issue_label,
+                should_comment=True,
+                comment_body=NEEDS_ISSUE_COMMENT,
+                exit_code=1,
+            ),
+            details,
+        )
+
+    return (
+        Verdict(
+            name="pass",
+            reason="Non-trivial PR includes linked intent and avoids configured high-risk paths.",
+            next_step="Code review can proceed.",
+            label=pass_label,
+            should_comment=False,
+            comment_body=None,
+            exit_code=0,
+        ),
+        details,
+    )
+
+
+def main() -> int:
+    try:
+        config = load_minimal_yaml(CONFIG_PATH)
+        event = load_event()
+        ctx = get_pr_context(event)
+        files = load_changed_files(ctx)
+        verdict, details = determine_verdict(ctx, config, files)
+
+        sync_labels(ctx, config, verdict.label)
+        marker = str(details["marker"])
+        if verdict.should_comment and verdict.comment_body:
+            upsert_comment(ctx, marker, verdict.comment_body)
+        elif verdict.exit_code == 0:
+            update_existing_gate_comment(ctx, marker, PASS_COMMENT)
+
+        summary = {
+            **details,
+            "verdict": verdict.name,
+            "reason": verdict.reason,
+            "next_step": verdict.next_step,
+        }
+        write_step_summary(summary)
+        print(json.dumps(summary, sort_keys=True))
+        return verdict.exit_code
+    except GateError as exc:
+        print(f"pr-intake-gate error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr_intake_gate.py
+++ b/scripts/pr_intake_gate.py
@@ -290,14 +290,24 @@ def load_changed_files(ctx: PullRequestContext) -> list[ChangedFile]:
 def path_matches(path: str, pattern: str) -> bool:
     normalized = path.strip("/")
     pattern = pattern.strip("/")
-    pure = PurePosixPath(normalized)
-    if fnmatchcase(normalized, pattern):
-        return True
-    if pure.match(pattern):
-        return True
-    if pattern.startswith("**/") and (fnmatchcase(normalized, pattern[3:]) or pure.match(pattern[3:])):
-        return True
-    return False
+    if not normalized or not pattern:
+        return normalized == pattern
+    return match_path_parts(tuple(PurePosixPath(normalized).parts), tuple(PurePosixPath(pattern).parts))
+
+
+def match_path_parts(path_parts: tuple[str, ...], pattern_parts: tuple[str, ...]) -> bool:
+    if not pattern_parts:
+        return not path_parts
+
+    head, *tail = pattern_parts
+    if head == "**":
+        if not tail:
+            return True
+        return any(match_path_parts(path_parts[index:], tuple(tail)) for index in range(len(path_parts) + 1))
+
+    if not path_parts:
+        return False
+    return fnmatchcase(path_parts[0], head) and match_path_parts(path_parts[1:], tuple(tail))
 
 
 def matching_patterns(path: str, patterns: Iterable[str]) -> list[str]:
@@ -382,7 +392,7 @@ def upsert_comment(ctx: PullRequestContext, marker: str, body: str) -> None:
     token = get_token()
     repo = urllib.parse.quote(ctx.repository, safe="/")
     for comment in list_comments(ctx):
-        if marker in str(comment.get("body") or ""):
+        if is_gate_comment(comment, marker):
             comment_id = comment.get("id")
             if comment_id:
                 api_request("PATCH", f"/repos/{repo}/issues/comments/{comment_id}", token, {"body": body})
@@ -396,11 +406,27 @@ def update_existing_gate_comment(ctx: PullRequestContext, marker: str, body: str
     token = get_token()
     repo = urllib.parse.quote(ctx.repository, safe="/")
     for comment in list_comments(ctx):
-        if marker in str(comment.get("body") or ""):
+        if is_gate_comment(comment, marker):
             comment_id = comment.get("id")
             if comment_id:
                 api_request("PATCH", f"/repos/{repo}/issues/comments/{comment_id}", token, {"body": body})
             return
+
+
+def gate_comment_bot_logins() -> set[str]:
+    raw = os.environ.get("PR_INTAKE_GATE_COMMENT_BOT_LOGINS", "github-actions[bot]")
+    return {item.strip() for item in raw.split(",") if item.strip()}
+
+
+def is_gate_comment(comment: dict[str, Any], marker: str) -> bool:
+    if marker not in str(comment.get("body") or ""):
+        return False
+    user = comment.get("user") or {}
+    if not isinstance(user, dict):
+        return False
+    login = str(user.get("login") or "")
+    user_type = str(user.get("type") or "")
+    return login in gate_comment_bot_logins() and user_type in {"", "Bot"}
 
 
 def write_step_summary(summary: dict[str, Any]) -> None:

--- a/tests/test-pr-intake-gate.sh
+++ b/tests/test-pr-intake-gate.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+write_event() {
+  local path="$1"
+  local body="$2"
+  local labels_json="$3"
+  python3 - "$path" "$body" "$labels_json" <<'PY'
+import json
+import sys
+path, body, labels_json = sys.argv[1], sys.argv[2], sys.argv[3]
+labels = [{"name": name} for name in json.loads(labels_json)]
+event = {
+    "repository": {"full_name": "heurema/signum"},
+    "pull_request": {
+        "number": 123,
+        "title": "Test PR",
+        "body": body,
+        "author_association": "CONTRIBUTOR",
+        "labels": labels,
+        "base": {"sha": "base-sha"},
+        "head": {"sha": "head-sha"},
+    },
+}
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(event, handle)
+PY
+}
+
+run_case() {
+  local name="$1"
+  local expected_status="$2"
+  local expected_verdict="$3"
+  local files_json="$4"
+  local body="$5"
+  local labels_json="$6"
+  local event_path="$TMP_DIR/${name}.event.json"
+  local stdout_path="$TMP_DIR/${name}.stdout.json"
+  local stderr_path="$TMP_DIR/${name}.stderr.txt"
+  local summary_path="$TMP_DIR/${name}.summary.md"
+
+  write_event "$event_path" "$body" "$labels_json"
+
+  set +e
+  (
+    cd "$ROOT_DIR"
+    GITHUB_EVENT_PATH="$event_path" \
+    GITHUB_STEP_SUMMARY="$summary_path" \
+    PR_INTAKE_GATE_CHANGED_FILES_JSON="$files_json" \
+    PR_INTAKE_GATE_DRY_RUN=1 \
+    python3 scripts/pr_intake_gate.py >"$stdout_path" 2>"$stderr_path"
+  )
+  local actual_status=$?
+  set -e
+
+  if [ "$actual_status" -ne "$expected_status" ]; then
+    echo "FAIL $name: expected exit $expected_status, got $actual_status" >&2
+    cat "$stderr_path" >&2 || true
+    cat "$stdout_path" >&2 || true
+    exit 1
+  fi
+
+  local actual_verdict
+  actual_verdict="$(python3 - "$stdout_path" <<'PY'
+import json
+import sys
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    print(json.load(handle)["verdict"])
+PY
+)"
+
+  if [ "$actual_verdict" != "$expected_verdict" ]; then
+    echo "FAIL $name: expected verdict $expected_verdict, got $actual_verdict" >&2
+    cat "$stdout_path" >&2 || true
+    exit 1
+  fi
+
+  if ! grep -q 'PR Intake Gate' "$summary_path"; then
+    echo "FAIL $name: missing step summary" >&2
+    cat "$summary_path" >&2 || true
+    exit 1
+  fi
+
+  echo "ok - $name"
+}
+
+run_case \
+  "docs_only_passes" \
+  0 \
+  "pass" \
+  '[{"filename":"README.md","additions":2,"deletions":1}]' \
+  '' \
+  '[]'
+
+run_case \
+  "non_trivial_without_intent_fails" \
+  1 \
+  "needs-issue" \
+  '[{"filename":"docs/usage.md","additions":31,"deletions":0}]' \
+  '' \
+  '[]'
+
+run_case \
+  "high_risk_workflow_fails" \
+  1 \
+  "high-risk" \
+  '[{"filename":".github/workflows/ci.yml","additions":1,"deletions":0}]' \
+  '' \
+  '[]'
+
+run_case \
+  "override_passes_high_risk" \
+  0 \
+  "pass" \
+  '[{"filename":".github/workflows/ci.yml","additions":1,"deletions":0}]' \
+  '' \
+  '["maintainer/override-intake"]'
+
+run_case \
+  "linked_non_trivial_passes" \
+  0 \
+  "pass" \
+  '[{"filename":"docs/usage.md","additions":31,"deletions":0}]' \
+  'Closes #42' \
+  '[]'

--- a/tests/test-pr-intake-gate.sh
+++ b/tests/test-pr-intake-gate.sh
@@ -88,11 +88,33 @@ PY
   echo "ok - $name"
 }
 
+python3 - <<'PY'
+from scripts.pr_intake_gate import is_gate_comment, path_matches
+
+marker = "<!-- pr-intake-gate -->"
+assert path_matches("README.md", "*.md")
+assert path_matches("docs/usage.md", "docs/**")
+assert not path_matches("src/runtime.md", "*.md")
+assert path_matches("scripts/check.sh", "scripts/**/*.sh")
+assert path_matches("scripts/nested/check.sh", "scripts/**/*.sh")
+assert not is_gate_comment({"body": marker, "user": {"login": "contributor", "type": "User"}}, marker)
+assert is_gate_comment({"body": marker, "user": {"login": "github-actions[bot]", "type": "Bot"}}, marker)
+print("ok - helper semantics")
+PY
+
 run_case \
   "docs_only_passes" \
   0 \
   "pass" \
   '[{"filename":"README.md","additions":2,"deletions":1}]' \
+  '' \
+  '[]'
+
+run_case \
+  "nested_markdown_without_intent_fails" \
+  1 \
+  "needs-issue" \
+  '[{"filename":"src/runtime.md","additions":1,"deletions":0}]' \
   '' \
   '[]'
 
@@ -109,6 +131,14 @@ run_case \
   1 \
   "high-risk" \
   '[{"filename":".github/workflows/ci.yml","additions":1,"deletions":0}]' \
+  '' \
+  '[]'
+
+run_case \
+  "high_risk_script_shell_fails" \
+  1 \
+  "high-risk" \
+  '[{"filename":"scripts/check.sh","additions":1,"deletions":0}]' \
   '' \
   '[]'
 


### PR DESCRIPTION
## Summary
- Add a deterministic PR Intake Gate workflow that uses `pull_request_target` without checking out or executing PR head code.
- Add repo-local intake policy config, issue/PR templates, contributor policy, and review instructions.
- Add stdlib-only gate implementation with idempotent labels/comments and local dry-run tests.

## Issue ID
N/A - repository intake setup

## Test plan
- `python3 -m py_compile scripts/pr_intake_gate.py`
- `bash tests/test-pr-intake-gate.sh`
- `bash tests/test-prose-check.sh`
- `bash tests/test-doc-parity.sh`
- all `tests/test-*.sh` scripts: 63 passed, 0 failed

## Follow-up after merge
- Open a test docs-only PR so `pr-intake-gate` appears as a recent successful check.
- Then enable `pr-intake-gate` as a required status check in the default-branch ruleset.
