### PR TITLE
Allow intake gate to label pull requests

### DIFF
--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:


### PR DESCRIPTION
## Summary
- Change `pr-intake-gate` workflow token permission from `pull-requests: read` to `pull-requests: write`.
- This is required for the gate to apply labels/comments to pull requests with the GitHub Actions token.

## Issue ID
N/A - rollout fix found during PR Intake Gate testing

## Test plan
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-intake-gate.yml")'`
- Real PR Intake Gate test rerun after merge on PRs #37, #38, and #39.
