### PR TITLE
chore(ci): trigger intake gate on review events

### DIFF
--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -10,6 +10,16 @@ on:
       - labeled
       - unlabeled
       - ready_for_review
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+      - dismissed
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+      - deleted
 
 permissions:
   contents: read


### PR DESCRIPTION
Summary:
- Run the required PR Intake Gate on pull request review and review comment events.
- Keep the existing required status context while allowing resolved Codex threads to turn green through the bounded wait.

Issue ID: N/A

Test plan:
- bash tests/test-github-action-pinning.sh
- git diff --check