### PR TITLE
chore(ci): use thread-only repo-governance gate

### DIFF
--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -20,7 +20,7 @@ jobs:
   pr-intake-gate:
     name: pr-intake-gate
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - name: Checkout trusted base code
@@ -32,10 +32,11 @@ jobs:
 
       - name: Run PR intake gate
         # pinned from heurema/repo-governance/actions/pr-intake-gate@main
-        uses: heurema/repo-governance/actions/pr-intake-gate@2413ba8db779a431d46505003870766b35b3ea57
+        uses: heurema/repo-governance/actions/pr-intake-gate@a7e37be8dcd8e3468eb4094451bae3ee208bb5dc
         with:
           policy-path: .github/pr-intake-gate.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
           codex-review-require-current-review: 'true'
           codex-review-wait-seconds: '480'
+          codex-review-resolution-wait-seconds: '480'
           codex-review-poll-interval-seconds: '10'

--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -32,11 +32,11 @@ jobs:
 
       - name: Run PR intake gate
         # pinned from heurema/repo-governance/actions/pr-intake-gate@main
-        uses: heurema/repo-governance/actions/pr-intake-gate@a7e37be8dcd8e3468eb4094451bae3ee208bb5dc
+        uses: heurema/repo-governance/actions/pr-intake-gate@655ca032dabaed8d66537ae2ac4890a71dc3bd94
         with:
           policy-path: .github/pr-intake-gate.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          codex-review-require-current-review: 'true'
-          codex-review-wait-seconds: '480'
+          codex-review-require-current-review: 'false'
+          codex-review-wait-seconds: '0'
           codex-review-resolution-wait-seconds: '480'
           codex-review-poll-interval-seconds: '10'

--- a/tests/fixtures/github-action-pins.json
+++ b/tests/fixtures/github-action-pins.json
@@ -49,12 +49,12 @@
     {
       "file": ".github/workflows/pr-intake-gate.yml",
       "occurrence": 2,
-      "uses": "heurema/repo-governance/actions/pr-intake-gate@a7e37be8dcd8e3468eb4094451bae3ee208bb5dc",
+      "uses": "heurema/repo-governance/actions/pr-intake-gate@655ca032dabaed8d66537ae2ac4890a71dc3bd94",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/pr-intake-gate",
       "status": "pinned",
       "originalRef": "main",
-      "pinnedSha": "a7e37be8dcd8e3468eb4094451bae3ee208bb5dc",
+      "pinnedSha": "655ca032dabaed8d66537ae2ac4890a71dc3bd94",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
       "resolution": "git rev-parse heurema/repo-governance main",
       "peeledTagUsed": false

--- a/tests/fixtures/github-action-pins.json
+++ b/tests/fixtures/github-action-pins.json
@@ -49,14 +49,14 @@
     {
       "file": ".github/workflows/pr-intake-gate.yml",
       "occurrence": 2,
-      "uses": "heurema/repo-governance/actions/pr-intake-gate@2413ba8db779a431d46505003870766b35b3ea57",
+      "uses": "heurema/repo-governance/actions/pr-intake-gate@a7e37be8dcd8e3468eb4094451bae3ee208bb5dc",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/pr-intake-gate",
       "status": "pinned",
       "originalRef": "main",
-      "pinnedSha": "2413ba8db779a431d46505003870766b35b3ea57",
+      "pinnedSha": "a7e37be8dcd8e3468eb4094451bae3ee208bb5dc",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
-      "resolution": "git rev-parse heurema/repo-governance 2413ba8db779a431d46505003870766b35b3ea57",
+      "resolution": "git rev-parse heurema/repo-governance main",
       "peeledTagUsed": false
     },
     {


### PR DESCRIPTION
Summary:
- Pin PR Intake Gate to repo-governance 655ca03.
- Use thread-only Codex Review gating without required current-review completion.
- Keep bounded unresolved-thread resolution wait and update action pin fixture.

Issue ID: N/A

Test plan:
- bash tests/test-github-action-pinning.sh
- git diff --check