### PR TITLE
fix(pr-intake): trust maintainers and enforce external context

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,9 +15,9 @@ What problem does this solve?
 
 Why is this needed now?
 
-## Existing options
+## Existing options checked
 
-Why are existing options or current behavior insufficient?
+Which existing options or current behavior did you check, and why are they insufficient?
 
 ## Alternatives considered
 
@@ -25,7 +25,11 @@ What alternatives did you consider?
 
 ## No-code alternative
 
-Why cannot this be solved without code?
+What docs, configuration, process, or support change could solve this without code?
+
+## Why code is needed
+
+Why is a code change still needed after checking no-code options?
 
 ## Summary
 

--- a/.github/pr-intake-gate.yml
+++ b/.github/pr-intake-gate.yml
@@ -34,20 +34,38 @@ high_risk_path_globs:
   - '**/crypto/**'
   - '**/migrations/**'
 
+trusted_authors:
+  permissions:
+    - 'admin'
+    - 'maintain'
+    - 'write'
+  fallback_author_associations:
+    - 'OWNER'
+    - 'MEMBER'
+    - 'COLLABORATOR'
+
+external_context:
+  required_sections:
+    - 'Problem'
+    - 'Why now'
+    - 'Existing options checked'
+    - 'Alternatives considered'
+    - 'No-code alternative'
+    - 'Why code is needed'
+  no_code_section: 'No-code alternative'
+  first_time_author_associations:
+    - 'FIRST_TIMER'
+    - 'FIRST_TIME_CONTRIBUTOR'
+
 labels:
   pass: 'intake/pass'
   needs_issue: 'intake/needs-issue'
   needs_more_context: 'intake/needs-more-context'
   no_code_alternative: 'intake/no-code-alternative'
   high_risk: 'intake/high-risk'
-  needs_maintainer: 'intake/needs-maintainer-decision'
   accepted_for_pr: 'intake/accepted-for-pr'
+  first_time: 'intake/first-time-contributor'
   override: 'maintainer/override-intake'
-
-verdicts:
-  pass: 'pass'
-  needs_issue: 'needs-issue'
-  high_risk: 'high-risk'
 
 linked_intent:
   accept_patterns:
@@ -56,6 +74,32 @@ linked_intent:
     - 'discussions/\d+'
     - '(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#\d+'
     - 'https://github.com/[^/\s]+/[^/\s]+/(issues|discussions)/\d+'
+
+label_details:
+  intake/pass:
+    color: '2ea44f'
+    description: 'PR intake passed'
+  intake/needs-issue:
+    color: 'd29922'
+    description: 'PR needs linked Issue or Discussion intent'
+  intake/needs-more-context:
+    color: 'd29922'
+    description: 'External PR needs required problem, timing, option, and alternative context'
+  intake/no-code-alternative:
+    color: 'd29922'
+    description: 'External PR needs no-code alternative analysis'
+  intake/high-risk:
+    color: 'cf222e'
+    description: 'PR touches high-risk Signum surfaces and needs maintainer attention'
+  intake/accepted-for-pr:
+    color: '0969da'
+    description: 'Maintainer accepted external PR intent for ordinary review'
+  intake/first-time-contributor:
+    color: 'bf8700'
+    description: 'External PR author appears to be a first-time contributor'
+  maintainer/override-intake:
+    color: '8250df'
+    description: 'Maintainer accepted responsibility to bypass intake gate'
 
 bot_comment:
   marker: '<!-- pr-intake-gate -->'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
+
 ## [4.21.0] - 2026-04-27
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,30 +87,30 @@ For deterministic bug fixes, a failing test first is strongly preferred.
 
 This repository uses a deterministic PR Intake Gate before ordinary code review.
 
-For non-trivial changes, open an Issue or Discussion first and link it from the PR body. The intent should explain:
-- the problem;
-- the expected outcome;
-- why existing behavior/options are insufficient;
-- alternatives considered;
-- why this cannot be solved without code.
+Trusted repository authors pass intake automatically when GitHub reports `admin`, `maintain`, or `write` permission. If GitHub cannot return permission, the gate falls back only to trusted author associations (`OWNER`, `MEMBER`, `COLLABORATOR`).
 
-Direct PRs are allowed for:
-- typo/docs fixes;
-- small test-only changes;
-- clearly scoped bug fixes;
-- maintainer-approved changes.
+External non-trivial PRs need a linked Issue or Discussion and the required PR body context:
+- `Problem`;
+- `Why now`;
+- `Existing options checked`;
+- `Alternatives considered`;
+- `No-code alternative`;
+- `Why code is needed`.
 
-PRs touching security, auth, dependencies, workflows, public APIs, install scripts, schemas, command behavior, or runtime behavior require maintainer attention.
+Direct external PRs are allowed for small typo/docs/test-only changes within the configured trivial limits. External PRs touching security, auth, dependencies, workflows, public APIs, install scripts, schemas, command behavior, or runtime behavior require maintainer attention.
 
-Maintainers can bypass the intake gate with the `maintainer/override-intake` label. Use that label only when taking explicit responsibility for reviewing the PR without the normal intake path.
+Maintainers can bypass any intake case with `maintainer/override-intake`. For non-high-risk external PRs only, maintainers can add `intake/accepted-for-pr` to accept the PR for ordinary review without requiring the full questionnaire first.
 
 ### PR Intake Gate self-check
 
 Expected behavior:
-- docs-only PR: passes and receives `intake/pass`;
-- non-trivial PR without linked Issue/Discussion: fails with `intake/needs-issue` and a short bot comment;
-- PR touching `.github/workflows/**`: fails with `intake/high-risk` and a maintainer-review comment;
-- PR with `maintainer/override-intake`: passes.
+- trusted author PR: passes and receives `intake/pass`, even for high-risk paths;
+- small external docs-only PR: passes and receives `intake/pass`;
+- external non-trivial PR missing required context: fails with `intake/needs-more-context` or `intake/no-code-alternative`;
+- external non-trivial PR with full context but no linked Issue/Discussion: fails with `intake/needs-issue`;
+- external PR touching `.github/workflows/**`: fails with `intake/high-risk` unless `maintainer/override-intake` is present;
+- external non-high-risk PR with `intake/accepted-for-pr`: passes;
+- label/comment write failures are warnings and do not change the deterministic verdict.
 
 Local deterministic checks:
 

