### PR TITLE
fix: make doc parity check pipefail-safe

### DIFF
--- a/lib/doc-parity-check.sh
+++ b/lib/doc-parity-check.sh
@@ -62,7 +62,7 @@ fi
 
 # 2. docs/reference.md schema range matches actual schema enum max
 SCHEMA_MAX=$(jq -r '.properties.schemaVersion.enum[]' "$SCHEMA_DOC" | sort -V | tail -1)
-SCHEMA_ROW=$(grep -F '| `schemaVersion` |' "$REFERENCE_DOC" | head -1 || true)
+SCHEMA_ROW=$(awk 'index($0, "| `schemaVersion` |") { print; exit }' "$REFERENCE_DOC")
 DOC_RANGE=$(echo "$SCHEMA_ROW" | sed -En 's/.*\| `schemaVersion` \| `\"([0-9.]+)\"`–`\"([0-9.]+)\"` \|.*/\1 \2/p')
 DOC_MIN=$(echo "$DOC_RANGE" | awk '{print $1}')
 DOC_MAX=$(echo "$DOC_RANGE" | awk '{print $2}')
@@ -123,7 +123,14 @@ fi
 
 # 5. Roadmap phases 1-5 are marked shipped in core
 for phase in 1 2 3 4 5; do
-  block=$(awk "/^### Phase $phase:/{flag=1;next}/^### Phase [0-9]+:/{flag=0}flag" "$ROADMAP_DOC" | head -n 5)
+  # Avoid piping awk into head under `set -o pipefail`: on GitHub-hosted
+  # Linux runners awk can receive SIGPIPE after head exits, causing an
+  # infrastructure failure even when parity is OK.
+  block=$(awk -v phase="$phase" '
+    $0 ~ "^### Phase " phase ":" { flag=1; count=0; next }
+    /^### Phase [0-9]+:/ { flag=0 }
+    flag && count < 5 { print; count++ }
+  ' "$ROADMAP_DOC")
   if ! echo "$block" | grep -Fq '**Status:** shipped in core'; then
     add_finding \
       "roadmap_phase_status_mismatch" \


### PR DESCRIPTION
## Linked intent

- Issue / Discussion: maintainer smoke test after repo-governance v0.3.0 rollout
- Closes/Fixes/Resolves:

## Problem

Signum's `doc-parity` workflow can fail with exit `141` on GitHub-hosted Linux runners even when the parity report is clean. The failure appeared on a temporary empty smoke PR after the pr-intake-gate v0.3.0 rollout.

## Why now

The rollout needs required checks to be reliable before we rely on branch protection and temporary smoke PRs as proof.

## Existing options checked

- Verified `pr-intake-gate` itself passed on the smoke PR and used repo-governance `7c7c203fbb170abc4c0dcd10201b67d495613aaf`.
- Checked the failing `doc-parity` log; the workflow exited before emitting `doc-parity.json` with process exit `141`.
- Ran the checker locally and confirmed the parity result is `ok`.

## Alternatives considered

- Re-run the smoke PR only: rejected because the script still contains `awk | head` patterns that can SIGPIPE under `set -o pipefail`.

## No-code alternative

Ignore the failed smoke PR as unrelated to pr-intake-gate.

## Why code is needed

The workflow failure is caused by shell pipeline behavior in `lib/doc-parity-check.sh`; making the script avoid early-closing pipelines removes the CI-only infrastructure failure.

## Summary

- Replace `grep | head -1` lookup with a single `awk` scan.
- Replace `awk | head -n 5` roadmap block slicing with bounded printing inside `awk`.
- Keep doc-parity output semantics unchanged.

## Type

- [ ] docs
- [x] deterministic core / `lib`
- [ ] prompt / orchestration
- [ ] init / harness
- [ ] schema / compatibility
- [ ] release / marketplace wiring
- [ ] tests
- [x] fix
- [ ] refactor
- [ ] other

## Scope

In:
- `lib/doc-parity-check.sh` pipefail-safe shell fix

Out:
- workflow changes
- docs parity policy changes
- schema or command behavior changes

## Risk areas

- [ ] public API
- [ ] dependency change
- [ ] CI/workflow change
- [ ] auth/security
- [ ] database/schema
- [ ] runtime behavior
- [ ] docs-only
- [ ] test-only
- [ ] `commands/signum.md`
- [ ] `commands/init.md`
- [ ] `agents/*`
- [x] `lib/*`
- [ ] `lib/schemas/*`
- [ ] `.github/workflows/*`
- [ ] none of the above

## Docs impact

- [x] no docs update needed
- [ ] `README.md` or `QUICKSTART.md` updated
- [ ] `AGENTS.md` updated
- [ ] `docs/how-it-works.md` or `docs/reference.md` updated
- [ ] `docs/SECURITY.md` updated
- [ ] follow-up docs work is needed

Docs / rationale:
- Behavior and policy are unchanged; this only prevents shell SIGPIPE from failing the check.

## Validation / proof

- [ ] not applicable yet (explain below)
- [x] targeted shell tests
- [ ] full test run
- [ ] eval / fixture run
- [ ] doc walkthrough
- [x] command output
- [ ] other

Commands run:

```text
set -o pipefail
bash lib/doc-parity-check.sh > /tmp/signum-doc-parity.json
cat /tmp/signum-doc-parity.json
bash tests/test-doc-parity.sh
git diff --check
git status --short
```

Result:

```text
doc_parity_check: no documentation/parity drift found
{
  "check": "doc_parity",
  "status": "ok",
  "summary": "No documentation/parity drift found",
  "findings": []
}
ALL PASSED
```

## DCO / authorship

- [x] Every commit in this PR is signed off (`git commit -s`) and complies with `DCO.md`

## Reviewer notes

This is intentionally a narrow reliability fix exposed by the temporary smoke PR. No workflow or policy behavior should change.
