### PR TITLE
Bump version to 4.21.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,5 @@
   "license": "MIT",
   "name": "signum",
   "repository": "https://github.com/heurema/signum",
-  "version": "4.20.2"
+  "version": "4.21.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## [4.21.0] - 2026-04-27
+
+### Added
+- Deterministic PR CI and local clean-room smoke coverage: `scripts/run-deterministic-tests.sh`, `scripts/run-cleanroom-smoke.sh`, and `.github/workflows/ci.yml` keep release-relevant tests reproducible without network or external CLIs.
+- Renderer/fragment parity, proofpack validation, policy scanner, init scanner, and stabilization inventory guards (`tests/test-signum-command-renderer.sh`, `tests/test-signum-fragment-parity.sh`, `tests/test-proofpack-validation.sh`, `tests/test-policy-scanner.sh`, `tests/test-init-scanner.sh`, `tests/test-stabilization-summary.sh`, etc.) prevent silent regressions in the imported stabilization surface.
+- `lib/templates/init-harness/*.tmpl` extracts the previously inline init-harness markdown heredocs into checked-in templates with golden scaffold coverage.
+
+### Changed
+- `commands/signum.md` and the Claude overlay are now rendered from `commands/signum.fragments/manifest.json` plus shared fragments. Output is byte-for-byte identical to the previous monolithic command file; fragment parity is enforced by `tests/test-signum-fragment-parity.sh`.
+- `_candidate_roots` in `scripts/validate_proofpack.py` (and the overlay copy) now resolves Signum-owned metadata from the Signum install location before `--repo-root`, so a scanned project that ships its own `.claude-plugin/plugin.json` no longer hijacks the source-of-truth check.
+- `compute_entrypoints` in `scripts/init_scanner.py` (and the overlay copy) now keeps entrypoint files one level below `bin/commands/skills`, restoring the historical `find ... -maxdepth 2` semantics so files like `commands/foo/run.md` are no longer dropped from `signals.entrypoints`.
+
+### Fixed
+- `tests/fixtures/stabilization-findings.json` evidence path for the init-harness template no longer drifts on case-sensitive filesystems (Linux CI), matching the actual lowercase template filename.
+- `tests/test-stabilization-summary.sh` now validates evidence paths case-exact via `os.listdir`, so macOS does not hide path-casing mistakes.
+- `tests/test-intentional-root-compatibility-mentions.sh` no longer depends on `ripgrep` and uses a Python stdlib search helper instead, keeping deterministic CI free of apt-installed tools.
+- Canonical-path shell tests (`tests/test-contract-bootstrap-canonical-paths.sh` and eight peers) now derive their root via `$SCRIPT_DIR/..` instead of hardcoded local `/Users/...` paths, and a static guard prevents the regression.
+
 ## [4.20.2] - 2026-04-24
 
 ### Fixed

--- a/commands/signum.fragments/100-phase-pack.md
+++ b/commands/signum.fragments/100-phase-pack.md
@@ -268,7 +268,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.20.2" \
+  --arg signumVersion "4.21.0" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/commands/signum.fragments/20-explain-mode.md
+++ b/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.20.2",
+  "version": "4.21.0",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -46,7 +46,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.20.2",
+  "version": "4.21.0",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -3547,7 +3547,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.20.2" \
+  --arg signumVersion "4.21.0" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/claude-code/.claude-plugin/plugin.json
+++ b/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "signum",
   "description": "Evidence-driven development pipeline with multi-model code review",
-  "version": "4.20.2",
+  "version": "4.21.0",
   "author": {
     "name": "heurema"
   },

--- a/platforms/claude-code/CHANGELOG.md
+++ b/platforms/claude-code/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## [4.21.0] - 2026-04-27
+
+### Added
+- Deterministic PR CI and local clean-room smoke coverage: `scripts/run-deterministic-tests.sh`, `scripts/run-cleanroom-smoke.sh`, and `.github/workflows/ci.yml` keep release-relevant tests reproducible without network or external CLIs.
+- Renderer/fragment parity, proofpack validation, policy scanner, init scanner, and stabilization inventory guards (`tests/test-signum-command-renderer.sh`, `tests/test-signum-fragment-parity.sh`, `tests/test-proofpack-validation.sh`, `tests/test-policy-scanner.sh`, `tests/test-init-scanner.sh`, `tests/test-stabilization-summary.sh`, etc.) prevent silent regressions in the imported stabilization surface.
+- `lib/templates/init-harness/*.tmpl` extracts the previously inline init-harness markdown heredocs into checked-in templates with golden scaffold coverage.
+
+### Changed
+- `commands/signum.md` and the Claude overlay are now rendered from `commands/signum.fragments/manifest.json` plus shared fragments. Output is byte-for-byte identical to the previous monolithic command file; fragment parity is enforced by `tests/test-signum-fragment-parity.sh`.
+- `_candidate_roots` in `scripts/validate_proofpack.py` (and the overlay copy) now resolves Signum-owned metadata from the Signum install location before `--repo-root`, so a scanned project that ships its own `.claude-plugin/plugin.json` no longer hijacks the source-of-truth check.
+- `compute_entrypoints` in `scripts/init_scanner.py` (and the overlay copy) now keeps entrypoint files one level below `bin/commands/skills`, restoring the historical `find ... -maxdepth 2` semantics so files like `commands/foo/run.md` are no longer dropped from `signals.entrypoints`.
+
+### Fixed
+- `tests/fixtures/stabilization-findings.json` evidence path for the init-harness template no longer drifts on case-sensitive filesystems (Linux CI), matching the actual lowercase template filename.
+- `tests/test-stabilization-summary.sh` now validates evidence paths case-exact via `os.listdir`, so macOS does not hide path-casing mistakes.
+- `tests/test-intentional-root-compatibility-mentions.sh` no longer depends on `ripgrep` and uses a Python stdlib search helper instead, keeping deterministic CI free of apt-installed tools.
+- Canonical-path shell tests (`tests/test-contract-bootstrap-canonical-paths.sh` and eight peers) now derive their root via `$SCRIPT_DIR/..` instead of hardcoded local `/Users/...` paths, and a static guard prevents the regression.
+
 ## [4.20.2] - 2026-04-24
 
 ### Fixed

