### PR TITLE
security(github): guard pr intake instruction surfaces

### DIFF
--- a/.github/pr-intake-gate.yml
+++ b/.github/pr-intake-gate.yml
@@ -39,6 +39,53 @@ high_risk_path_globs:
   - '**/crypto/**'
   - '**/migrations/**'
 
+instruction_surface:
+  description: 'Signum files that AI agents may read as instructions, project intent, commands, prompts, review templates, schemas, evals, or operating context'
+  path_globs:
+    - 'README.md'
+    - 'QUICKSTART.md'
+    - 'AGENTS.md'
+    - '**/AGENTS.md'
+    - 'CLAUDE.md'
+    - '**/CLAUDE.md'
+    - 'GEMINI.md'
+    - '**/GEMINI.md'
+    - 'SKILL.md'
+    - '**/SKILL.md'
+    - '.github/PULL_REQUEST_TEMPLATE.md'
+    - '.github/pull_request_template.md'
+    - '.github/pull_request_template/**'
+    - '.github/ISSUE_TEMPLATE/**'
+    - '.github/copilot-instructions.md'
+    - '.github/pr-intake-gate.yml'
+    - 'project.intent.md'
+    - '.punk/**'
+    - 'agents/**'
+    - 'commands/**'
+    - 'docs/research/**'
+    - 'docs/plans/**'
+    - 'evals/**'
+    - 'lib/prompts/**'
+    - 'platforms/**/SKILL.md'
+
+prompt_injection:
+  enabled: true
+  description: 'detect obvious prompt-injection-like additions in external PRs before ordinary review'
+  text_path_globs:
+    - '*.md'
+    - '**/*.md'
+    - '*.mdx'
+    - '**/*.mdx'
+    - '*.txt'
+    - '**/*.txt'
+    - '.github/**'
+    - 'agents/**'
+    - 'commands/**'
+    - 'docs/**'
+    - 'evals/**'
+    - 'lib/prompts/**'
+    - 'platforms/**'
+
 trusted_authors:
   permissions:
     - 'admin'

--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -30,8 +30,8 @@ jobs:
           persist-credentials: false
 
       - name: Run PR intake gate
-        # pinned from heurema/repo-governance/actions/pr-intake-gate@v0.2.0
-        uses: heurema/repo-governance/actions/pr-intake-gate@197bf4d71d03f0871dfd9877506debd28ccea2d5
+        # pinned from heurema/repo-governance/actions/pr-intake-gate@v0.3.0
+        uses: heurema/repo-governance/actions/pr-intake-gate@7c7c203fbb170abc4c0dcd10201b67d495613aaf
         with:
           policy-path: .github/pr-intake-gate.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/fixtures/github-action-pins.json
+++ b/tests/fixtures/github-action-pins.json
@@ -49,14 +49,14 @@
     {
       "file": ".github/workflows/pr-intake-gate.yml",
       "occurrence": 2,
-      "uses": "heurema/repo-governance/actions/pr-intake-gate@197bf4d71d03f0871dfd9877506debd28ccea2d5",
+      "uses": "heurema/repo-governance/actions/pr-intake-gate@7c7c203fbb170abc4c0dcd10201b67d495613aaf",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/pr-intake-gate",
       "status": "pinned",
-      "originalRef": "v0.2.0",
-      "pinnedSha": "197bf4d71d03f0871dfd9877506debd28ccea2d5",
+      "originalRef": "v0.3.0",
+      "pinnedSha": "7c7c203fbb170abc4c0dcd10201b67d495613aaf",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
-      "resolution": "git rev-parse heurema/repo-governance v0.2.0",
+      "resolution": "git rev-parse heurema/repo-governance v0.3.0",
       "peeledTagUsed": false
     },
     {


### PR DESCRIPTION
## Summary
- Roll out repo-governance `v0.3.0` PR Intake Gate hardening.
- Mark Signum AI-readable instruction/context surfaces as high-risk for external PRs.
- Keep the action pinned to the exact repo-governance commit SHA and update the action-pin fixture.

## Issue ID
- N/A

## Test plan
- `git diff --check`
- GitHub checks on this PR, including deterministic tests, doc parity, and pr-intake-gate.

## Notes
- No runtime/product behavior changed.
- Suspicious external docs changes become `high-risk`; maintainers can still review or override intentionally.
