### PR TITLE
chore(ci): fix repo-governance gate pin

### DIFF
--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -10,16 +10,6 @@ on:
       - labeled
       - unlabeled
       - ready_for_review
-  pull_request_review:
-    types:
-      - submitted
-      - edited
-      - dismissed
-  pull_request_review_comment:
-    types:
-      - created
-      - edited
-      - deleted
 
 permissions:
   contents: read
@@ -42,7 +32,7 @@ jobs:
 
       - name: Run PR intake gate
         # pinned from heurema/repo-governance/actions/pr-intake-gate@main
-        uses: heurema/repo-governance/actions/pr-intake-gate@06fb3a73bfbd4b3a087376beb2a95d36f0e32b78
+        uses: heurema/repo-governance/actions/pr-intake-gate@2413ba8db779a431d46505003870766b35b3ea57
         with:
           policy-path: .github/pr-intake-gate.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/fixtures/github-action-pins.json
+++ b/tests/fixtures/github-action-pins.json
@@ -49,14 +49,14 @@
     {
       "file": ".github/workflows/pr-intake-gate.yml",
       "occurrence": 2,
-      "uses": "heurema/repo-governance/actions/pr-intake-gate@06fb3a73bfbd4b3a087376beb2a95d36f0e32b78",
+      "uses": "heurema/repo-governance/actions/pr-intake-gate@2413ba8db779a431d46505003870766b35b3ea57",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/pr-intake-gate",
       "status": "pinned",
       "originalRef": "main",
-      "pinnedSha": "06fb3a73bfbd4b3a087376beb2a95d36f0e32b78",
+      "pinnedSha": "2413ba8db779a431d46505003870766b35b3ea57",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
-      "resolution": "git rev-parse heurema/repo-governance 06fb3a73bfbd4b3a087376beb2a95d36f0e32b78",
+      "resolution": "git rev-parse heurema/repo-governance 2413ba8db779a431d46505003870766b35b3ea57",
       "peeledTagUsed": false
     },
     {


### PR DESCRIPTION
## Linked intent

- Issue / Discussion: N/A, maintainer-requested follow-up after repo-governance #8.
- Closes/Fixes/Resolves: N/A

## Problem

The previous downstream rollout copied review-event triggers into `pr-intake-gate`, but that workflow writes labels and comments and should stay on write-capable `pull_request_target` events.

## Why now

Codex Review caught this trigger boundary during the Punk rollout after repo-governance #7.

## Existing options checked

Checked repo-governance #8 and the current Signum `pr-intake-gate` workflow and pin fixture.

## Alternatives considered

Leaving review-event triggers in `pr-intake-gate` was rejected because fork/Dependabot review events can run with read-only tokens. Adding standalone `codex-review-gate` here was deferred because Signum currently has no branch protection configured.

## No-code alternative

Docs alone would not fix the workflow trigger and pinned action reference.

## Why code is needed

The repository workflow owns the pinned shared action version and trigger boundary.

## Summary

- Pin `pr-intake-gate` to repo-governance `2413ba8db779a431d46505003870766b35b3ea57`.
- Remove review-event triggers from write-capable `pr-intake-gate`.
- Keep explicit current-review wait settings and update the action-pin fixture.

## Type

- [ ] docs
- [ ] deterministic core / `lib`
- [ ] prompt / orchestration
- [ ] init / harness
- [ ] schema / compatibility
- [ ] release / marketplace wiring
- [x] tests
- [x] fix
- [ ] refactor
- [x] other

## Scope

In:
- `.github/workflows/pr-intake-gate.yml`
- `tests/fixtures/github-action-pins.json`

Out:
- Signum pipeline behavior, prompts, schemas, runtime scripts.

## Risk areas

- [ ] public API
- [ ] dependency change
- [x] CI/workflow change
- [ ] auth/security
- [ ] database/schema
- [ ] runtime behavior
- [ ] docs-only
- [ ] test-only
- [ ] `commands/signum.md`
- [ ] `commands/init.md`
- [ ] `agents/*`
- [ ] `lib/*`
- [ ] `lib/schemas/*`
- [x] `.github/workflows/*`
- [ ] none of the above

## Docs impact

- [x] no docs update needed
- [ ] `README.md` or `QUICKSTART.md` updated
- [ ] `AGENTS.md` updated
- [ ] `docs/how-it-works.md` or `docs/reference.md` updated
- [ ] `docs/SECURITY.md` updated
- [ ] follow-up docs work is needed

Docs / rationale:
- Workflow pin and fixture update only; no product or command docs changed.

## Validation / proof

- [ ] not applicable yet (explain below)
- [x] targeted shell tests
- [ ] full test run
- [x] eval / fixture run
- [ ] doc walkthrough
- [x] command output
- [ ] other

Commands run:

```text
bash tests/test-github-action-pinning.sh
git diff --check
```

## DCO / authorship

- [x] Every commit in this PR is signed off (`git commit -s`) and complies with `DCO.md`

## Reviewer notes

Signum currently has no branch protection configured; standalone read-only `codex-review-gate` can be added later if/when the repo requires review-event gating.