--- a/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
+++ b/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
@@ -268,7 +268,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.20.2" \
+  --arg signumVersion "4.21.0" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
+++ b/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.20.2",
+  "version": "4.21.0",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -47,7 +47,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.20.2",
+  "version": "4.21.0",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -3569,7 +3569,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.20.2" \
+  --arg signumVersion "4.21.0" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/tests/fixtures/proofpack/invalid-removal-evidence.json
+++ b/tests/fixtures/proofpack/invalid-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.20.2",
+  "signumVersion": "4.21.0",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-bad-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-artifact-ref.json
+++ b/tests/fixtures/proofpack/missing-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.20.2",
+  "signumVersion": "4.21.0",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-required.json
+++ b/tests/fixtures/proofpack/missing-required.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.20.2",
+  "signumVersion": "4.21.0",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/schema-version-mismatch.json
+++ b/tests/fixtures/proofpack/schema-version-mismatch.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.7",
-  "signumVersion": "4.20.2",
+  "signumVersion": "4.21.0",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/unsafe-artifact-path.json
+++ b/tests/fixtures/proofpack/unsafe-artifact-path.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.20.2",
+  "signumVersion": "4.21.0",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-minimal.json
+++ b/tests/fixtures/proofpack/valid-minimal.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.20.2",
+  "signumVersion": "4.21.0",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-artifact-ref.json
+++ b/tests/fixtures/proofpack/valid-with-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.20.2",
+  "signumVersion": "4.21.0",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-removal-evidence.json
+++ b/tests/fixtures/proofpack/valid-with-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.20.2",
+  "signumVersion": "4.21.0",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/wrong-type.json
+++ b/tests/fixtures/proofpack/wrong-type.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.20.2",
+  "signumVersion": "4.21.0",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",


### PR DESCRIPTION
## Summary

Minor release covering the stabilization baseline (#41) and the post-stabilization fixes (#44, closing #42 and #43).

### Highlights

- Deterministic PR CI and local clean-room smoke coverage (no network, no apt-installed test deps).
- Renderer/fragment parity, proofpack validation, policy scanner, init scanner, and stabilization inventory guards.
- Init harness markdown heredocs extracted into checked-in templates with golden coverage.
- `validate_proofpack` now resolves Signum metadata from the install location before `--repo-root` (closes false `signumVersion mismatch` for plugin-shipping projects).
- `init_scanner` now keeps nested entrypoint files one level deeper than the entrypoint dir, matching historical `find ... -maxdepth 2` semantics.
- Several portability/regression fixes for tests: locale-pinned sort, case-exact path validation, ripgrep removed, repo-relative canonical-path tests.

## Surface

- `.claude-plugin/plugin.json` and overlay → `4.21.0`.
- `commands/signum.fragments/{20-explain-mode,100-phase-pack}.md` and overlay re-rendered.
- `commands/signum.md` and overlay re-rendered (auto-generated).
- All `tests/fixtures/proofpack/*.json` shipping `signumVersion` updated to `4.21.0` (mismatch fixture stays at `0.0.0` by design).
- `CHANGELOG.md` and overlay updated with grouped Added/Changed/Fixed entries.

## Verification

- `bash tests/test-metadata-consistency.sh` — PASS (Plugin version 4.21.0 propagated everywhere).
- `bash tests/test-proofpack-validation.sh` — PASS (27).
- `bash tests/test-signum-fragment-parity.sh` — PASS (138).
- `bash tests/test-emporium-sync.sh` — PASS.
- `bash scripts/run-deterministic-tests.sh` — PASS.
- `SIGNUM_CLEANROOM_FULL=1 bash scripts/run-cleanroom-smoke.sh` — PASS.
- `python3 evals/run.py` — PASS (6/6).

## Marketplace follow-up

After this PR merges and `v4.21.0` tag is created, `heurema/emporium`'s `marketplace.json` will be synced to point Signum at `version: 4.21.0` / `ref: v4.21.0` via `lib/update-emporium-marketplace.sh`. The release-guardrails workflow (`.github/workflows/release-guardrails.yml`) already validates this on tag publish.