### PR TITLE
[codex] Add Codex marketplace metadata

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "signum",
+  "interface": {
+    "displayName": "Signum"
+  },
+  "plugins": [
+    {
+      "name": "signum",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ review_cadence: quarterly
 | Deterministic core | `lib/` | Shell checks, DSL runner, scanners, state/policy helpers | `@vi` | Prefer tests for every behavioral change |
 | Schemas and contracts | `lib/schemas/` | Contract / proofpack / modules schemas | `@vi` | Treat schema changes as compatibility-sensitive |
 | Platform overlays | `platforms/` | Surface-specific command/docs variants | `@vi` | Root command/docs remain canonical unless an overlay deviation is explicitly documented |
-| Codex plugin metadata | `.codex-plugin/plugin.json`, `platforms/codex/SKILL.md` | Codex App install surface and skill entry point | `@vi` | Keep version aligned with `.claude-plugin/plugin.json`; Codex skill remains an overlay |
+| Codex plugin metadata | `.agents/plugins/marketplace.json`, `.codex-plugin/plugin.json`, `platforms/codex/SKILL.md` | Codex App marketplace, install manifest, and skill entry point | `@vi` | Keep version aligned with `.claude-plugin/plugin.json`; Codex skill remains an overlay |
 | Verification surface | `tests/` | Shell tests for deterministic behavior | `@vi` | If a deterministic behavior changes, add/update a test |
 
 ## Repo-Specific Rules
@@ -40,14 +40,14 @@ review_cadence: quarterly
 - `lib/policy-scanner.sh`, `lib/policy-resolver.sh` — execution policy enforcement
 - `lib/contract-injection-scan.sh` — prompt/contract injection defense
 - `lib/schemas/*.json` — compatibility-sensitive contract/proofpack formats
-- `.codex-plugin/plugin.json`, `platforms/codex/SKILL.md` — Codex App install and orchestration surface
+- `.agents/plugins/marketplace.json`, `.codex-plugin/plugin.json`, `platforms/codex/SKILL.md` — Codex App marketplace, install, and orchestration surface
 
 ## First Reads By Task Type
 - **Understand the product**: `README.md`, `project.intent.md`, `docs/how-it-works.md`
 - **Change core pipeline behavior**: `commands/signum.md`, `docs/reference.md`, matching `tests/*`
 - **Change init/bootstrap behavior**: `commands/init.md`, `agents/init-synthesizer.md`, `lib/init-scanner.sh`, `lib/init-harness-scaffold.sh`, `tests/test-init*.sh`
 - **Change docs/parity policy**: `docs/reference.md`, `docs/overlay-deviations.json`, `lib/doc-parity-check.sh`, `tests/test-doc-parity.sh`
-- **Change Codex App plugin support**: `.codex-plugin/plugin.json`, `platforms/codex/SKILL.md`, `tests/test-codex-plugin-metadata.sh`
+- **Change Codex App plugin support**: `.agents/plugins/marketplace.json`, `.codex-plugin/plugin.json`, `platforms/codex/SKILL.md`, `tests/test-codex-plugin-metadata.sh`
 - **Change future architecture direction**: `docs/plans/2026-03-15-large-project-support-roadmap.md`, `docs/thin-cli-extraction-plan.md`
 
 ## Update Protocol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Codex App repo-level marketplace metadata via `.agents/plugins/marketplace.json`, enabling `heurema/signum` to be added directly from the Plugins UI.
+
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -19,24 +19,15 @@ Verify:
 claude "/signum explain"
 ```
 
-For Codex App, install Signum from a Codex plugin marketplace entry that points at the plugin package. The install manifest lives at `.codex-plugin/plugin.json` and exposes the `signum` skill from `platforms/codex/SKILL.md`.
+For Codex App, open **Plugins -> Add marketplace** and use:
 
-Example Codex marketplace entry:
-
-```json
-{
-  "name": "signum",
-  "source": {
-    "source": "local",
-    "path": "./plugins/signum"
-  },
-  "policy": {
-    "installation": "AVAILABLE",
-    "authentication": "ON_INSTALL"
-  },
-  "category": "Coding"
-}
+```text
+Source: heurema/signum
+Git ref: main
+Sparse paths: leave blank
 ```
+
+The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the install manifest lives at `.codex-plugin/plugin.json`. If you need sparse checkout, include `.agents/plugins`, `.codex-plugin`, and `platforms/codex`. For pinned installs, use a release tag created after this marketplace file is present.
 
 ## 2. Run Your First Pipeline
 

--- a/README.md
+++ b/README.md
@@ -128,24 +128,15 @@ Use the canonical init command:
 
 For Claude Code usage, install the Claude Code CLI according to your environment.
 
-For Codex App usage, Signum ships plugin metadata at `.codex-plugin/plugin.json`. The Codex plugin entry point is the `signum` skill under `platforms/codex/SKILL.md`, so a Codex plugin marketplace entry should point at a Signum plugin checkout and use that manifest.
+For Codex App usage, Signum ships both the plugin manifest at `.codex-plugin/plugin.json` and a repo-level marketplace at `.agents/plugins/marketplace.json`. In **Plugins -> Add marketplace**, use:
 
-Example Codex marketplace entry:
-
-```json
-{
-  "name": "signum",
-  "source": {
-    "source": "local",
-    "path": "./plugins/signum"
-  },
-  "policy": {
-    "installation": "AVAILABLE",
-    "authentication": "ON_INSTALL"
-  },
-  "category": "Coding"
-}
+```text
+Source: heurema/signum
+Git ref: main
+Sparse paths: leave blank
 ```
+
+If you need sparse checkout, include `.agents/plugins`, `.codex-plugin`, and `platforms/codex`. For pinned installs, use a release tag created after this marketplace file is present.
 
 In Codex, invoke the workflow with a prompt such as:
 
@@ -384,7 +375,7 @@ Signum includes a maintainer release path for syncing the plugin entry with the 
 
 - **Release smoke test**: run `bash lib/release-smoke.sh` before publishing release metadata.
 - **Marketplace sync**: the `Sync Emporium marketplace entry` workflow updates `heurema/emporium/.claude-plugin/marketplace.json`.
-- **Codex plugin metadata**: `.codex-plugin/plugin.json` defines the Codex App install manifest and points at `platforms/codex/SKILL.md`.
+- **Codex plugin metadata**: `.codex-plugin/plugin.json` defines the Codex App install manifest and points at `platforms/codex/SKILL.md`; `.agents/plugins/marketplace.json` lets Codex App add `heurema/signum` directly as a marketplace.
 - **Automation secret**: non-dry-run cross-repo sync requires `EMPORIUM_SSH_KEY`.
 - **Manual trigger**: the workflow supports `workflow_dispatch` so maintainers can run a controlled release dry-run or sync.
 - **Release trigger**: the workflow also runs on release publication so marketplace metadata stays aligned with Signum releases.

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -12,7 +12,7 @@ review_cadence: quarterly
 | Journey | Why it matters | Primary Surfaces | Current Evidence |
 | --- | --- | --- | --- |
 | Run `/signum <task>` end-to-end | Core product promise | `commands/signum.md`, `agents/`, `lib/`, schemas | README + reference docs + deterministic shell tests |
-| Fresh marketplace install resolves current Signum release | Users should not install a stale registry target after a version bump | `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `platforms/codex/SKILL.md`, `heurema/emporium/.claude-plugin/marketplace.json`, `lib/update-emporium-marketplace.sh`, `lib/check-emporium-sync.sh`, `.github/workflows/release-guardrails.yml` | `bash lib/release-smoke.sh`, `bash tests/test-emporium-sync.sh`, `bash tests/test-update-emporium-marketplace.sh`, `bash tests/test-codex-plugin-metadata.sh`; CI syncs first, then verifies |
+| Fresh marketplace install resolves current Signum release | Users should not install a stale registry target after a version bump | `.claude-plugin/plugin.json`, `.agents/plugins/marketplace.json`, `.codex-plugin/plugin.json`, `platforms/codex/SKILL.md`, `heurema/emporium/.claude-plugin/marketplace.json`, `lib/update-emporium-marketplace.sh`, `lib/check-emporium-sync.sh`, `.github/workflows/release-guardrails.yml` | `bash lib/release-smoke.sh`, `bash tests/test-emporium-sync.sh`, `bash tests/test-update-emporium-marketplace.sh`, `bash tests/test-codex-plugin-metadata.sh`; CI syncs first, then verifies |
 | Generate correct runtime artifacts in `.signum/` | Needed for auditability and CI gating | `commands/signum.md`, `lib/`, `.signum/` artifact contract | `docs/reference.md`, `docs/how-it-works.md` |
 | Bootstrap project context with `/signum init` | Reduces missing-context failures in downstream repos | `commands/init.md`, `agents/init-synthesizer.md`, `lib/init-scanner.sh`, `lib/init-harness-scaffold.sh` | `tests/test-init.sh`, `tests/test-init-harness-scaffold.sh` |
 | Keep root docs and overlays aligned | Prevents trust loss from doc drift | `docs/reference.md`, `docs/overlay-deviations.json`, `lib/doc-parity-check.sh` | `tests/test-doc-parity.sh`, `.github/workflows/doc-parity.yml` |
@@ -51,4 +51,4 @@ review_cadence: quarterly
 - Most reliability evidence is still shell-script unit coverage plus documentation, not integrated scenario runs.
 - Anti-entropy / recurring cleanup mode is planned but not yet a canonical root feature.
 - Cross-repo Claude marketplace writes require the `EMPORIUM_SSH_KEY` secret in `heurema/signum`; without it, guardrails still fail loudly on drift but cannot self-heal.
-- Codex App install metadata is present in `.codex-plugin/plugin.json`, but publishing that metadata to a shared Codex plugin marketplace is a separate distribution step.
+- Codex App can add `heurema/signum` directly through `.agents/plugins/marketplace.json`, but promotion to any shared curated Codex marketplace is still a separate distribution step.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -11,7 +11,7 @@ review_cadence: quarterly
 - **Local deterministic boundary**: shell scripts in `lib/`, schemas, proofpack assembly, receipt logic.
 - **Claude Code / LLM orchestration boundary**: `commands/` and `agents/` define what context goes to contractor/engineer/reviewer agents.
 - **External provider boundary**: current docs state Codex CLI and Gemini CLI receive the diff only, not the full codebase.
-- **Plugin/install boundary**: plugin metadata and install surfaces live under `.claude-plugin/` for Claude Code and `.codex-plugin/` plus `platforms/codex/SKILL.md` for Codex App.
+- **Plugin/install boundary**: plugin metadata and install surfaces live under `.claude-plugin/` for Claude Code and `.agents/plugins/marketplace.json`, `.codex-plugin/`, plus `platforms/codex/SKILL.md` for Codex App.
 
 ## Sensitive Surfaces
 
@@ -21,6 +21,7 @@ review_cadence: quarterly
 | `lib/policy-scanner.sh` / `lib/policy-resolver.sh` | Enforces execution policy and denied command patterns |
 | `lib/contract-injection-scan.sh` | Guards against contract/prompt injection input |
 | `commands/signum.md` and `agents/*.md` | Control what context and instructions reach models |
+| `.agents/plugins/marketplace.json` and `.codex-plugin/plugin.json` | Control how Codex App discovers and installs the plugin |
 | `lib/schemas/*.json` | Define structured inputs/outputs trusted by the pipeline |
 
 ## Existing Controls

--- a/platforms/claude-code/CHANGELOG.md
+++ b/platforms/claude-code/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Codex App repo-level marketplace metadata via `.agents/plugins/marketplace.json`, enabling `heurema/signum` to be added directly from the Plugins UI.
+
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
 

--- a/platforms/claude-code/QUICKSTART.md
+++ b/platforms/claude-code/QUICKSTART.md
@@ -19,24 +19,15 @@ Verify:
 claude "/signum explain"
 ```
 
-For Codex App, install Signum from a Codex plugin marketplace entry that points at the plugin package. The install manifest lives at `.codex-plugin/plugin.json` and exposes the `signum` skill from `platforms/codex/SKILL.md`.
+For Codex App, open **Plugins -> Add marketplace** and use:
 
-Example Codex marketplace entry:
-
-```json
-{
-  "name": "signum",
-  "source": {
-    "source": "local",
-    "path": "./plugins/signum"
-  },
-  "policy": {
-    "installation": "AVAILABLE",
-    "authentication": "ON_INSTALL"
-  },
-  "category": "Coding"
-}
+```text
+Source: heurema/signum
+Git ref: main
+Sparse paths: leave blank
 ```
+
+The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the install manifest lives at `.codex-plugin/plugin.json`. If you need sparse checkout, include `.agents/plugins`, `.codex-plugin`, and `platforms/codex`. For pinned installs, use a release tag created after this marketplace file is present.
 
 ## 2. Run Your First Pipeline
 

--- a/tests/test-codex-plugin-metadata.sh
+++ b/tests/test-codex-plugin-metadata.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
 PLUGIN_JSON="$REPO_ROOT/.codex-plugin/plugin.json"
+MARKETPLACE_JSON="$REPO_ROOT/.agents/plugins/marketplace.json"
 CLAUDE_PLUGIN_JSON="$REPO_ROOT/.claude-plugin/plugin.json"
 CODEX_SKILL="$REPO_ROOT/platforms/codex/SKILL.md"
 
@@ -52,6 +53,7 @@ assert_contains() {
 echo "=== Codex plugin metadata ==="
 
 assert_file "Codex plugin manifest exists" "$PLUGIN_JSON"
+assert_file "Codex marketplace exists" "$MARKETPLACE_JSON"
 assert_file "Codex skill entrypoint exists" "$CODEX_SKILL"
 
 if [ -f "$PLUGIN_JSON" ]; then
@@ -64,6 +66,27 @@ if [ -f "$PLUGIN_JSON" ]; then
   assert_json_eq "plugin points at Codex skill overlay" "$PLUGIN_JSON" '.skills' "./platforms/codex/"
   assert_json_eq "plugin display name is Signum" "$PLUGIN_JSON" '.interface.displayName' "Signum"
   assert_json_eq "plugin category is Coding" "$PLUGIN_JSON" '.interface.category' "Coding"
+fi
+
+if [ -f "$MARKETPLACE_JSON" ]; then
+  jq empty "$MARKETPLACE_JSON"
+  pass "Codex marketplace is valid JSON"
+
+  assert_json_eq "marketplace name is signum" "$MARKETPLACE_JSON" '.name' "signum"
+  assert_json_eq "marketplace display name is Signum" "$MARKETPLACE_JSON" '.interface.displayName' "Signum"
+  assert_json_eq "marketplace has one Signum plugin" "$MARKETPLACE_JSON" '[.plugins[] | select(.name == "signum")] | length' "1"
+  assert_json_eq "marketplace plugin source is local" "$MARKETPLACE_JSON" '.plugins[] | select(.name == "signum") | .source.source' "local"
+  assert_json_eq "marketplace plugin points at repo root" "$MARKETPLACE_JSON" '.plugins[] | select(.name == "signum") | .source.path' "./"
+  assert_json_eq "marketplace plugin install is available" "$MARKETPLACE_JSON" '.plugins[] | select(.name == "signum") | .policy.installation' "AVAILABLE"
+  assert_json_eq "marketplace plugin auth is on install" "$MARKETPLACE_JSON" '.plugins[] | select(.name == "signum") | .policy.authentication' "ON_INSTALL"
+  assert_json_eq "marketplace plugin category is Coding" "$MARKETPLACE_JSON" '.plugins[] | select(.name == "signum") | .category' "Coding"
+
+  MARKETPLACE_PLUGIN_ROOT="$REPO_ROOT/$(jq -r '.plugins[] | select(.name == "signum") | .source.path' "$MARKETPLACE_JSON")"
+  if [ -f "$MARKETPLACE_PLUGIN_ROOT/.codex-plugin/plugin.json" ]; then
+    pass "marketplace plugin path resolves to Codex manifest"
+  else
+    fail "marketplace plugin path resolves to Codex manifest" "missing $MARKETPLACE_PLUGIN_ROOT/.codex-plugin/plugin.json"
+  fi
 fi
 
 if [ -f "$CODEX_SKILL" ]; then

--- a/tests/test-release-smoke.sh
+++ b/tests/test-release-smoke.sh
@@ -77,11 +77,15 @@ assert_contains "README documents automation ssh key" "$README_FILE" 'EMPORIUM_S
 assert_contains "README documents automatic sync workflow" "$README_FILE" 'Sync Emporium marketplace entry'
 assert_contains "README documents release smoke command" "$README_FILE" 'bash lib/release-smoke.sh'
 assert_contains "README documents Codex plugin metadata" "$README_FILE" '.codex-plugin/plugin.json'
+assert_contains "README documents Codex marketplace metadata" "$README_FILE" '.agents/plugins/marketplace.json'
+assert_contains "README documents direct Codex marketplace source" "$README_FILE" 'Source: heurema/signum'
+assert_contains "README documents direct Codex marketplace ref" "$README_FILE" 'Git ref: main'
 assert_contains "README documents harness smoke coverage" "$README_FILE" '/signum:init --harness'
 assert_contains "README documents trigger rationale" "$README_FILE" 'workflow_dispatch'
 assert_contains "Reliability doc includes release smoke" "$RELIABILITY_FILE" 'bash lib/release-smoke.sh'
 assert_contains "Reliability doc mentions marketplace install journey" "$RELIABILITY_FILE" 'Fresh marketplace install resolves current Signum release'
 assert_contains "Reliability doc mentions Codex plugin metadata" "$RELIABILITY_FILE" '.codex-plugin/plugin.json'
+assert_contains "Reliability doc mentions Codex marketplace metadata" "$RELIABILITY_FILE" '.agents/plugins/marketplace.json'
 assert_contains "Reliability doc documents automation ssh key" "$RELIABILITY_FILE" 'EMPORIUM_SSH_KEY'
 
 echo ""


### PR DESCRIPTION
## Summary
- Add repo-level Codex marketplace metadata so `heurema/signum` can be added directly from the Codex App Plugins UI.
- Document the Add marketplace fields and sparse checkout paths.
- Extend Codex plugin/release smoke guardrails to validate the marketplace entry and path resolution.

## Verification
- `env -u CDPATH bash scripts/run-deterministic-tests.sh`
- Sparse marketplace smoke with `.agents/plugins`, `.codex-plugin`, and `platforms/codex` sparse paths