### PR TITLE
Fix proofpack validator precedence and init scanner depth

### DIFF
--- a/platforms/claude-code/scripts/init_scanner.py
+++ b/platforms/claude-code/scripts/init_scanner.py
@@ -244,9 +244,11 @@ def compute_entrypoints(root: Path) -> str:
                 rel = candidate.relative_to(root).as_posix()
                 if "__pycache__" in rel:
                     continue
-                # Historical find -maxdepth 2 includes files directly in the dir
-                # and one level below it.
-                if len(Path(rel).parts) <= 2:
+                # Historical find -maxdepth 2 from the entrypoint dir includes
+                # files directly in the dir and one level below it; relative to
+                # the repo root that means up to 3 path parts (ep_dir + up to 2
+                # deeper components).
+                if len(Path(rel).parts) <= 3:
                     entries.append(rel)
         except OSError:
             entries = []

--- a/platforms/claude-code/scripts/validate_proofpack.py
+++ b/platforms/claude-code/scripts/validate_proofpack.py
@@ -76,14 +76,18 @@ def _script_root() -> Path:
 
 
 def _candidate_roots(repo_root: Path | None) -> list[Path]:
+    # Resolve Signum-owned metadata (plugin.json, schema, command file) from the
+    # Signum install location first. A scanned project may ship its own
+    # .claude-plugin/plugin.json, which would otherwise hijack signumVersion
+    # source-of-truth checks and produce false mismatches.
     roots: list[Path] = []
-    if repo_root is not None:
-        roots.append(repo_root)
     script_root = _script_root()
     roots.append(script_root)
     # When running a mirrored platform script, script_root is platforms/claude-code.
     # When running root script, this duplicate is harmless.
     roots.append(script_root.parent)
+    if repo_root is not None:
+        roots.append(repo_root)
 
     unique: list[Path] = []
     seen: set[Path] = set()

--- a/scripts/init_scanner.py
+++ b/scripts/init_scanner.py
@@ -244,9 +244,11 @@ def compute_entrypoints(root: Path) -> str:
                 rel = candidate.relative_to(root).as_posix()
                 if "__pycache__" in rel:
                     continue
-                # Historical find -maxdepth 2 includes files directly in the dir
-                # and one level below it.
-                if len(Path(rel).parts) <= 2:
+                # Historical find -maxdepth 2 from the entrypoint dir includes
+                # files directly in the dir and one level below it; relative to
+                # the repo root that means up to 3 path parts (ep_dir + up to 2
+                # deeper components).
+                if len(Path(rel).parts) <= 3:
                     entries.append(rel)
         except OSError:
             entries = []

--- a/scripts/validate_proofpack.py
+++ b/scripts/validate_proofpack.py
@@ -76,14 +76,18 @@ def _script_root() -> Path:
 
 
 def _candidate_roots(repo_root: Path | None) -> list[Path]:
+    # Resolve Signum-owned metadata (plugin.json, schema, command file) from the
+    # Signum install location first. A scanned project may ship its own
+    # .claude-plugin/plugin.json, which would otherwise hijack signumVersion
+    # source-of-truth checks and produce false mismatches.
     roots: list[Path] = []
-    if repo_root is not None:
-        roots.append(repo_root)
     script_root = _script_root()
     roots.append(script_root)
     # When running a mirrored platform script, script_root is platforms/claude-code.
     # When running root script, this duplicate is harmless.
     roots.append(script_root.parent)
+    if repo_root is not None:
+        roots.append(repo_root)
 
     unique: list[Path] = []
     seen: set[Path] = set()

--- a/tests/fixtures/init-scanner/expected/manifest-project.json
+++ b/tests/fixtures/init-scanner/expected/manifest-project.json
@@ -12,7 +12,7 @@
     "cargo_toml": "[package]\nname = \"manifest-project\"\nversion = \"0.1.0\"",
     "go_mod": "module example.com/manifest-project\n\ngo 1.22",
     "ci_signals": "",
-    "entrypoints": "\n=== bin/ ===\nbin/manifest.js\n\n=== commands/ ===\ncommands/run.md\n\n=== skills/ ===\nskills/main.md\n",
+    "entrypoints": "\n=== bin/ ===\nbin/manifest.js\n\n=== commands/ ===\ncommands/nested-group/run.md\ncommands/run.md\n\n=== skills/ ===\nskills/main.md\n",
     "console_scripts": "[project.scripts]\nmanifest-py = \"manifest_project.cli:main\"",
     "pkg_bin": "manifest-cli: bin/manifest.js",
     "git_dirstat": "",

