### PR TITLE
chore(governance): update repo-governance action pin

### DIFF
--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -30,8 +30,8 @@ jobs:
           persist-credentials: false
 
       - name: Run PR intake gate
-        # pinned from heurema/repo-governance/actions/pr-intake-gate@v0.3.0
-        uses: heurema/repo-governance/actions/pr-intake-gate@7c7c203fbb170abc4c0dcd10201b67d495613aaf
+        # pinned from heurema/repo-governance/actions/pr-intake-gate@main
+        uses: heurema/repo-governance/actions/pr-intake-gate@89824d5ba0530021eac640d23290889000223723
         with:
           policy-path: .github/pr-intake-gate.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/fixtures/github-action-pins.json
+++ b/tests/fixtures/github-action-pins.json
@@ -49,14 +49,14 @@
     {
       "file": ".github/workflows/pr-intake-gate.yml",
       "occurrence": 2,
-      "uses": "heurema/repo-governance/actions/pr-intake-gate@7c7c203fbb170abc4c0dcd10201b67d495613aaf",
+      "uses": "heurema/repo-governance/actions/pr-intake-gate@89824d5ba0530021eac640d23290889000223723",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/pr-intake-gate",
       "status": "pinned",
-      "originalRef": "v0.3.0",
-      "pinnedSha": "7c7c203fbb170abc4c0dcd10201b67d495613aaf",
+      "originalRef": "main",
+      "pinnedSha": "89824d5ba0530021eac640d23290889000223723",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
-      "resolution": "git rev-parse heurema/repo-governance v0.3.0",
+      "resolution": "git rev-parse heurema/repo-governance 89824d5ba0530021eac640d23290889000223723",
       "peeledTagUsed": false
     },
     {


### PR DESCRIPTION
## Linked intent

- Issue / Discussion: N/A - maintainer-requested direct PR
- Closes/Fixes/Resolves: N/A

## Problem

Signum still pins `heurema/repo-governance/actions/pr-intake-gate` to the previous shared action commit. The shared action was updated after the Codex Review timing issue, so this repo should consume the current pinned commit.

## Why now

This keeps PR intake behavior aligned with the shared governance fix already merged in `heurema/repo-governance`.

## Existing options checked

Checked the active workflow and the action pin fixture. The active workflow still referenced `7c7c203fbb170abc4c0dcd10201b67d495613aaf`.

## Alternatives considered

Leaving the old pin in place would keep Signum on the previous gate behavior.

## No-code alternative

N/A. The active workflow pin is code/config and must change for the repo to run the updated shared action.

## Why code is needed

The workflow must reference the new immutable shared action SHA.

## Summary

- Update `.github/workflows/pr-intake-gate.yml` to `89824d5ba0530021eac640d23290889000223723`.
- Update `tests/fixtures/github-action-pins.json` so the action pin inventory remains deterministic.

## Type

- [ ] docs
- [ ] deterministic core / `lib`
- [ ] prompt / orchestration
- [ ] init / harness
- [ ] schema / compatibility
- [ ] release / marketplace wiring
- [x] tests
- [ ] fix
- [ ] refactor
- [x] other

## Scope

In:
- PR Intake Gate workflow pin
- GitHub action pin fixture

Out:
- Signum runtime behavior
- Signum command behavior
- Release workflows beyond the touched pin

## Risk areas

- [ ] public API
- [ ] dependency change
- [x] CI/workflow change
- [ ] auth/security
- [ ] database/schema
- [ ] runtime behavior
- [ ] docs-only
- [ ] test-only
- [ ] `commands/signum.md`
- [ ] `commands/init.md`
- [ ] `agents/*`
- [ ] `lib/*`
- [ ] `lib/schemas/*`
- [x] `.github/workflows/*`
- [ ] none of the above

## Docs impact

- [x] no docs update needed
- [ ] `README.md` or `QUICKSTART.md` updated
- [ ] `AGENTS.md` updated
- [ ] `docs/how-it-works.md` or `docs/reference.md` updated
- [ ] `docs/SECURITY.md` updated
- [ ] follow-up docs work is needed

Docs / rationale:
- Workflow pin only; no product or user-facing behavior changes.

## Validation / proof

- [x] targeted shell tests
- [ ] full test run
- [x] eval / fixture run
- [ ] doc walkthrough
- [x] command output
- [ ] other

Commands run:

```text
bash tests/test-github-action-pinning.sh
# Passed: 233
# Failed: 0
# ALL PASSED

git diff --check
# no output
```

## DCO / authorship

- [x] Every commit in this PR is signed off (`git commit -s`) and complies with `DCO.md`

## Reviewer notes

The workflow comment now preserves `main` as the original mutable ref because the new shared action commit is not a release tag.
