### PR TITLE
[codex] Add Codex plugin support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,5 @@
   "license": "MIT",
   "name": "signum",
   "repository": "https://github.com/heurema/signum",
-  "version": "4.21.0"
+  "version": "4.21.1"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signum",
-  "version": "4.21.0",
+  "version": "4.21.1",
   "description": "Evidence-driven development pipeline with multi-model code review",
   "author": {
     "name": "heurema",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "signum",
+  "version": "4.21.0",
+  "description": "Evidence-driven development pipeline with multi-model code review",
+  "author": {
+    "name": "heurema",
+    "url": "https://github.com/heurema"
+  },
+  "homepage": "https://github.com/heurema/signum",
+  "repository": "https://github.com/heurema/signum",
+  "license": "MIT",
+  "keywords": [
+    "dev-pipeline",
+    "code-review",
+    "multi-model",
+    "evidence-driven",
+    "proofpack"
+  ],
+  "skills": "./platforms/codex/",
+  "interface": {
+    "displayName": "Signum",
+    "shortDescription": "Contract-first implementation with audit evidence",
+    "longDescription": "Run a CONTRACT -> EXECUTE -> AUDIT -> PACK workflow for agentic code changes and package the result as local proof artifacts.",
+    "developerName": "heurema",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/heurema/signum",
+    "defaultPrompt": [
+      "Use Signum to implement this with a contract, audit, and proofpack."
+    ],
+    "brandColor": "#111827"
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ review_cadence: quarterly
 | Deterministic core | `lib/` | Shell checks, DSL runner, scanners, state/policy helpers | `@vi` | Prefer tests for every behavioral change |
 | Schemas and contracts | `lib/schemas/` | Contract / proofpack / modules schemas | `@vi` | Treat schema changes as compatibility-sensitive |
 | Platform overlays | `platforms/` | Surface-specific command/docs variants | `@vi` | Root command/docs remain canonical unless an overlay deviation is explicitly documented |
+| Codex plugin metadata | `.codex-plugin/plugin.json`, `platforms/codex/SKILL.md` | Codex App install surface and skill entry point | `@vi` | Keep version aligned with `.claude-plugin/plugin.json`; Codex skill remains an overlay |
 | Verification surface | `tests/` | Shell tests for deterministic behavior | `@vi` | If a deterministic behavior changes, add/update a test |
 
 ## Repo-Specific Rules
@@ -39,12 +40,14 @@ review_cadence: quarterly
 - `lib/policy-scanner.sh`, `lib/policy-resolver.sh` — execution policy enforcement
 - `lib/contract-injection-scan.sh` — prompt/contract injection defense
 - `lib/schemas/*.json` — compatibility-sensitive contract/proofpack formats
+- `.codex-plugin/plugin.json`, `platforms/codex/SKILL.md` — Codex App install and orchestration surface
 
 ## First Reads By Task Type
 - **Understand the product**: `README.md`, `project.intent.md`, `docs/how-it-works.md`
 - **Change core pipeline behavior**: `commands/signum.md`, `docs/reference.md`, matching `tests/*`
 - **Change init/bootstrap behavior**: `commands/init.md`, `agents/init-synthesizer.md`, `lib/init-scanner.sh`, `lib/init-harness-scaffold.sh`, `tests/test-init*.sh`
 - **Change docs/parity policy**: `docs/reference.md`, `docs/overlay-deviations.json`, `lib/doc-parity-check.sh`, `tests/test-doc-parity.sh`
+- **Change Codex App plugin support**: `.codex-plugin/plugin.json`, `platforms/codex/SKILL.md`, `tests/test-codex-plugin-metadata.sh`
 - **Change future architecture direction**: `docs/plans/2026-03-15-large-project-support-roadmap.md`, `docs/thin-cli-extraction-plan.md`
 
 ## Update Protocol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
 
+## [4.21.1] - 2026-05-08
+
+### Added
+- Codex App plugin metadata via `.codex-plugin/plugin.json`, wired to the existing `platforms/codex/SKILL.md` overlay.
+- Codex plugin metadata guardrail coverage in release smoke and deterministic metadata checks.
+
+### Fixed
+- GitHub Action and runner pinning scans now ignore local `.signum/` snapshots so ignored proof artifacts do not break local guardrail runs.
+
 ## [4.21.0] - 2026-04-27
 
 ### Added

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -4,7 +4,9 @@ Get from zero to a verified code change in 3 minutes.
 
 ## 1. Install
 
-Signum is a Claude Code plugin. Install it:
+Signum is available as a Claude Code plugin and ships Codex App plugin metadata.
+
+For Claude Code, install it:
 
 ```bash
 claude plugin marketplace add heurema/emporium
@@ -17,12 +19,37 @@ Verify:
 claude "/signum explain"
 ```
 
+For Codex App, install Signum from a Codex plugin marketplace entry that points at the plugin package. The install manifest lives at `.codex-plugin/plugin.json` and exposes the `signum` skill from `platforms/codex/SKILL.md`.
+
+Example Codex marketplace entry:
+
+```json
+{
+  "name": "signum",
+  "source": {
+    "source": "local",
+    "path": "./plugins/signum"
+  },
+  "policy": {
+    "installation": "AVAILABLE",
+    "authentication": "ON_INSTALL"
+  },
+  "category": "Coding"
+}
+```
+
 ## 2. Run Your First Pipeline
 
 Give Signum a task:
 
 ```bash
 claude "/signum Add a health check endpoint that returns {status: ok}"
+```
+
+In Codex App, use the skill-oriented prompt form:
+
+```text
+Use Signum to add a health check endpoint that returns {status: ok}
 ```
 
 Signum runs 4 phases automatically:

--- a/README.md
+++ b/README.md
@@ -128,6 +128,31 @@ Use the canonical init command:
 
 For Claude Code usage, install the Claude Code CLI according to your environment.
 
+For Codex App usage, Signum ships plugin metadata at `.codex-plugin/plugin.json`. The Codex plugin entry point is the `signum` skill under `platforms/codex/SKILL.md`, so a Codex plugin marketplace entry should point at a Signum plugin checkout and use that manifest.
+
+Example Codex marketplace entry:
+
+```json
+{
+  "name": "signum",
+  "source": {
+    "source": "local",
+    "path": "./plugins/signum"
+  },
+  "policy": {
+    "installation": "AVAILABLE",
+    "authentication": "ON_INSTALL"
+  },
+  "category": "Coding"
+}
+```
+
+In Codex, invoke the workflow with a prompt such as:
+
+```text
+Use Signum to add a health check endpoint that returns {status: ok}
+```
+
 Optional reviewer tools may be used when available, but Signum keeps deterministic checks separate from model-based review.
 
 ### Run local deterministic checks
@@ -359,6 +384,7 @@ Signum includes a maintainer release path for syncing the plugin entry with the 
 
 - **Release smoke test**: run `bash lib/release-smoke.sh` before publishing release metadata.
 - **Marketplace sync**: the `Sync Emporium marketplace entry` workflow updates `heurema/emporium/.claude-plugin/marketplace.json`.
+- **Codex plugin metadata**: `.codex-plugin/plugin.json` defines the Codex App install manifest and points at `platforms/codex/SKILL.md`.
 - **Automation secret**: non-dry-run cross-repo sync requires `EMPORIUM_SSH_KEY`.
 - **Manual trigger**: the workflow supports `workflow_dispatch` so maintainers can run a controlled release dry-run or sync.
 - **Release trigger**: the workflow also runs on release publication so marketplace metadata stays aligned with Signum releases.

--- a/commands/signum.fragments/100-phase-pack.md
+++ b/commands/signum.fragments/100-phase-pack.md
@@ -268,7 +268,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.0" \
+  --arg signumVersion "4.21.1" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \
@@ -423,4 +423,3 @@ fi
 ```
 
 ---
-

--- a/commands/signum.fragments/20-explain-mode.md
+++ b/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.0",
+  "version": "4.21.1",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -47,4 +47,3 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```
 
 Do not proceed to Setup or any phase.
-

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -46,7 +46,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.0",
+  "version": "4.21.1",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -88,7 +88,6 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```
 
 Do not proceed to Setup or any phase.
-
 ## Archive Mode
 
 If the user's task starts with `archive` (case-insensitive), do NOT run the pipeline. Instead, archive a completed contract.
@@ -3547,7 +3546,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.0" \
+  --arg signumVersion "4.21.1" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \
@@ -3702,7 +3701,6 @@ fi
 ```
 
 ---
-
 ## Final Output
 
 Display to the user:

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -12,7 +12,7 @@ review_cadence: quarterly
 | Journey | Why it matters | Primary Surfaces | Current Evidence |
 | --- | --- | --- | --- |
 | Run `/signum <task>` end-to-end | Core product promise | `commands/signum.md`, `agents/`, `lib/`, schemas | README + reference docs + deterministic shell tests |
-| Fresh marketplace install resolves current Signum release | Users should not install a stale registry target after a version bump | `.claude-plugin/plugin.json`, `heurema/emporium/.claude-plugin/marketplace.json`, `lib/update-emporium-marketplace.sh`, `lib/check-emporium-sync.sh`, `.github/workflows/release-guardrails.yml` | `bash lib/release-smoke.sh`, `bash tests/test-emporium-sync.sh`, `bash tests/test-update-emporium-marketplace.sh`; CI syncs first, then verifies |
+| Fresh marketplace install resolves current Signum release | Users should not install a stale registry target after a version bump | `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `platforms/codex/SKILL.md`, `heurema/emporium/.claude-plugin/marketplace.json`, `lib/update-emporium-marketplace.sh`, `lib/check-emporium-sync.sh`, `.github/workflows/release-guardrails.yml` | `bash lib/release-smoke.sh`, `bash tests/test-emporium-sync.sh`, `bash tests/test-update-emporium-marketplace.sh`, `bash tests/test-codex-plugin-metadata.sh`; CI syncs first, then verifies |
 | Generate correct runtime artifacts in `.signum/` | Needed for auditability and CI gating | `commands/signum.md`, `lib/`, `.signum/` artifact contract | `docs/reference.md`, `docs/how-it-works.md` |
 | Bootstrap project context with `/signum init` | Reduces missing-context failures in downstream repos | `commands/init.md`, `agents/init-synthesizer.md`, `lib/init-scanner.sh`, `lib/init-harness-scaffold.sh` | `tests/test-init.sh`, `tests/test-init-harness-scaffold.sh` |
 | Keep root docs and overlays aligned | Prevents trust loss from doc drift | `docs/reference.md`, `docs/overlay-deviations.json`, `lib/doc-parity-check.sh` | `tests/test-doc-parity.sh`, `.github/workflows/doc-parity.yml` |
@@ -36,6 +36,7 @@ review_cadence: quarterly
 
 ## Operational Checks
 - `bash lib/release-smoke.sh`
+- `bash tests/test-codex-plugin-metadata.sh`
 - `bash tests/test-emporium-sync.sh`
 - `bash tests/test-update-emporium-marketplace.sh`
 - `bash tests/test-release-smoke.sh`
@@ -49,4 +50,5 @@ review_cadence: quarterly
 - There is now a maintainer-facing release smoke path, but there is still no single runtime end-to-end CI smoke test for `/signum <task>`.
 - Most reliability evidence is still shell-script unit coverage plus documentation, not integrated scenario runs.
 - Anti-entropy / recurring cleanup mode is planned but not yet a canonical root feature.
-- Cross-repo marketplace writes require the `EMPORIUM_SSH_KEY` secret in `heurema/signum`; without it, guardrails still fail loudly on drift but cannot self-heal.
+- Cross-repo Claude marketplace writes require the `EMPORIUM_SSH_KEY` secret in `heurema/signum`; without it, guardrails still fail loudly on drift but cannot self-heal.
+- Codex App install metadata is present in `.codex-plugin/plugin.json`, but publishing that metadata to a shared Codex plugin marketplace is a separate distribution step.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -11,7 +11,7 @@ review_cadence: quarterly
 - **Local deterministic boundary**: shell scripts in `lib/`, schemas, proofpack assembly, receipt logic.
 - **Claude Code / LLM orchestration boundary**: `commands/` and `agents/` define what context goes to contractor/engineer/reviewer agents.
 - **External provider boundary**: current docs state Codex CLI and Gemini CLI receive the diff only, not the full codebase.
-- **Plugin/install boundary**: plugin metadata and install surfaces live under `.claude-plugin/`.
+- **Plugin/install boundary**: plugin metadata and install surfaces live under `.claude-plugin/` for Claude Code and `.codex-plugin/` plus `platforms/codex/SKILL.md` for Codex App.
 
 ## Sensitive Surfaces
 

--- a/lib/release-smoke.sh
+++ b/lib/release-smoke.sh
@@ -16,6 +16,7 @@ run_step() {
 cd "$REPO_ROOT"
 
 run_step "Emporium sync check" bash lib/check-emporium-sync.sh
+run_step "Codex plugin metadata" bash tests/test-codex-plugin-metadata.sh
 run_step "/signum:init --harness command surface" bash tests/test-init-command-surface.sh
 run_step "/signum:init --harness scaffold coverage" bash tests/test-init-harness-scaffold.sh
 run_step "/signum:init --harness brownfield smoke" bash tests/test-brownfield-harness-flow.sh

--- a/platforms/claude-code/.claude-plugin/plugin.json
+++ b/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "signum",
   "description": "Evidence-driven development pipeline with multi-model code review",
-  "version": "4.21.0",
+  "version": "4.21.1",
   "author": {
     "name": "heurema"
   },

--- a/platforms/claude-code/CHANGELOG.md
+++ b/platforms/claude-code/CHANGELOG.md
@@ -5,6 +5,15 @@
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
 
+## [4.21.1] - 2026-05-08
+
+### Added
+- Codex App plugin metadata via `.codex-plugin/plugin.json`, wired to the existing `platforms/codex/SKILL.md` overlay.
+- Codex plugin metadata guardrail coverage in release smoke and deterministic metadata checks.
+
+### Fixed
+- GitHub Action and runner pinning scans now ignore local `.signum/` snapshots so ignored proof artifacts do not break local guardrail runs.
+
 ## [4.21.0] - 2026-04-27
 
 ### Added

--- a/platforms/claude-code/QUICKSTART.md
+++ b/platforms/claude-code/QUICKSTART.md
@@ -4,7 +4,9 @@ Get from zero to a verified code change in 3 minutes.
 
 ## 1. Install
 
-Signum is a Claude Code plugin. Install it:
+Signum is available as a Claude Code plugin and ships Codex App plugin metadata.
+
+For Claude Code, install it:
 
 ```bash
 claude plugin marketplace add heurema/emporium
@@ -17,12 +19,37 @@ Verify:
 claude "/signum explain"
 ```
 
+For Codex App, install Signum from a Codex plugin marketplace entry that points at the plugin package. The install manifest lives at `.codex-plugin/plugin.json` and exposes the `signum` skill from `platforms/codex/SKILL.md`.
+
+Example Codex marketplace entry:
+
+```json
+{
+  "name": "signum",
+  "source": {
+    "source": "local",
+    "path": "./plugins/signum"
+  },
+  "policy": {
+    "installation": "AVAILABLE",
+    "authentication": "ON_INSTALL"
+  },
+  "category": "Coding"
+}
+```
+
 ## 2. Run Your First Pipeline
 
 Give Signum a task:
 
 ```bash
 claude "/signum Add a health check endpoint that returns {status: ok}"
+```
+
+In Codex App, use the skill-oriented prompt form:
+
+```text
+Use Signum to add a health check endpoint that returns {status: ok}
 ```
 
 Signum runs 4 phases automatically:

--- a/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
+++ b/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
@@ -268,7 +268,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.0" \
+  --arg signumVersion "4.21.1" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \
@@ -386,4 +386,3 @@ fi
 ```
 
 ---
-

--- a/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
+++ b/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.0",
+  "version": "4.21.1",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -47,4 +47,3 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```
 
 Do not proceed to Setup or any phase.
-

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -47,7 +47,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.0",
+  "version": "4.21.1",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -89,7 +89,6 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```
 
 Do not proceed to Setup or any phase.
-
 ## Archive Mode
 
 If the user's task starts with `archive` (case-insensitive), do NOT run the pipeline. Instead, archive a completed contract.
@@ -3569,7 +3568,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.0" \
+  --arg signumVersion "4.21.1" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \
@@ -3687,7 +3686,6 @@ fi
 ```
 
 ---
-
 ## Phase 5: RECONCILE
 
 **Goal:** Resolve post-implementation obligations and update project state. Runs only when `cleanupObligations` is present and non-empty in the contract, AND the audit decision is `AUTO_OK`.

--- a/tests/fixtures/proofpack/invalid-removal-evidence.json
+++ b/tests/fixtures/proofpack/invalid-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.0",
+  "signumVersion": "4.21.1",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-bad-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-artifact-ref.json
+++ b/tests/fixtures/proofpack/missing-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.0",
+  "signumVersion": "4.21.1",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-required.json
+++ b/tests/fixtures/proofpack/missing-required.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.0",
+  "signumVersion": "4.21.1",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/schema-version-mismatch.json
+++ b/tests/fixtures/proofpack/schema-version-mismatch.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.7",
-  "signumVersion": "4.21.0",
+  "signumVersion": "4.21.1",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/unsafe-artifact-path.json
+++ b/tests/fixtures/proofpack/unsafe-artifact-path.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.0",
+  "signumVersion": "4.21.1",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-minimal.json
+++ b/tests/fixtures/proofpack/valid-minimal.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.0",
+  "signumVersion": "4.21.1",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-artifact-ref.json
+++ b/tests/fixtures/proofpack/valid-with-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.0",
+  "signumVersion": "4.21.1",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-removal-evidence.json
+++ b/tests/fixtures/proofpack/valid-with-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.0",
+  "signumVersion": "4.21.1",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/wrong-type.json
+++ b/tests/fixtures/proofpack/wrong-type.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.0",
+  "signumVersion": "4.21.1",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/test-codex-plugin-metadata.sh
+++ b/tests/test-codex-plugin-metadata.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# test-codex-plugin-metadata.sh -- keep Codex App plugin metadata installable and aligned
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+PLUGIN_JSON="$REPO_ROOT/.codex-plugin/plugin.json"
+CLAUDE_PLUGIN_JSON="$REPO_ROOT/.claude-plugin/plugin.json"
+CODEX_SKILL="$REPO_ROOT/platforms/codex/SKILL.md"
+
+passed=0
+failed=0
+
+pass() {
+  printf '  PASS: %s\n' "$1"
+  passed=$((passed + 1))
+}
+
+fail() {
+  printf '  FAIL: %s -- %s\n' "$1" "$2"
+  failed=$((failed + 1))
+}
+
+assert_file() {
+  local name="$1" path="$2"
+  if [ -f "$path" ]; then
+    pass "$name"
+  else
+    fail "$name" "missing $path"
+  fi
+}
+
+assert_json_eq() {
+  local name="$1" file="$2" filter="$3" expected="$4" actual
+  actual="$(jq -r "$filter" "$file")"
+  if [ "$actual" = "$expected" ]; then
+    pass "$name"
+  else
+    fail "$name" "expected $expected, got $actual"
+  fi
+}
+
+assert_contains() {
+  local name="$1" file="$2" expected="$3"
+  if grep -Fq "$expected" "$file"; then
+    pass "$name"
+  else
+    fail "$name" "missing \"$expected\" in $file"
+  fi
+}
+
+echo "=== Codex plugin metadata ==="
+
+assert_file "Codex plugin manifest exists" "$PLUGIN_JSON"
+assert_file "Codex skill entrypoint exists" "$CODEX_SKILL"
+
+if [ -f "$PLUGIN_JSON" ]; then
+  jq empty "$PLUGIN_JSON"
+  pass "Codex plugin manifest is valid JSON"
+
+  ROOT_VERSION="$(jq -r '.version' "$CLAUDE_PLUGIN_JSON")"
+  assert_json_eq "plugin name is signum" "$PLUGIN_JSON" '.name' "signum"
+  assert_json_eq "plugin version matches release metadata" "$PLUGIN_JSON" '.version' "$ROOT_VERSION"
+  assert_json_eq "plugin points at Codex skill overlay" "$PLUGIN_JSON" '.skills' "./platforms/codex/"
+  assert_json_eq "plugin display name is Signum" "$PLUGIN_JSON" '.interface.displayName' "Signum"
+  assert_json_eq "plugin category is Coding" "$PLUGIN_JSON" '.interface.category' "Coding"
+fi
+
+if [ -f "$CODEX_SKILL" ]; then
+  assert_contains "Codex skill declares Signum name" "$CODEX_SKILL" "name: signum"
+  assert_contains "Codex skill uses contract-first pipeline" "$CODEX_SKILL" "CONTRACT -> EXECUTE -> AUDIT -> PACK"
+  assert_contains "Codex skill uses canonical artifact root" "$CODEX_SKILL" ".signum/contracts/<contractId>/"
+  assert_contains "Codex skill treats external reviewers as optional" "$CODEX_SKILL" "optional evidence sources"
+fi
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-github-action-pinning.sh
+++ b/tests/test-github-action-pinning.sh
@@ -125,6 +125,8 @@ for path in sorted(repo_root.rglob("*")):
     rel = path.relative_to(repo_root)
     if ".git" in rel.parts:
         continue
+    if rel.parts and rel.parts[0] == ".signum":
+        continue
     text = path.read_text(encoding="utf-8", errors="ignore")
     if re.search(r"(?m)^\s*uses\s*:", text):
         all_yaml_with_uses.append(rel)

--- a/tests/test-github-runner-pinning.sh
+++ b/tests/test-github-runner-pinning.sh
@@ -206,6 +206,8 @@ for path in sorted(repo_root.rglob("*")):
     rel = path.relative_to(repo_root)
     if ".git" in rel.parts:
         continue
+    if rel.parts and rel.parts[0] == ".signum":
+        continue
     text = path.read_text(encoding="utf-8", errors="ignore")
     if re.search(r"(?m)^\s*runs-on\s*:", text):
         all_yaml_with_runs_on.append(rel)

--- a/tests/test-metadata-consistency.sh
+++ b/tests/test-metadata-consistency.sh
@@ -60,6 +60,7 @@ def assert_all_eq(name, rel, pattern, expected):
 
 
 plugin_version = json.loads(read(".claude-plugin/plugin.json"))["version"]
+codex_plugin_path = repo_root / ".codex-plugin/plugin.json"
 root_schema = one_or_fail(
     "root proofpack schema source exists",
     "commands/signum.md",
@@ -83,6 +84,13 @@ if (repo_root / "platforms/claude-code/.claude-plugin/plugin.json").exists():
         pass_("Claude overlay plugin version matches root")
     else:
         fail("Claude overlay plugin version matches root", f"expected {plugin_version}, got {overlay_version}")
+
+if codex_plugin_path.exists():
+    codex_version = json.loads(read(".codex-plugin/plugin.json"))["version"]
+    if codex_version == plugin_version:
+        pass_("Codex plugin version matches root")
+    else:
+        fail("Codex plugin version matches root", f"expected {plugin_version}, got {codex_version}")
 
 for rel in command_files:
     assert_all_eq(

--- a/tests/test-release-smoke.sh
+++ b/tests/test-release-smoke.sh
@@ -37,6 +37,7 @@ assert_not_contains() {
 
 echo "=== Release smoke wiring ==="
 assert_contains "smoke runs Emporium sync check" "$SMOKE_SCRIPT" 'bash lib/check-emporium-sync.sh'
+assert_contains "smoke covers Codex plugin metadata" "$SMOKE_SCRIPT" 'bash tests/test-codex-plugin-metadata.sh'
 assert_contains "smoke covers init command surface" "$SMOKE_SCRIPT" 'bash tests/test-init-command-surface.sh'
 assert_contains "smoke covers init harness scaffold" "$SMOKE_SCRIPT" 'bash tests/test-init-harness-scaffold.sh'
 assert_contains "smoke covers brownfield harness flow" "$SMOKE_SCRIPT" 'bash tests/test-brownfield-harness-flow.sh'
@@ -75,10 +76,12 @@ assert_contains "README documents Emporium release step" "$README_FILE" 'heurema
 assert_contains "README documents automation ssh key" "$README_FILE" 'EMPORIUM_SSH_KEY'
 assert_contains "README documents automatic sync workflow" "$README_FILE" 'Sync Emporium marketplace entry'
 assert_contains "README documents release smoke command" "$README_FILE" 'bash lib/release-smoke.sh'
+assert_contains "README documents Codex plugin metadata" "$README_FILE" '.codex-plugin/plugin.json'
 assert_contains "README documents harness smoke coverage" "$README_FILE" '/signum:init --harness'
 assert_contains "README documents trigger rationale" "$README_FILE" 'workflow_dispatch'
 assert_contains "Reliability doc includes release smoke" "$RELIABILITY_FILE" 'bash lib/release-smoke.sh'
 assert_contains "Reliability doc mentions marketplace install journey" "$RELIABILITY_FILE" 'Fresh marketplace install resolves current Signum release'
+assert_contains "Reliability doc mentions Codex plugin metadata" "$RELIABILITY_FILE" '.codex-plugin/plugin.json'
 assert_contains "Reliability doc documents automation ssh key" "$RELIABILITY_FILE" 'EMPORIUM_SSH_KEY'
 
 echo ""


### PR DESCRIPTION
## Summary
- Add Codex App plugin metadata and docs for installing Signum through Codex plugins.
- Bump Signum metadata and generated command versions to 4.21.1 so plugin consumers pick up the release.
- Add/adjust deterministic guardrails for Codex plugin metadata and release smoke behavior.

## Verification
- env -u CDPATH bash scripts/run-deterministic-tests.sh

Supersedes #62; that PR hit a stale Codex connector review signal after the version bump.