--- a/tests/fixtures/init-scanner/manifest-project/commands/nested-group/deep/run.md
+++ b/tests/fixtures/init-scanner/manifest-project/commands/nested-group/deep/run.md
@@ -1,0 +1,5 @@
+# Too deep — must be excluded.
+
+This file lives at `commands/nested-group/deep/run.md` (4 path parts from repo
+root). Historical `find -maxdepth 2` from `commands/` excludes it. The scanner
+must keep it out of `signals.entrypoints`.

--- a/tests/fixtures/init-scanner/manifest-project/commands/nested-group/run.md
+++ b/tests/fixtures/init-scanner/manifest-project/commands/nested-group/run.md
@@ -1,0 +1,5 @@
+# Nested entrypoint at depth 2 inside commands/
+
+This file lives at `commands/nested-group/run.md` (3 path parts from repo root)
+to exercise the historical `find -maxdepth 2` semantics: scanner must include
+files one directory below the entrypoint dir.

--- a/tests/test-proofpack-validation.sh
+++ b/tests/test-proofpack-validation.sh
@@ -103,6 +103,17 @@ printf '{"goal":"fixture"}\n' > "$INFER_ROOT/contract.json"
 assert_ok "validator infers canonical contract root from proofpack path" \
   python3 "$VALIDATOR" "$INFER_ROOT/proofpack.json" --repo-root "$REPO_ROOT"
 
+# Regression for issue #42: when --repo-root points to a project that ships its
+# own .claude-plugin/plugin.json with a different version, the validator must
+# still resolve signumVersion from the Signum install, not from the scanned
+# project. Otherwise valid runs against plugin-shipping projects fail.
+PROJECT_WITH_PLUGIN="$WORK/project-with-conflicting-plugin"
+mkdir -p "$PROJECT_WITH_PLUGIN/.claude-plugin"
+printf '{"name":"unrelated","version":"0.0.0-conflicting"}\n' \
+  > "$PROJECT_WITH_PLUGIN/.claude-plugin/plugin.json"
+assert_ok "validator prefers Signum plugin metadata over scanned project's plugin.json" \
+  python3 "$VALIDATOR" "$FIXTURES/valid-minimal.json" --repo-root "$PROJECT_WITH_PLUGIN"
+
 echo ""
 echo "=== Invalid proofpacks ==="
 assert_fail_contains "malformed JSON fails" "invalid JSON" \


### PR DESCRIPTION
## Summary

- Closes #42 — `scripts/validate_proofpack.py` and its overlay copy now resolve `signumVersion` from the Signum install location before `--repo-root`, so a scanned project that ships its own `.claude-plugin/plugin.json` no longer hijacks the source-of-truth check and produces false `signumVersion mismatch` errors.
- Closes #43 — `scripts/init_scanner.py` and its overlay copy now keep entrypoint files one level below `bin/commands/skills`, matching the historical `find ... -maxdepth 2` semantics. Files like `commands/foo/run.md` are no longer silently dropped from `signals.entrypoints`; deeper nesting (e.g. `commands/foo/bar/run.md`) is still excluded.

## Verification

- `bash tests/test-init-scanner.sh` — PASS, including new nested-group fixture (`commands/nested-group/run.md` retained, `commands/nested-group/deep/run.md` correctly omitted).
- `bash tests/test-proofpack-validation.sh` — PASS, including new regression: validator succeeds against a `--repo-root` that ships a conflicting `0.0.0-conflicting` plugin.json.
- `bash scripts/run-deterministic-tests.sh` — PASS.
- `SIGNUM_CLEANROOM_FULL=1 bash scripts/run-cleanroom-smoke.sh` — PASS.
- `python3 evals/run.py` — PASS (6/6).
- Root and overlay command renderer `--check` — PASS.
- Sanity-checked: reverting either fix while keeping the new fixtures/asserts fails the corresponding test, confirming the guards exercise the bug.

## Notes

- Both bugs were pre-existing in the stabilization import surface (#41), not introduced by it. Scope is intentionally narrow: only the precedence list, the depth condition, and the matching guards.
- Runtime command output, workflows, fragments, and renderer behavior are unchanged.