--- a/platforms/claude-code/CHANGELOG.md
+++ b/platforms/claude-code/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
+
 ## [4.21.0] - 2026-04-27
 
 ### Added

--- a/scripts/pr_intake_gate.py
+++ b/scripts/pr_intake_gate.py
@@ -3,7 +3,7 @@
 
 Security model:
 - Reads the trusted script/config from the base checkout.
-- Fetches PR metadata and changed-file metadata through GitHub REST API.
+- Fetches PR metadata, author permission, and changed-file metadata through GitHub REST API.
 - Does not checkout, import, install, or execute PR head code.
 - Does not interpolate PR title/body into shell commands.
 """
@@ -17,10 +17,10 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from fnmatch import fnmatchcase
 from pathlib import PurePosixPath
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 ROOT = os.environ.get("GITHUB_WORKSPACE") or os.getcwd()
 CONFIG_PATH = os.path.join(ROOT, ".github", "pr-intake-gate.yml")
@@ -30,33 +30,34 @@ NEEDS_ISSUE_COMMENT = """<!-- pr-intake-gate -->
 
 ## PR Intake Gate: Issue or Discussion needed
 
-Thanks for the contribution. Before code review, this PR needs a linked Issue or Discussion because it appears to be non-trivial.
+Thanks for the contribution. External non-trivial PRs need enough context before ordinary code review.
 
-Please add a link to the relevant Issue/Discussion, or open one describing:
+Please link the relevant GitHub Issue or Discussion in the PR body. The linked intent should explain:
 
 1. The problem.
-2. The expected outcome.
-3. Why existing options are insufficient.
+2. Why it is needed now.
+3. Existing options checked.
 4. Alternatives considered.
-5. Why this cannot be solved without code.
+5. The no-code alternative.
+6. Why code is needed.
 
-A maintainer can bypass this gate by adding `maintainer/override-intake`.
+A maintainer can bypass this gate by adding `maintainer/override-intake`, or accept non-high-risk external PRs with `intake/accepted-for-pr`.
 """
 
 HIGH_RISK_COMMENT = """<!-- pr-intake-gate -->
 
-## PR Intake Gate: Maintainer review needed
+## PR Intake Gate: maintainer review needed
 
-Thanks for the contribution. This PR touches high-risk areas, so it needs explicit maintainer attention before code review proceeds.
+Thanks for the contribution. This external PR touches high-risk Signum areas, so it needs explicit maintainer attention before ordinary code review proceeds.
 
-High-risk areas may include workflows, dependencies, auth/security, install scripts, public APIs, or runtime behavior.
+High-risk areas may include workflows, dependencies, auth/security, install scripts, public APIs, schemas, command behavior, or runtime behavior.
 
-A maintainer can bypass this gate by adding `maintainer/override-intake`.
+A maintainer can bypass this gate by adding `maintainer/override-intake`. For non-high-risk external PRs, a maintainer can use `intake/accepted-for-pr`, but that label does not bypass high-risk intake.
 """
 
 PASS_COMMENT = """<!-- pr-intake-gate -->
 
