### PR TITLE
[codex] Document iterative audit support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,5 @@
   "license": "MIT",
   "name": "signum",
   "repository": "https://github.com/heurema/signum",
-  "version": "4.21.5"
+  "version": "4.21.6"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signum",
-  "version": "4.21.5",
+  "version": "4.21.6",
   "description": "Evidence-driven development pipeline with multi-model code review",
   "author": {
     "name": "heurema",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
 
+## [4.21.6] - 2026-05-08
+
+### Added
+- Codex App skill metadata now explicitly documents iterative AUDIT repair loops, iteration artifacts, and proofpack output.
+
 ## [4.21.5] - 2026-05-08
 
 ### Added

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -29,7 +29,7 @@ Sparse paths: leave blank
 
 After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**.
 
-The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.5` or a newer release tag.
+The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.6` or a newer release tag.
 
 ## 2. Run Your First Pipeline
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Sparse paths: leave blank
 
 After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**.
 
-If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. Include `.codex-plugin` only for direct local-folder installs. For pinned installs, use `v4.21.5` or a newer release tag.
+If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. Include `.codex-plugin` only for direct local-folder installs. For pinned installs, use `v4.21.6` or a newer release tag.
 
 In Codex, invoke the workflow with a prompt such as:
 

--- a/commands/signum.fragments/100-phase-pack.md
+++ b/commands/signum.fragments/100-phase-pack.md
@@ -268,7 +268,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.5" \
+  --arg signumVersion "4.21.6" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/commands/signum.fragments/20-explain-mode.md
+++ b/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.5",
+  "version": "4.21.6",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -46,7 +46,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.5",
+  "version": "4.21.6",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -3546,7 +3546,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.5" \
+  --arg signumVersion "4.21.6" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/claude-code/.claude-plugin/plugin.json
+++ b/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "signum",
   "description": "Evidence-driven development pipeline with multi-model code review",
-  "version": "4.21.5",
+  "version": "4.21.6",
   "author": {
     "name": "heurema"
   },

--- a/platforms/claude-code/CHANGELOG.md
+++ b/platforms/claude-code/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
 
+## [4.21.6] - 2026-05-08
+
+### Added
+- Codex App skill metadata now explicitly documents iterative AUDIT repair loops, iteration artifacts, and proofpack output.
+
 ## [4.21.5] - 2026-05-08
 
 ### Added

--- a/platforms/claude-code/QUICKSTART.md
+++ b/platforms/claude-code/QUICKSTART.md
@@ -29,7 +29,7 @@ Sparse paths: leave blank
 
 After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**.
 
-The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.5` or a newer release tag.
+The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.6` or a newer release tag.
 
 ## 2. Run Your First Pipeline
 

--- a/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
+++ b/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
@@ -268,7 +268,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.5" \
+  --arg signumVersion "4.21.6" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
+++ b/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.5",
+  "version": "4.21.6",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -47,7 +47,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.5",
+  "version": "4.21.6",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -3568,7 +3568,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.5" \
+  --arg signumVersion "4.21.6" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/codex/.codex-plugin/plugin.json
+++ b/platforms/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signum",
-  "version": "4.21.5",
+  "version": "4.21.6",
   "description": "Evidence-driven development pipeline with multi-model code review",
   "author": {
     "name": "heurema",

--- a/platforms/codex/SKILL.md
+++ b/platforms/codex/SKILL.md
@@ -95,10 +95,14 @@ Within that active contract root, create and use:
 - `baseline.json`
 - `execute_log.json`
 - `combined.patch`
+- `iteration_delta.patch`
 - `mechanic_report.json`
 - `audit_summary.json`
+- `audit_iteration_log.json`
+- `repair_brief.json`
 - `proofpack.json`
 - `reviews/`
+- `iterations/`
 
 Also ensure root `.signum/` is ignored by git when appropriate.
 
@@ -228,6 +232,27 @@ If a provider returns `auth_error`, do not retry automatically.
 Run hidden or extra scenarios if they exist.
 
 If holdouts fail, the pipeline should not claim success even if visible acceptance criteria pass.
+
+### `iterative repair`
+
+If synthesis finds MAJOR or CRITICAL review findings, mechanic regressions, or holdout failures, enter iterative AUDIT instead of stopping after the first audit pass.
+
+Use `SIGNUM_AUDIT_MAX_ITERATIONS` as the maximum repair count; default to `20` when it is unset.
+
+For each iteration:
+
+1. Build a sanitized `repair_brief.json` under the active contract artifact root.
+2. Include only actionable findings, mechanic regression summaries, and holdout categories; never reveal hidden holdout details.
+3. Start a fresh repair context that fixes only the listed findings.
+4. Re-run the full safety chain: scope gate, policy checks, mechanic checks, holdouts, available reviewers, and synthesis.
+5. Store the full pass snapshot under `iterations/NN/`, including `combined.patch`, `iteration_delta.patch` when present, mechanic and holdout reports, reviewer outputs, and `audit_summary.json`.
+6. Append per-pass metadata to `audit_iteration_log.json`.
+
+Score each pass with the same severity weighting used by canonical Signum: CRITICAL findings dominate MAJOR findings, mechanic regressions, holdout failures, and MINOR findings. Keep the best-scoring candidate, not necessarily the last candidate.
+
+Stop early after two consecutive non-improving iterations. Before PACK, restore the best candidate and make its `audit_summary.json`, `combined.patch`, `reviews/`, and verification artifacts the active artifacts.
+
+When more than one audit iteration was used, include an `iterativeAudit` section in `proofpack.json` with `iterationsUsed`, `iterationsMax`, `bestIteration`, `auditIterations`, `resolvedFindings`, and `remainingFindings`.
 
 ## Phase 4: PACK
 

--- a/tests/fixtures/proofpack/invalid-removal-evidence.json
+++ b/tests/fixtures/proofpack/invalid-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.5",
+  "signumVersion": "4.21.6",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-bad-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-artifact-ref.json
+++ b/tests/fixtures/proofpack/missing-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.5",
+  "signumVersion": "4.21.6",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-required.json
+++ b/tests/fixtures/proofpack/missing-required.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.5",
+  "signumVersion": "4.21.6",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/schema-version-mismatch.json
+++ b/tests/fixtures/proofpack/schema-version-mismatch.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.7",
-  "signumVersion": "4.21.5",
+  "signumVersion": "4.21.6",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/unsafe-artifact-path.json
+++ b/tests/fixtures/proofpack/unsafe-artifact-path.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.5",
+  "signumVersion": "4.21.6",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-minimal.json
+++ b/tests/fixtures/proofpack/valid-minimal.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.5",
+  "signumVersion": "4.21.6",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-artifact-ref.json
+++ b/tests/fixtures/proofpack/valid-with-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.5",
+  "signumVersion": "4.21.6",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-removal-evidence.json
+++ b/tests/fixtures/proofpack/valid-with-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.5",
+  "signumVersion": "4.21.6",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/wrong-type.json
+++ b/tests/fixtures/proofpack/wrong-type.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.5",
+  "signumVersion": "4.21.6",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/test-codex-plugin-metadata.sh
+++ b/tests/test-codex-plugin-metadata.sh
@@ -115,6 +115,11 @@ if [ -f "$CODEX_SKILL" ]; then
   assert_contains "Codex skill declares Signum name" "$CODEX_SKILL" "name: signum"
   assert_contains "Codex skill uses contract-first pipeline" "$CODEX_SKILL" "CONTRACT -> EXECUTE -> AUDIT -> PACK"
   assert_contains "Codex skill uses canonical artifact root" "$CODEX_SKILL" ".signum/contracts/<contractId>/"
+  assert_contains "Codex skill declares iterative AUDIT" "$CODEX_SKILL" "iterative repair"
+  assert_contains "Codex skill documents audit iteration limit" "$CODEX_SKILL" "SIGNUM_AUDIT_MAX_ITERATIONS"
+  assert_contains "Codex skill stores iteration artifacts" "$CODEX_SKILL" "iterations/NN/"
+  assert_contains "Codex skill records audit iteration log" "$CODEX_SKILL" "audit_iteration_log.json"
+  assert_contains "Codex skill packages iterative audit proof" "$CODEX_SKILL" "iterativeAudit"
   assert_contains "Codex skill treats external reviewers as optional" "$CODEX_SKILL" "optional evidence sources"
 fi
 


### PR DESCRIPTION
## Summary
- document the iterative AUDIT repair loop directly in the Codex App skill overlay
- add Codex skill metadata checks for iteration artifacts and proofpack output
- bump plugin metadata to 4.21.6 so marketplace upgrade picks up the overlay change

## Verification
- jq empty .agents/plugins/marketplace.json .codex-plugin/plugin.json platforms/codex/.codex-plugin/plugin.json .claude-plugin/plugin.json platforms/claude-code/.claude-plugin/plugin.json
- env -u CDPATH bash tests/test-codex-plugin-metadata.sh
- env -u CDPATH bash tests/test-metadata-consistency.sh
- env -u CDPATH bash tests/test-release-smoke.sh
- env -u CDPATH bash tests/test-proofpack-validation.sh
- isolated CODEX_HOME marketplace add smoke
- env -u CDPATH bash scripts/run-deterministic-tests.sh