### PR TITLE
[codex] Fix Heurema marketplace display name

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
-  "name": "signum",
+  "name": "heurema",
   "interface": {
-    "displayName": "Signum"
+    "displayName": "Heurema"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,5 @@
   "license": "MIT",
   "name": "signum",
   "repository": "https://github.com/heurema/signum",
-  "version": "4.21.2"
+  "version": "4.21.3"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signum",
-  "version": "4.21.2",
+  "version": "4.21.3",
   "description": "Evidence-driven development pipeline with multi-model code review",
   "author": {
     "name": "heurema",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
 
+## [4.21.3] - 2026-05-08
+
+### Fixed
+- Codex App marketplace metadata now names the marketplace source `heurema` / `Heurema` while keeping the plugin entry as `signum` / `Signum`.
+
 ## [4.21.2] - 2026-05-08
 
 ### Added

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -27,7 +27,9 @@ Git ref: main
 Sparse paths: leave blank
 ```
 
-The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.2` or a newer release tag.
+After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**.
+
+The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.3` or a newer release tag.
 
 ## 2. Run Your First Pipeline
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ Git ref: main
 Sparse paths: leave blank
 ```
 
-If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. Include `.codex-plugin` only for direct local-folder installs. For pinned installs, use `v4.21.2` or a newer release tag.
+After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**.
+
+If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. Include `.codex-plugin` only for direct local-folder installs. For pinned installs, use `v4.21.3` or a newer release tag.
 
 In Codex, invoke the workflow with a prompt such as:
 

--- a/commands/signum.fragments/100-phase-pack.md
+++ b/commands/signum.fragments/100-phase-pack.md
@@ -268,7 +268,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.2" \
+  --arg signumVersion "4.21.3" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/commands/signum.fragments/20-explain-mode.md
+++ b/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.2",
+  "version": "4.21.3",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -46,7 +46,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.2",
+  "version": "4.21.3",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -3546,7 +3546,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.2" \
+  --arg signumVersion "4.21.3" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/claude-code/.claude-plugin/plugin.json
+++ b/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "signum",
   "description": "Evidence-driven development pipeline with multi-model code review",
-  "version": "4.21.2",
+  "version": "4.21.3",
   "author": {
     "name": "heurema"
   },

--- a/platforms/claude-code/CHANGELOG.md
+++ b/platforms/claude-code/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
 
+## [4.21.3] - 2026-05-08
+
+### Fixed
+- Codex App marketplace metadata now names the marketplace source `heurema` / `Heurema` while keeping the plugin entry as `signum` / `Signum`.
+
 ## [4.21.2] - 2026-05-08
 
 ### Added

--- a/platforms/claude-code/QUICKSTART.md
+++ b/platforms/claude-code/QUICKSTART.md
@@ -27,7 +27,9 @@ Git ref: main
 Sparse paths: leave blank
 ```
 
-The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.2` or a newer release tag.
+After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**.
+
+The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.3` or a newer release tag.
 
 ## 2. Run Your First Pipeline
 

--- a/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
+++ b/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
@@ -268,7 +268,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.2" \
+  --arg signumVersion "4.21.3" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
+++ b/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.2",
+  "version": "4.21.3",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -47,7 +47,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.2",
+  "version": "4.21.3",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -3568,7 +3568,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.2" \
+  --arg signumVersion "4.21.3" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/codex/.codex-plugin/plugin.json
+++ b/platforms/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signum",
-  "version": "4.21.2",
+  "version": "4.21.3",
   "description": "Evidence-driven development pipeline with multi-model code review",
   "author": {
     "name": "heurema",

--- a/tests/fixtures/proofpack/invalid-removal-evidence.json
+++ b/tests/fixtures/proofpack/invalid-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.2",
+  "signumVersion": "4.21.3",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-bad-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-artifact-ref.json
+++ b/tests/fixtures/proofpack/missing-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.2",
+  "signumVersion": "4.21.3",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-required.json
+++ b/tests/fixtures/proofpack/missing-required.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.2",
+  "signumVersion": "4.21.3",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/schema-version-mismatch.json
+++ b/tests/fixtures/proofpack/schema-version-mismatch.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.7",
-  "signumVersion": "4.21.2",
+  "signumVersion": "4.21.3",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/unsafe-artifact-path.json
+++ b/tests/fixtures/proofpack/unsafe-artifact-path.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.2",
+  "signumVersion": "4.21.3",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-minimal.json
+++ b/tests/fixtures/proofpack/valid-minimal.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.2",
+  "signumVersion": "4.21.3",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-artifact-ref.json
+++ b/tests/fixtures/proofpack/valid-with-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.2",
+  "signumVersion": "4.21.3",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-removal-evidence.json
+++ b/tests/fixtures/proofpack/valid-with-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.2",
+  "signumVersion": "4.21.3",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/wrong-type.json
+++ b/tests/fixtures/proofpack/wrong-type.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.2",
+  "signumVersion": "4.21.3",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/test-codex-plugin-metadata.sh
+++ b/tests/test-codex-plugin-metadata.sh
@@ -86,8 +86,8 @@ if [ -f "$MARKETPLACE_JSON" ]; then
   jq empty "$MARKETPLACE_JSON"
   pass "Codex marketplace is valid JSON"
 
-  assert_json_eq "marketplace name is signum" "$MARKETPLACE_JSON" '.name' "signum"
-  assert_json_eq "marketplace display name is Signum" "$MARKETPLACE_JSON" '.interface.displayName' "Signum"
+  assert_json_eq "marketplace name is heurema" "$MARKETPLACE_JSON" '.name' "heurema"
+  assert_json_eq "marketplace display name is Heurema" "$MARKETPLACE_JSON" '.interface.displayName' "Heurema"
   assert_json_eq "marketplace has one Signum plugin" "$MARKETPLACE_JSON" '[.plugins[] | select(.name == "signum")] | length' "1"
   assert_json_eq "marketplace plugin source is local" "$MARKETPLACE_JSON" '.plugins[] | select(.name == "signum") | .source.source' "local"
   assert_json_eq "marketplace plugin points at Codex platform root" "$MARKETPLACE_JSON" '.plugins[] | select(.name == "signum") | .source.path' "./platforms/codex"


### PR DESCRIPTION
## Summary
- rename the Codex marketplace source from `signum` / `Signum` to `heurema` / `Heurema`
- keep the plugin entry and install manifest as `signum` / `Signum`
- bump Signum metadata to `4.21.3` and document that the Plugins source dropdown shows `Heurema`

## Why
The marketplace source should represent the publisher namespace (`Heurema`), while the installable plugin inside that marketplace remains `Signum`.

## Verification
- `jq empty .agents/plugins/marketplace.json .codex-plugin/plugin.json platforms/codex/.codex-plugin/plugin.json .claude-plugin/plugin.json platforms/claude-code/.claude-plugin/plugin.json`
- `env -u CDPATH bash tests/test-codex-plugin-metadata.sh`
- `env -u CDPATH bash tests/test-metadata-consistency.sh`
- `env -u CDPATH bash tests/test-release-smoke.sh`
- `env -u CDPATH bash tests/test-proofpack-validation.sh`
- `env -u CDPATH bash scripts/run-deterministic-tests.sh`
- isolated `CODEX_HOME` marketplace add smoke confirms `[marketplaces.heurema]`
- sparse checkout marketplace smoke for `.agents/plugins` + `platforms/codex`