-## PR Intake Gate: Passed
+## PR Intake Gate: passed
 
 This PR passed the intake gate. Code review can proceed.
 """
@@ -72,6 +73,7 @@ class PullRequestContext:
     number: int
     title: str
     body: str
+    author_login: str
     author_association: str
     labels: set[str]
     base_sha: str
@@ -94,6 +96,13 @@ class Verdict:
     should_comment: bool
     comment_body: str | None
     exit_code: int
+    extra_labels: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class AuthorPermission:
+    permission: str | None
+    error: str | None = None
 
 
 def parse_scalar(raw: str) -> Any:
@@ -140,8 +149,7 @@ def load_minimal_yaml(path: str) -> dict[str, Any]:
         current_indent, current_text = lines[index]
         if current_indent < indent:
             return {}, index
-        is_list = current_text.startswith("- ")
-        if is_list:
+        if current_text.startswith("- "):
             values: list[Any] = []
             while index < len(lines):
                 line_indent, text = lines[index]
@@ -185,6 +193,10 @@ def env_flag(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def dry_run() -> bool:
+    return env_flag("PR_INTAKE_GATE_DRY_RUN")
+
+
 def load_event() -> dict[str, Any]:
     event_path = os.environ.get("GITHUB_EVENT_PATH")
     if not event_path:
@@ -207,12 +219,15 @@ def get_pr_context(event: dict[str, Any]) -> PullRequestContext:
         for label in pr.get("labels", [])
         if isinstance(label, dict) and label.get("name")
     }
+    user = pr.get("user") or {}
+    author_login = user.get("login") if isinstance(user, dict) else ""
 
     return PullRequestContext(
         repository=str(repository),
         number=int(pr["number"]),
         title=str(pr.get("title") or ""),
         body=str(pr.get("body") or ""),
+        author_login=str(author_login or ""),
         author_association=str(pr.get("author_association") or ""),
         labels=labels,
         base_sha=str(pr.get("base", {}).get("sha") or ""),
@@ -243,13 +258,39 @@ def api_request(method: str, path: str, token: str, body: Any | None = None, all
             return None
         detail = exc.read().decode("utf-8", errors="replace")
         raise GateError(f"GitHub API {method} {path} failed: HTTP {exc.code}: {detail}") from exc
+    except (TimeoutError, urllib.error.URLError) as exc:
+        raise GateError(f"GitHub API {method} {path} failed: {exc}") from exc
 
 
 def get_token() -> str:
     token = os.environ.get("GITHUB_TOKEN")
     if not token:
-        raise GateError("GITHUB_TOKEN is required unless PR_INTAKE_GATE_CHANGED_FILES_JSON is set")
+        raise GateError("GITHUB_TOKEN is required for GitHub API reads and writes")
     return token
+
+
+def resolve_author_permission(ctx: PullRequestContext) -> AuthorPermission:
+    fixture = os.environ.get("PR_INTAKE_GATE_AUTHOR_PERMISSION")
+    if fixture is not None:
+        normalized = fixture.strip().lower()
+        return AuthorPermission(None if normalized in {"", "none", "null"} else normalized)
+    if dry_run():
+        return AuthorPermission(None)
+    if not ctx.author_login:
+        return AuthorPermission(None, "missing author login")
+
+    try:
+        token = get_token()
+        repo = urllib.parse.quote(ctx.repository, safe="/")
+        login = urllib.parse.quote(ctx.author_login, safe="")
+        payload = api_request("GET", f"/repos/{repo}/collaborators/{login}/permission", token)
+    except GateError as exc:
+        return AuthorPermission(None, str(exc))
+
+    if not isinstance(payload, dict):
+        return AuthorPermission(None, "unexpected author permission response")
+    permission = payload.get("permission")
+    return AuthorPermission(str(permission).lower() if permission else None)
 
 
 def load_changed_files(ctx: PullRequestContext) -> list[ChangedFile]:
@@ -315,27 +356,89 @@ def matching_patterns(path: str, patterns: Iterable[str]) -> list[str]:
 
 
 def has_linked_intent(text: str, patterns: Iterable[str]) -> bool:
-    for pattern in patterns:
-        if re.search(pattern, text, flags=re.IGNORECASE):
-            return True
-    return False
+    return any(re.search(pattern, text, flags=re.IGNORECASE) for pattern in patterns)
 
 
-def managed_intake_labels(config: dict[str, Any]) -> set[str]:
+def normalize_heading(value: str) -> str:
+    return " ".join(re.sub(r"[^a-z0-9]+", " ", value.lower()).split())
+
+
+def markdown_sections(text: str) -> dict[str, str]:
+    matches = list(re.finditer(r"^#{2,6}\s+(.+?)\s*$", text, flags=re.MULTILINE))
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        sections[normalize_heading(match.group(1))] = text[start:end].strip()
+    return sections
+
+
+def is_meaningful_section_value(value: str) -> bool:
+    stripped_lines = [line.strip() for line in value.splitlines()]
+    content_lines = [line for line in stripped_lines if line and line not in {"-", "N/A", "n/a"}]
+    return bool(content_lines)
+
+
+def missing_required_sections(body: str, required_sections: Iterable[str]) -> list[str]:
+    sections = markdown_sections(body)
+    missing: list[str] = []
+    for section in required_sections:
+        normalized = normalize_heading(section)
+        if not is_meaningful_section_value(sections.get(normalized, "")):
+            missing.append(section)
+    return missing
+
+
+def managed_verdict_labels(config: dict[str, Any]) -> set[str]:
     labels = config.get("labels", {})
     if not isinstance(labels, dict):
         return set()
-    override = labels.get("override")
-    return {str(value) for value in labels.values() if value and value != override and str(value).startswith("intake/")}
+    verdict_keys = {"pass", "needs_issue", "needs_more_context", "no_code_alternative", "high_risk"}
+    return {str(labels[key]) for key in verdict_keys if labels.get(key) and str(labels[key]).startswith("intake/")}
 
 
-def dry_run() -> bool:
-    return env_flag("PR_INTAKE_GATE_DRY_RUN")
+def get_label_details(config: dict[str, Any], label: str) -> dict[str, str]:
+    details = config.get("label_details", {})
+    if not isinstance(details, dict):
+        return {}
+    raw = details.get(label, {})
+    if not isinstance(raw, dict):
+        return {}
+    result: dict[str, str] = {}
+    for key in ("color", "description"):
+        value = raw.get(key)
+        if value is not None:
+            result[key] = str(value)
+    return result
 
 
-def apply_label(ctx: PullRequestContext, label: str) -> None:
+def ensure_label(ctx: PullRequestContext, config: dict[str, Any], label: str) -> None:
     if not label:
         return
+    details = get_label_details(config, label)
+    if not details:
+        return
+    if dry_run():
+        print(f"dry-run: ensure label {label}", file=sys.stderr)
+        return
+
+    token = get_token()
+    repo = urllib.parse.quote(ctx.repository, safe="/")
+    encoded_label = urllib.parse.quote(label, safe="")
+    existing = api_request("GET", f"/repos/{repo}/labels/{encoded_label}", token, allow_404=True)
+    if existing is not None:
+        return
+
+    body = {"name": label, "color": details.get("color", "ededed")}
+    if details.get("description"):
+        body["description"] = details["description"]
+    api_request("POST", f"/repos/{repo}/labels", token, body)
+
+
+def apply_label(ctx: PullRequestContext, config: dict[str, Any], label: str) -> None:
+    if not label:
+        return
+    ensure_label(ctx, config, label)
     if dry_run():
         print(f"dry-run: apply label {label}", file=sys.stderr)
         return
@@ -356,9 +459,11 @@ def remove_labels(ctx: PullRequestContext, labels: Iterable[str]) -> None:
         api_request("DELETE", f"/repos/{repo}/issues/{ctx.number}/labels/{encoded_label}", token, allow_404=True)
 
 
-def sync_labels(ctx: PullRequestContext, config: dict[str, Any], target_label: str) -> None:
-    stale = sorted((managed_intake_labels(config) - {target_label}) & ctx.labels)
-    apply_label(ctx, target_label)
+def sync_labels(ctx: PullRequestContext, config: dict[str, Any], target_label: str, extra_labels: Iterable[str]) -> None:
+    stale = sorted((managed_verdict_labels(config) - {target_label}) & ctx.labels)
+    apply_label(ctx, config, target_label)
+    for label in extra_labels:
+        apply_label(ctx, config, label)
     remove_labels(ctx, stale)
 
 
@@ -383,6 +488,22 @@ def list_comments(ctx: PullRequestContext) -> list[dict[str, Any]]:
             break
         page += 1
     return comments
+
+
+def gate_comment_bot_logins() -> set[str]:
+    raw = os.environ.get("PR_INTAKE_GATE_COMMENT_BOT_LOGINS", "github-actions[bot]")
+    return {item.strip() for item in raw.split(",") if item.strip()}
+
+
+def is_gate_comment(comment: dict[str, Any], marker: str) -> bool:
+    if marker not in str(comment.get("body") or ""):
+        return False
+    user = comment.get("user") or {}
+    if not isinstance(user, dict):
+        return False
+    login = str(user.get("login") or "")
+    user_type = str(user.get("type") or "")
+    return login in gate_comment_bot_logins() and user_type in {"", "Bot"}
 
 
 def upsert_comment(ctx: PullRequestContext, marker: str, body: str) -> None:
@@ -413,20 +534,20 @@ def update_existing_gate_comment(ctx: PullRequestContext, marker: str, body: str
             return
 
 
-def gate_comment_bot_logins() -> set[str]:
-    raw = os.environ.get("PR_INTAKE_GATE_COMMENT_BOT_LOGINS", "github-actions[bot]")
-    return {item.strip() for item in raw.split(",") if item.strip()}
+def run_optional_side_effect(name: str, action: Callable[[], None]) -> bool:
+    try:
+        action()
+        return True
+    except GateError as exc:
+        print(f"pr-intake-gate warning: {name} skipped: {exc}", file=sys.stderr)
+        return False
 
 
-def is_gate_comment(comment: dict[str, Any], marker: str) -> bool:
-    if marker not in str(comment.get("body") or ""):
-        return False
-    user = comment.get("user") or {}
-    if not isinstance(user, dict):
-        return False
-    login = str(user.get("login") or "")
-    user_type = str(user.get("type") or "")
-    return login in gate_comment_bot_logins() and user_type in {"", "Bot"}
+def format_list(values: Iterable[str]) -> str:
+    items = list(values)
+    if not items:
+        return "none"
+    return ", ".join(f"`{item}`" for item in items)
 
 
 def write_step_summary(summary: dict[str, Any]) -> None:
@@ -434,19 +555,29 @@ def write_step_summary(summary: dict[str, Any]) -> None:
     if not path:
         return
     high_risk_paths = summary.get("high_risk_paths") or []
-    if high_risk_paths:
-        high_risk_text = "\n".join(f"  - `{item}`" for item in high_risk_paths)
-    else:
-        high_risk_text = "  - none"
+    high_risk_text = "\n".join(f"  - `{item}`" for item in high_risk_paths) if high_risk_paths else "  - none"
+    changed_paths = summary.get("changed_paths") or []
+    changed_paths_text = "\n".join(f"  - `{item}`" for item in changed_paths) if changed_paths else "  - none"
 
     lines = [
         "## PR Intake Gate",
         "",
         f"- Verdict: `{summary['verdict']}`",
+        f"- Author login: `{summary['author_login'] or 'unknown'}`",
+        f"- Author association: `{summary['author_association'] or 'unknown'}`",
+        f"- Author permission: `{summary['author_permission'] or 'unknown'}`",
+        f"- Author permission error: `{summary['author_permission_error'] or 'none'}`",
+        f"- Trusted author: `{'yes' if summary['trusted_author'] else 'no'}`",
+        f"- Trust source: `{summary['trust_source']}`",
+        f"- First-time external: `{'yes' if summary['first_time_external'] else 'no'}`",
         f"- Changed lines: `{summary['changed_lines']}`",
-        f"- Linked intent: `{'yes' if summary['linked_intent'] else 'no'}`",
+        "- Changed paths:",
+        changed_paths_text,
         "- High-risk paths:",
         high_risk_text,
+        f"- Linked intent: `{'yes' if summary['linked_intent'] else 'no'}`",
+        f"- Accepted for PR: `{'yes' if summary['accepted_for_pr'] else 'no'}`",
+        f"- Missing external context sections: {format_list(summary.get('missing_external_context_sections') or [])}",
         f"- Reason: {summary['reason']}",
         f"- Next step: {summary['next_step']}",
         "",
@@ -455,10 +586,74 @@ def write_step_summary(summary: dict[str, Any]) -> None:
         handle.write("\n".join(lines))
 
 
+def list_config(config: dict[str, Any], path: tuple[str, ...], default: list[str]) -> list[str]:
+    raw: Any = config
+    for key in path:
+        if not isinstance(raw, dict):
+            return default
+        raw = raw.get(key)
+    if not isinstance(raw, list):
+        return default
+    return [str(item) for item in raw]
+
+
+def scalar_config(config: dict[str, Any], path: tuple[str, ...], default: str) -> str:
+    raw: Any = config
+    for key in path:
+        if not isinstance(raw, dict):
+            return default
+        raw = raw.get(key)
+    return str(raw) if raw is not None else default
+
+
+def trust_author(ctx: PullRequestContext, config: dict[str, Any], author_permission: AuthorPermission) -> tuple[bool, str]:
+    trusted_permissions = {
+        item.lower()
+        for item in list_config(config, ("trusted_authors", "permissions"), ["admin", "maintain", "write"])
+    }
+    trusted_associations = {
+        item.upper()
+        for item in list_config(
+            config,
+            ("trusted_authors", "fallback_author_associations"),
+            ["OWNER", "MEMBER", "COLLABORATOR"],
+        )
+    }
+
+    if author_permission.permission and author_permission.permission.lower() in trusted_permissions:
+        return True, f"permission:{author_permission.permission.lower()}"
+    if author_permission.permission is None and ctx.author_association.upper() in trusted_associations:
+        return True, f"author_association:{ctx.author_association.upper()}"
+    return False, "external"
+
+
+def build_missing_context_comment(missing: list[str], no_code_only: bool) -> str:
+    heading = "no-code alternative needed" if no_code_only else "more context needed"
+    lines = [
+        "<!-- pr-intake-gate -->",
+        "",
+        f"## PR Intake Gate: {heading}",
+        "",
+        "Thanks for the contribution. External non-trivial PRs need enough context before ordinary code review.",
+        "",
+        "Please fill these PR body sections:",
+        "",
+    ]
+    lines.extend(f"- `{item}`" for item in missing)
+    lines.extend(
+        [
+            "",
+            "A maintainer can bypass this gate by adding `maintainer/override-intake`, or accept non-high-risk external PRs with `intake/accepted-for-pr`.",
+        ]
+    )
+    return "\n".join(lines)
+
+
 def determine_verdict(
     ctx: PullRequestContext,
     config: dict[str, Any],
     files: list[ChangedFile],
+    author_permission: AuthorPermission,
 ) -> tuple[Verdict, dict[str, Any]]:
     labels = config.get("labels", {})
     if not isinstance(labels, dict):
@@ -467,40 +662,61 @@ def determine_verdict(
     override_label = str(labels.get("override") or "maintainer/override-intake")
     pass_label = str(labels.get("pass") or "intake/pass")
     needs_issue_label = str(labels.get("needs_issue") or "intake/needs-issue")
+    needs_more_context_label = str(labels.get("needs_more_context") or "intake/needs-more-context")
+    no_code_alternative_label = str(labels.get("no_code_alternative") or "intake/no-code-alternative")
     high_risk_label = str(labels.get("high_risk") or "intake/high-risk")
+    accepted_for_pr_label = str(labels.get("accepted_for_pr") or "intake/accepted-for-pr")
+    first_time_label = str(labels.get("first_time") or "intake/first-time-contributor")
 
     trivial_config = config.get("trivial", {})
     max_changed_lines = int(trivial_config.get("max_changed_lines", 30))
     allowed_path_globs = [str(item) for item in trivial_config.get("allowed_path_globs", [])]
     high_risk_globs = [str(item) for item in config.get("high_risk_path_globs", [])]
     accept_patterns = [str(item) for item in config.get("linked_intent", {}).get("accept_patterns", [])]
+    required_sections = list_config(config, ("external_context", "required_sections"), [])
+    no_code_section = scalar_config(config, ("external_context", "no_code_section"), "No-code alternative")
+    first_time_associations = {
+        item.upper()
+        for item in list_config(
+            config,
+            ("external_context", "first_time_author_associations"),
+            ["FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR"],
+        )
+    }
 
     changed_lines = sum(item.additions + item.deletions for item in files)
     changed_paths = [item.filename for item in files]
-    high_risk_paths = sorted(
-        path
-        for path in changed_paths
-        if matching_patterns(path, high_risk_globs)
-    )
-    all_paths_allowed = all(
-        any(path_matches(path, pattern) for pattern in allowed_path_globs)
-        for path in changed_paths
-    )
-    is_trivial = changed_lines <= max_changed_lines and all_paths_allowed and not high_risk_paths
+    high_risk_paths = sorted(path for path in changed_paths if matching_patterns(path, high_risk_globs))
+    all_paths_allowed = all(any(path_matches(path, pattern) for pattern in allowed_path_globs) for path in changed_paths)
+    is_trivial = bool(changed_paths) and changed_lines <= max_changed_lines and all_paths_allowed and not high_risk_paths
     linked = has_linked_intent(ctx.body, accept_patterns)
+    trusted_author, trust_source = trust_author(ctx, config, author_permission)
+    first_time_external = (not trusted_author) and ctx.author_association.upper() in first_time_associations
+    external_extra_labels = (first_time_label,) if first_time_external else ()
+    accepted_for_pr = accepted_for_pr_label in ctx.labels
+    missing_sections = missing_required_sections(ctx.body, required_sections) if required_sections else []
+    missing_no_code = no_code_section in missing_sections
 
     marker = str(config.get("bot_comment", {}).get("marker") or "<!-- pr-intake-gate -->")
     details = {
         "repository": ctx.repository,
         "pull_request": ctx.number,
+        "author_login": ctx.author_login,
         "author_association": ctx.author_association,
+        "author_permission": author_permission.permission,
+        "author_permission_error": author_permission.error,
+        "trusted_author": trusted_author,
+        "trust_source": trust_source,
+        "first_time_external": first_time_external,
         "base_sha": ctx.base_sha,
         "head_sha": ctx.head_sha,
         "changed_lines": changed_lines,
         "changed_paths": changed_paths,
         "high_risk_paths": high_risk_paths,
         "linked_intent": linked,
+        "accepted_for_pr": accepted_for_pr,
         "is_trivial": is_trivial,
+        "missing_external_context_sections": missing_sections,
         "marker": marker,
     }
 
@@ -514,30 +730,17 @@ def determine_verdict(
                 should_comment=False,
                 comment_body=None,
                 exit_code=0,
+                extra_labels=external_extra_labels,
             ),
             details,
         )
 
-    if high_risk_paths:
-        return (
-            Verdict(
-                name="high-risk",
-                reason="PR touches high-risk paths.",
-                next_step="Maintainer should review intent/risk or add maintainer override.",
-                label=high_risk_label,
-                should_comment=True,
-                comment_body=HIGH_RISK_COMMENT,
-                exit_code=1,
-            ),
-            details,
-        )
-
-    if is_trivial:
+    if trusted_author:
         return (
             Verdict(
                 name="pass",
-                reason="PR is within trivial direct-PR limits.",
-                next_step="Code review can proceed.",
+                reason=f"Trusted repository author ({trust_source}).",
+                next_step="Code review can proceed; external-contributor intake checks are skipped.",
                 label=pass_label,
                 should_comment=False,
                 comment_body=None,
@@ -546,16 +749,92 @@ def determine_verdict(
             details,
         )
 
+    if high_risk_paths:
+        return (
+            Verdict(
+                name="high-risk",
+                reason="External PR touches configured high-risk Signum paths.",
+                next_step="Maintainer should review intent/risk or add maintainer override.",
+                label=high_risk_label,
+                should_comment=True,
+                comment_body=HIGH_RISK_COMMENT,
+                exit_code=1,
+                extra_labels=external_extra_labels,
+            ),
+            details,
+        )
+
+    if is_trivial:
+        return (
+            Verdict(
+                name="pass",
+                reason="External PR is within trivial direct-PR limits.",
+                next_step="Code review can proceed.",
+                label=pass_label,
+                should_comment=False,
+                comment_body=None,
+                exit_code=0,
+                extra_labels=external_extra_labels,
+            ),
+            details,
+        )
+
+    if accepted_for_pr:
+        return (
+            Verdict(
+                name="pass",
+                reason="Maintainer accepted this non-high-risk external PR for review.",
+                next_step="Code review can proceed.",
+                label=pass_label,
+                should_comment=False,
+                comment_body=None,
+                exit_code=0,
+                extra_labels=external_extra_labels,
+            ),
+            details,
+        )
+
+    if missing_no_code:
+        return (
+            Verdict(
+                name="no-code-alternative",
+                reason="External non-trivial PR is missing no-code alternative analysis.",
+                next_step="Fill the no-code alternative section or ask a maintainer to accept the PR intent.",
+                label=no_code_alternative_label,
+                should_comment=True,
+                comment_body=build_missing_context_comment(missing_sections, no_code_only=True),
+                exit_code=1,
+                extra_labels=external_extra_labels,
+            ),
+            details,
+        )
+
+    if missing_sections:
+        return (
+            Verdict(
+                name="needs-more-context",
+                reason="External non-trivial PR is missing required intake context sections.",
+                next_step="Fill the required context sections or ask a maintainer to accept the PR intent.",
+                label=needs_more_context_label,
+                should_comment=True,
+                comment_body=build_missing_context_comment(missing_sections, no_code_only=False),
+                exit_code=1,
+                extra_labels=external_extra_labels,
+            ),
+            details,
+        )
+
     if not linked:
         return (
             Verdict(
                 name="needs-issue",
-                reason="Non-trivial PR does not include linked Issue or Discussion intent.",
-                next_step="Add a linked Issue/Discussion or ask a maintainer for override.",
+                reason="External non-trivial PR does not include linked Issue or Discussion intent.",
+                next_step="Add a linked Issue/Discussion or ask a maintainer to accept the PR intent.",
                 label=needs_issue_label,
                 should_comment=True,
                 comment_body=NEEDS_ISSUE_COMMENT,
                 exit_code=1,
+                extra_labels=external_extra_labels,
             ),
             details,
         )
@@ -563,12 +842,13 @@ def determine_verdict(
     return (
         Verdict(
             name="pass",
-            reason="Non-trivial PR includes linked intent and avoids configured high-risk paths.",
+            reason="External non-trivial PR includes required context, linked intent, and avoids configured high-risk paths.",
             next_step="Code review can proceed.",
             label=pass_label,
             should_comment=False,
             comment_body=None,
             exit_code=0,
+            extra_labels=external_extra_labels,
         ),
         details,
     )
@@ -579,15 +859,16 @@ def main() -> int:
         config = load_minimal_yaml(CONFIG_PATH)
         event = load_event()
         ctx = get_pr_context(event)
+        author_permission = resolve_author_permission(ctx)
         files = load_changed_files(ctx)
-        verdict, details = determine_verdict(ctx, config, files)
+        verdict, details = determine_verdict(ctx, config, files, author_permission)
 
-        sync_labels(ctx, config, verdict.label)
+        run_optional_side_effect("label sync", lambda: sync_labels(ctx, config, verdict.label, verdict.extra_labels))
         marker = str(details["marker"])
         if verdict.should_comment and verdict.comment_body:
-            upsert_comment(ctx, marker, verdict.comment_body)
+            run_optional_side_effect("comment upsert", lambda: upsert_comment(ctx, marker, verdict.comment_body))
         elif verdict.exit_code == 0:
-            update_existing_gate_comment(ctx, marker, PASS_COMMENT)
+            run_optional_side_effect("comment update", lambda: update_existing_gate_comment(ctx, marker, PASS_COMMENT))
 
         summary = {
             **details,

--- a/tests/test-pr-intake-gate.sh
+++ b/tests/test-pr-intake-gate.sh
@@ -9,10 +9,13 @@ write_event() {
   local path="$1"
   local body="$2"
   local labels_json="$3"
-  python3 - "$path" "$body" "$labels_json" <<'PY'
+  local author_association="$4"
+  local author_login="$5"
+  python3 - "$path" "$body" "$labels_json" "$author_association" "$author_login" <<'PY'
 import json
 import sys
-path, body, labels_json = sys.argv[1], sys.argv[2], sys.argv[3]
+
+path, body, labels_json, author_association, author_login = sys.argv[1:]
 labels = [{"name": name} for name in json.loads(labels_json)]
 event = {
     "repository": {"full_name": "heurema/signum"},
@@ -20,7 +23,8 @@ event = {
         "number": 123,
         "title": "Test PR",
         "body": body,
-        "author_association": "CONTRIBUTOR",
+        "author_association": author_association,
+        "user": {"login": author_login},
         "labels": labels,
         "base": {"sha": "base-sha"},
         "head": {"sha": "head-sha"},
@@ -35,15 +39,17 @@ run_case() {
   local name="$1"
   local expected_status="$2"
   local expected_verdict="$3"
-  local files_json="$4"
-  local body="$5"
-  local labels_json="$6"
+  local author_association="$4"
+  local author_permission="$5"
+  local files_json="$6"
+  local body="$7"
+  local labels_json="$8"
   local event_path="$TMP_DIR/${name}.event.json"
   local stdout_path="$TMP_DIR/${name}.stdout.json"
   local stderr_path="$TMP_DIR/${name}.stderr.txt"
   local summary_path="$TMP_DIR/${name}.summary.md"
 
-  write_event "$event_path" "$body" "$labels_json"
+  write_event "$event_path" "$body" "$labels_json" "$author_association" "${name}-author"
 
   set +e
   (
@@ -51,6 +57,7 @@ run_case() {
     GITHUB_EVENT_PATH="$event_path" \
     GITHUB_STEP_SUMMARY="$summary_path" \
     PR_INTAKE_GATE_CHANGED_FILES_JSON="$files_json" \
+    PR_INTAKE_GATE_AUTHOR_PERMISSION="$author_permission" \
     PR_INTAKE_GATE_DRY_RUN=1 \
     python3 scripts/pr_intake_gate.py >"$stdout_path" 2>"$stderr_path"
   )
@@ -88,8 +95,144 @@ PY
   echo "ok - $name"
 }
 
+json_assert() {
+  local path="$1"
+  local key="$2"
+  local expected_json="$3"
+  python3 - "$path" "$key" "$expected_json" <<'PY'
+import json
+import sys
+
+path, key, expected_json = sys.argv[1:]
+with open(path, "r", encoding="utf-8") as handle:
+    value = json.load(handle)
+for part in key.split("."):
+    value = value[part]
+expected = json.loads(expected_json)
+if value != expected:
+    raise SystemExit(f"expected {key}={expected!r}, got {value!r}")
+PY
+}
+
+json_list_contains() {
+  local path="$1"
+  local key="$2"
+  local expected="$3"
+  python3 - "$path" "$key" "$expected" <<'PY'
+import json
+import sys
+
+path, key, expected = sys.argv[1:]
+with open(path, "r", encoding="utf-8") as handle:
+    value = json.load(handle)
+for part in key.split("."):
+    value = value[part]
+if expected not in value:
+    raise SystemExit(f"expected {key} to contain {expected!r}, got {value!r}")
+PY
+}
+
+case_stdout() {
+  printf '%s/%s.stdout.json' "$TMP_DIR" "$1"
+}
+
+case_stderr() {
+  printf '%s/%s.stderr.txt' "$TMP_DIR" "$1"
+}
+
+full_context_body() {
+  cat <<'EOF'
+## Problem
+The current behavior blocks a needed contributor workflow.
+
+### Why now
+The project is ready to accept this contribution path.
+
+#### Existing options checked
+Existing documentation and configuration were checked and are insufficient.
+
+## Alternatives considered
+Keeping the current process was considered and rejected because it blocks review.
+
+##### No-code alternative
+Documentation-only guidance would not enforce the intake policy.
+
+###### Why code is needed
+The gate must make the decision deterministically in CI.
+EOF
+}
+
+full_context_with_link_body() {
+  cat <<'EOF'
+## Problem
+The current behavior blocks a needed contributor workflow.
+
+## Why now
+The project is ready to accept this contribution path.
+
+## Existing options checked
+Existing documentation and configuration were checked and are insufficient.
+
+## Alternatives considered
+Keeping the current process was considered and rejected because it blocks review.
+
+## No-code alternative
+Documentation-only guidance would not enforce the intake policy.
+
+## Why code is needed
+The gate must make the decision deterministically in CI.
+
+Closes #42
+EOF
+}
+
+missing_no_code_body() {
+  cat <<'EOF'
+## Problem
+The current behavior blocks a needed contributor workflow.
+
+## Why now
+The project is ready to accept this contribution path.
+
+## Existing options checked
+Existing documentation and configuration were checked and are insufficient.
+
+## Alternatives considered
+Keeping the current process was considered and rejected because it blocks review.
+
+## Why code is needed
+The gate must make the decision deterministically in CI.
+
+Closes #42
+EOF
+}
+
+missing_context_body() {
+  cat <<'EOF'
+## No-code alternative
+Documentation-only guidance would not enforce the intake policy.
+
+## Why code is needed
+The gate must make the decision deterministically in CI.
+
+Closes #42
+EOF
+}
+
 python3 - <<'PY'
-from scripts.pr_intake_gate import is_gate_comment, path_matches
+import contextlib
+import io
+
+from scripts.pr_intake_gate import (
+    GateError,
+    is_gate_comment,
+    load_minimal_yaml,
+    managed_verdict_labels,
+    markdown_sections,
+    missing_required_sections,
+    path_matches,
+    run_optional_side_effect,
+)
 
 marker = "<!-- pr-intake-gate -->"
 assert path_matches("README.md", "*.md")
@@ -97,63 +240,192 @@ assert path_matches("docs/usage.md", "docs/**")
 assert not path_matches("src/runtime.md", "*.md")
 assert path_matches("scripts/check.sh", "scripts/**/*.sh")
 assert path_matches("scripts/nested/check.sh", "scripts/**/*.sh")
-assert not is_gate_comment({"body": marker, "user": {"login": "contributor", "type": "User"}}, marker)
 assert is_gate_comment({"body": marker, "user": {"login": "github-actions[bot]", "type": "Bot"}}, marker)
+assert not is_gate_comment({"body": marker, "user": {"login": "contributor", "type": "User"}}, marker)
+assert not is_gate_comment({"body": marker, "user": {"login": "other-bot", "type": "Bot"}}, marker)
+
+sections = markdown_sections("## Problem!\nreal problem\n\n### Why now?\nright now\n")
+assert sections["problem"] == "real problem"
+assert sections["why now"] == "right now"
+
+required = [
+    "Problem",
+    "Why now",
+    "Existing options checked",
+    "Alternatives considered",
+    "No-code alternative",
+    "Why code is needed",
+]
+body = """
+## Problem
+real problem
+## Why now
+right now
+## Existing options checked
+checked
+## Alternatives considered
+alternative
+## Why code is needed
+needs deterministic enforcement
+"""
+assert missing_required_sections(body, required) == ["No-code alternative"]
+assert missing_required_sections("## Problem\nN/A\n", ["Problem"]) == ["Problem"]
+assert missing_required_sections("## Problem\n-\n", ["Problem"]) == ["Problem"]
+
+stream = io.StringIO()
+with contextlib.redirect_stderr(stream):
+    result = run_optional_side_effect("label sync", lambda: (_ for _ in ()).throw(GateError("boom")))
+assert result is False
+assert "pr-intake-gate warning: label sync skipped: boom" in stream.getvalue()
+
+config = load_minimal_yaml(".github/pr-intake-gate.yml")
+managed = managed_verdict_labels(config)
+assert "intake/pass" in managed
+assert "intake/needs-issue" in managed
+assert "intake/accepted-for-pr" not in managed
+assert "intake/first-time-contributor" not in managed
 print("ok - helper semantics")
 PY
 
 run_case \
-  "docs_only_passes" \
+  "trusted_permission_passes_high_risk" \
   0 \
   "pass" \
-  '[{"filename":"README.md","additions":2,"deletions":1}]' \
-  '' \
-  '[]'
-
-run_case \
-  "nested_markdown_without_intent_fails" \
-  1 \
-  "needs-issue" \
-  '[{"filename":"src/runtime.md","additions":1,"deletions":0}]' \
-  '' \
-  '[]'
-
-run_case \
-  "non_trivial_without_intent_fails" \
-  1 \
-  "needs-issue" \
-  '[{"filename":"docs/usage.md","additions":31,"deletions":0}]' \
-  '' \
-  '[]'
-
-run_case \
-  "high_risk_workflow_fails" \
-  1 \
-  "high-risk" \
+  "CONTRIBUTOR" \
+  "admin" \
   '[{"filename":".github/workflows/ci.yml","additions":1,"deletions":0}]' \
   '' \
   '[]'
+json_assert "$(case_stdout trusted_permission_passes_high_risk)" "trusted_author" 'true'
+json_assert "$(case_stdout trusted_permission_passes_high_risk)" "trust_source" '"permission:admin"'
+json_assert "$(case_stdout trusted_permission_passes_high_risk)" "author_permission" '"admin"'
 
 run_case \
-  "high_risk_script_shell_fails" \
-  1 \
-  "high-risk" \
-  '[{"filename":"scripts/check.sh","additions":1,"deletions":0}]' \
-  '' \
-  '[]'
-
-run_case \
-  "override_passes_high_risk" \
+  "trusted_association_fallback_passes_high_risk" \
   0 \
   "pass" \
+  "OWNER" \
+  "none" \
+  '[{"filename":".github/workflows/ci.yml","additions":1,"deletions":0}]' \
+  '' \
+  '[]'
+json_assert "$(case_stdout trusted_association_fallback_passes_high_risk)" "trusted_author" 'true'
+json_assert "$(case_stdout trusted_association_fallback_passes_high_risk)" "trust_source" '"author_association:OWNER"'
+json_assert "$(case_stdout trusted_association_fallback_passes_high_risk)" "author_permission" 'null'
+
+run_case \
+  "external_docs_only_passes" \
+  0 \
+  "pass" \
+  "CONTRIBUTOR" \
+  "none" \
+  '[{"filename":"docs/README.md","additions":2,"deletions":1}]' \
+  '' \
+  '[]'
+json_assert "$(case_stdout external_docs_only_passes)" "trusted_author" 'false'
+json_assert "$(case_stdout external_docs_only_passes)" "is_trivial" 'true'
+
+run_case \
+  "external_high_risk_fails" \
+  1 \
+  "high-risk" \
+  "CONTRIBUTOR" \
+  "none" \
+  '[{"filename":".github/workflows/ci.yml","additions":1,"deletions":0}]' \
+  '' \
+  '[]'
+json_assert "$(case_stdout external_high_risk_fails)" "trusted_author" 'false'
+json_list_contains "$(case_stdout external_high_risk_fails)" "high_risk_paths" '.github/workflows/ci.yml'
+
+run_case \
+  "first_time_external_high_risk_fails_with_signal" \
+  1 \
+  "high-risk" \
+  "FIRST_TIMER" \
+  "none" \
+  '[{"filename":".github/workflows/ci.yml","additions":1,"deletions":0}]' \
+  '' \
+  '[]'
+json_assert "$(case_stdout first_time_external_high_risk_fails_with_signal)" "first_time_external" 'true'
+grep -q 'intake/first-time-contributor' "$(case_stderr first_time_external_high_risk_fails_with_signal)"
+
+run_case \
+  "external_non_trivial_missing_no_code_fails" \
+  1 \
+  "no-code-alternative" \
+  "CONTRIBUTOR" \
+  "none" \
+  '[{"filename":"docs/usage.md","additions":31,"deletions":0}]' \
+  "$(missing_no_code_body)" \
+  '[]'
+json_list_contains "$(case_stdout external_non_trivial_missing_no_code_fails)" "missing_external_context_sections" 'No-code alternative'
+
+run_case \
+  "external_non_trivial_missing_context_fails" \
+  1 \
+  "needs-more-context" \
+  "CONTRIBUTOR" \
+  "none" \
+  '[{"filename":"docs/usage.md","additions":31,"deletions":0}]' \
+  "$(missing_context_body)" \
+  '[]'
+json_list_contains "$(case_stdout external_non_trivial_missing_context_fails)" "missing_external_context_sections" 'Problem'
+
+run_case \
+  "external_full_context_without_link_fails" \
+  1 \
+  "needs-issue" \
+  "CONTRIBUTOR" \
+  "none" \
+  '[{"filename":"docs/usage.md","additions":31,"deletions":0}]' \
+  "$(full_context_body)" \
+  '[]'
+json_assert "$(case_stdout external_full_context_without_link_fails)" "linked_intent" 'false'
+
+run_case \
+  "external_full_context_with_link_passes" \
+  0 \
+  "pass" \
+  "CONTRIBUTOR" \
+  "none" \
+  '[{"filename":"docs/usage.md","additions":31,"deletions":0}]' \
+  "$(full_context_with_link_body)" \
+  '[]'
+json_assert "$(case_stdout external_full_context_with_link_passes)" "linked_intent" 'true'
+
+run_case \
+  "accepted_external_non_high_risk_passes" \
+  0 \
+  "pass" \
+  "CONTRIBUTOR" \
+  "none" \
+  '[{"filename":"docs/usage.md","additions":31,"deletions":0}]' \
+  '' \
+  '["intake/accepted-for-pr"]'
+json_assert "$(case_stdout accepted_external_non_high_risk_passes)" "accepted_for_pr" 'true'
+json_assert "$(case_stdout accepted_external_non_high_risk_passes)" "trusted_author" 'false'
+
+run_case \
+  "override_passes_external_high_risk" \
+  0 \
+  "pass" \
+  "CONTRIBUTOR" \
+  "none" \
   '[{"filename":".github/workflows/ci.yml","additions":1,"deletions":0}]' \
   '' \
   '["maintainer/override-intake"]'
+json_assert "$(case_stdout override_passes_external_high_risk)" "trusted_author" 'false'
 
-run_case \
-  "linked_non_trivial_passes" \
-  0 \
-  "pass" \
-  '[{"filename":"docs/usage.md","additions":31,"deletions":0}]' \
-  'Closes #42' \
-  '[]'
+python3 - <<'PY'
+import contextlib
+import io
+
+from scripts.pr_intake_gate import GateError, run_optional_side_effect
+
+stream = io.StringIO()
+with contextlib.redirect_stderr(stream):
+    result = run_optional_side_effect("comment upsert", lambda: (_ for _ in ()).throw(GateError("HTTP 403")))
+assert result is False
+assert "pr-intake-gate warning: comment upsert skipped: HTTP 403" in stream.getvalue()
+print("ok - side-effect failures are non-fatal")
+PY


### PR DESCRIPTION
## Summary

- Add trusted-author intake pass based on GitHub `admin`/`maintain`/`write` permission, with association fallback only when permission is unavailable.
- Enforce external contributor context: linked Issue/Discussion, required PR sections, no-code analysis, and high-risk maintainer override.
- Make label/comment API writes best-effort so a known verdict is not converted into infrastructure failure.
- Update PR template, contributor docs, changelog, config label details, and deterministic fixture tests.
- Repo-governance only; this does not change Signum runtime/product behavior.

## Issue ID

N/A

## Test plan

- `python3 -m py_compile scripts/pr_intake_gate.py`
- `bash tests/test-pr-intake-gate.sh`
- `bash tests/run.sh` (not present in this repo; captured `exit 127`, `No such file or directory`)
- `bash scripts/run-deterministic-tests.sh`
- `git diff --check`
- PR #47 checks after labeling: `deterministic-tests`, `doc-parity`, and `pr-intake-gate` pass.

## Live GitHub verification

- GitHub labels were created/updated best-effort via `gh label edit/create`.
- Current base-branch `pull_request_target` still runs the pre-change intake gate for this PR, so `maintainer/override-intake` was applied to let the governance PR through the existing high-risk gate.
- Trusted-author live verification of the new permission path should be done after this PR is merged, because only then will `pull_request_target` execute the updated trusted base script.
- External live verification was not possible here because it requires a non-trusted fork/account; deterministic fixtures cover external contributor behavior.