### PR TITLE
chore(github): use shared PR intake gate

### DIFF
--- a/.github/pr-intake-gate.yml
+++ b/.github/pr-intake-gate.yml
@@ -1,3 +1,9 @@
+project:
+  name: 'Signum'
+
+high_risk:
+  description: 'workflows, dependencies, auth/security, install scripts, public APIs, schemas, command behavior, or runtime behavior'
+
 trivial:
   max_changed_lines: 30
   allowed_path_globs:

--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -30,6 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Run PR intake gate
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 scripts/pr_intake_gate.py
+        uses: heurema/repo-governance/actions/pr-intake-gate@v0.1.0
+        with:
+          policy-path: .github/pr-intake-gate.yml
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -30,7 +30,8 @@ jobs:
           persist-credentials: false
 
       - name: Run PR intake gate
-        uses: heurema/repo-governance/actions/pr-intake-gate@v0.1.0
+        # pinned from heurema/repo-governance/actions/pr-intake-gate@v0.1.0
+        uses: heurema/repo-governance/actions/pr-intake-gate@b7a5cb71ec24c69b4c8295e211a851f8678b67a0
         with:
           policy-path: .github/pr-intake-gate.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/fixtures/github-action-pins.json
+++ b/tests/fixtures/github-action-pins.json
@@ -47,6 +47,19 @@
       "peeledTagUsed": false
     },
     {
+      "file": ".github/workflows/pr-intake-gate.yml",
+      "occurrence": 2,
+      "uses": "heurema/repo-governance/actions/pr-intake-gate@b7a5cb71ec24c69b4c8295e211a851f8678b67a0",
+      "kind": "external_action",
+      "action": "heurema/repo-governance/actions/pr-intake-gate",
+      "status": "pinned",
+      "originalRef": "v0.1.0",
+      "pinnedSha": "b7a5cb71ec24c69b4c8295e211a851f8678b67a0",
+      "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
+      "resolution": "git rev-parse heurema/repo-governance v0.1.0",
+      "peeledTagUsed": false
+    },
+    {
       "file": ".github/workflows/release-guardrails.yml",
       "occurrence": 1,
       "uses": "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",


### PR DESCRIPTION
## Summary

- Switch Signum PR Intake Gate workflow to the shared `repo-governance` action.
- Keep Signum-specific intake policy local in `.github/pr-intake-gate.yml`.
- Add Signum project metadata used by shared action comments and summaries.

## Problem

Signum currently carries its own PR Intake Gate engine, which duplicates the shared governance engine now published in `heurema/repo-governance`.

## Why now

The shared action is available as `heurema/repo-governance/actions/pr-intake-gate@v0.1.0`, so Signum can move to the common engine while keeping local policy.

## Existing options checked

The existing Signum workflow and local policy were checked. The workflow can call the shared action without changing the required check name.

## Alternatives considered

Keeping the local workflow script was considered but rejected because future gate fixes should be centralized.

## No-code alternative

No process-only alternative applies; the GitHub workflow needs to call the shared action.

## Why code is needed

The workflow wrapper must be changed, and the local policy needs project metadata for shared action output.

## Linked intent

Related: repo-governance rollout.

## Validation / proof

Commands run:

- Dry-run shared action fixture: external high-risk workflow change failed with verdict `high-risk`.
- Dry-run shared action fixture: trusted admin high-risk workflow change passed.
- `git diff --check`

## Risks

- narrow - required check name remains `pr-intake-gate`; Signum-specific policy remains local.

## Reviewer notes

- Legacy local fixture scripts are intentionally left untouched to keep this PR to the operational workflow migration.
