### PR TITLE
fix(ci): update repo-governance action pin

### DIFF
--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run PR intake gate
         # pinned from heurema/repo-governance/actions/pr-intake-gate@main
-        uses: heurema/repo-governance/actions/pr-intake-gate@89824d5ba0530021eac640d23290889000223723
+        uses: heurema/repo-governance/actions/pr-intake-gate@25de0a4c5b2f7316e90b3c373c9b4170c3ebcb4c
         with:
           policy-path: .github/pr-intake-gate.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/fixtures/github-action-pins.json
+++ b/tests/fixtures/github-action-pins.json
@@ -49,14 +49,14 @@
     {
       "file": ".github/workflows/pr-intake-gate.yml",
       "occurrence": 2,
-      "uses": "heurema/repo-governance/actions/pr-intake-gate@89824d5ba0530021eac640d23290889000223723",
+      "uses": "heurema/repo-governance/actions/pr-intake-gate@25de0a4c5b2f7316e90b3c373c9b4170c3ebcb4c",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/pr-intake-gate",
       "status": "pinned",
       "originalRef": "main",
-      "pinnedSha": "89824d5ba0530021eac640d23290889000223723",
+      "pinnedSha": "25de0a4c5b2f7316e90b3c373c9b4170c3ebcb4c",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
-      "resolution": "git rev-parse heurema/repo-governance 89824d5ba0530021eac640d23290889000223723",
+      "resolution": "git rev-parse heurema/repo-governance 25de0a4c5b2f7316e90b3c373c9b4170c3ebcb4c",
       "peeledTagUsed": false
     },
     {


### PR DESCRIPTION
## Summary

- Update PR intake gate to repo-governance commit 25de0a4c5b2f7316e90b3c373c9b4170c3ebcb4c.
- Update the GitHub action pin inventory fixture to match the workflow.

## Issue

- N/A

## Test plan

- bash tests/test-github-action-pinning.sh
- git diff --check

## Risk

- narrow - workflow action pin update only.