### PR TITLE
chore(ci): update repo-governance gate pin

### DIFF
--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -9,6 +9,17 @@ on:
       - synchronize
       - labeled
       - unlabeled
+      - ready_for_review
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+      - dismissed
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+      - deleted
 
 permissions:
   contents: read
@@ -31,7 +42,10 @@ jobs:
 
       - name: Run PR intake gate
         # pinned from heurema/repo-governance/actions/pr-intake-gate@main
-        uses: heurema/repo-governance/actions/pr-intake-gate@25de0a4c5b2f7316e90b3c373c9b4170c3ebcb4c
+        uses: heurema/repo-governance/actions/pr-intake-gate@06fb3a73bfbd4b3a087376beb2a95d36f0e32b78
         with:
           policy-path: .github/pr-intake-gate.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          codex-review-require-current-review: 'true'
+          codex-review-wait-seconds: '480'
+          codex-review-poll-interval-seconds: '10'

--- a/tests/fixtures/github-action-pins.json
+++ b/tests/fixtures/github-action-pins.json
@@ -49,14 +49,14 @@
     {
       "file": ".github/workflows/pr-intake-gate.yml",
       "occurrence": 2,
-      "uses": "heurema/repo-governance/actions/pr-intake-gate@25de0a4c5b2f7316e90b3c373c9b4170c3ebcb4c",
+      "uses": "heurema/repo-governance/actions/pr-intake-gate@06fb3a73bfbd4b3a087376beb2a95d36f0e32b78",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/pr-intake-gate",
       "status": "pinned",
       "originalRef": "main",
-      "pinnedSha": "25de0a4c5b2f7316e90b3c373c9b4170c3ebcb4c",
+      "pinnedSha": "06fb3a73bfbd4b3a087376beb2a95d36f0e32b78",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
-      "resolution": "git rev-parse heurema/repo-governance 25de0a4c5b2f7316e90b3c373c9b4170c3ebcb4c",
+      "resolution": "git rev-parse heurema/repo-governance 06fb3a73bfbd4b3a087376beb2a95d36f0e32b78",
       "peeledTagUsed": false
     },
     {


### PR DESCRIPTION
## Linked intent

- Issue / Discussion: N/A, maintainer-requested downstream rollout after repo-governance #7.
- Closes/Fixes/Resolves: N/A

## Problem

The previous shared gate pin did not include the bundled current-review wait fix, so PRs could still briefly look green before asynchronous Codex Review finished.

## Why now

The timing gap was observed during a live downstream PR merge flow.

## Existing options checked

Checked repo-governance #7, the current Signum workflow pin, and the action-pin fixture.

## Alternatives considered

Leaving the old pin was rejected because it keeps the early-green window open. Updating only the SHA without review triggers was rejected because review state changes should rerun the gate.

## No-code alternative

Branch protection helps after review conversations exist, but it does not update the shared action behavior.

## Why code is needed

The repository workflow owns the pinned shared action version and event triggers.

## Summary

- Pin `pr-intake-gate` to repo-governance `06fb3a73bfbd4b3a087376beb2a95d36f0e32b78`.
- Add review and review-comment triggers so the gate reruns when Codex Review state changes.
- Pass explicit current-review wait settings and update the action-pin fixture.

## Type

- [ ] docs
- [ ] deterministic core / `lib`
- [ ] prompt / orchestration
- [ ] init / harness
- [ ] schema / compatibility
- [ ] release / marketplace wiring
- [x] tests
- [x] fix
- [ ] refactor
- [x] other

## Scope

In:
- `.github/workflows/pr-intake-gate.yml`
- `tests/fixtures/github-action-pins.json`

Out:
- Signum pipeline behavior, prompts, schemas, runtime scripts.

## Risk areas

- [ ] public API
- [ ] dependency change
- [x] CI/workflow change
- [ ] auth/security
- [ ] database/schema
- [ ] runtime behavior
- [ ] docs-only
- [ ] test-only
- [ ] `commands/signum.md`
- [ ] `commands/init.md`
- [ ] `agents/*`
- [ ] `lib/*`
- [ ] `lib/schemas/*`
- [x] `.github/workflows/*`
- [ ] none of the above

## Docs impact

- [x] no docs update needed
- [ ] `README.md` or `QUICKSTART.md` updated
- [ ] `AGENTS.md` updated
- [ ] `docs/how-it-works.md` or `docs/reference.md` updated
- [ ] `docs/SECURITY.md` updated
- [ ] follow-up docs work is needed

Docs / rationale:
- Workflow pin and fixture update only; no product or command docs changed.

## Validation / proof

- [ ] not applicable yet (explain below)
- [x] targeted shell tests
- [ ] full test run
- [x] eval / fixture run
- [ ] doc walkthrough
- [x] command output
- [ ] other

Commands run:

```text
bash tests/test-github-action-pinning.sh
git diff --check
```

## DCO / authorship

- [x] Every commit in this PR is signed off (`git commit -s`) and complies with `DCO.md`

## Reviewer notes

This intentionally relies on repo-governance #7 and pins the post-merge main SHA.
