### PR TITLE
ci: pin pr intake gate v0.2.0

### DIFF
--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -30,8 +30,8 @@ jobs:
           persist-credentials: false
 
       - name: Run PR intake gate
-        # pinned from heurema/repo-governance/actions/pr-intake-gate@v0.1.0
-        uses: heurema/repo-governance/actions/pr-intake-gate@b7a5cb71ec24c69b4c8295e211a851f8678b67a0
+        # pinned from heurema/repo-governance/actions/pr-intake-gate@v0.2.0
+        uses: heurema/repo-governance/actions/pr-intake-gate@197bf4d71d03f0871dfd9877506debd28ccea2d5
         with:
           policy-path: .github/pr-intake-gate.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/fixtures/github-action-pins.json
+++ b/tests/fixtures/github-action-pins.json
@@ -49,14 +49,14 @@
     {
       "file": ".github/workflows/pr-intake-gate.yml",
       "occurrence": 2,
-      "uses": "heurema/repo-governance/actions/pr-intake-gate@b7a5cb71ec24c69b4c8295e211a851f8678b67a0",
+      "uses": "heurema/repo-governance/actions/pr-intake-gate@197bf4d71d03f0871dfd9877506debd28ccea2d5",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/pr-intake-gate",
       "status": "pinned",
-      "originalRef": "v0.1.0",
-      "pinnedSha": "b7a5cb71ec24c69b4c8295e211a851f8678b67a0",
+      "originalRef": "v0.2.0",
+      "pinnedSha": "197bf4d71d03f0871dfd9877506debd28ccea2d5",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
-      "resolution": "git rev-parse heurema/repo-governance v0.1.0",
+      "resolution": "git rev-parse heurema/repo-governance v0.2.0",
       "peeledTagUsed": false
     },
     {


### PR DESCRIPTION
## Summary
- Pin PR Intake Gate to repo-governance `v0.2.0` commit SHA.
- Update the action-pin inventory fixture to keep deterministic tests aligned.
- This keeps `pull_request_target` off mutable action tags and picks up the bundled Codex Review Gate behavior.

## Issue ID
- N/A

## Test plan
- `git diff --check`
- GitHub checks on this PR, including `deterministic-tests`, `doc-parity`, and `pr-intake-gate`.

## Notes
- No product/runtime code changed.
- The required check name remains `pr-intake-gate`.
