### PR TITLE
Fix eval foundation review findings

### DIFF
--- a/evals/policy_scanner/README.md
+++ b/evals/policy_scanner/README.md
@@ -98,8 +98,10 @@ Regression thresholds:
 - recall must not drop
 - critical recall must not drop
 - false positives must not increase without material recall improvement
-- `runtimeMsP95` must not exceed `1.5x` baseline
 - known baseline failures must not increase
+
+`runtimeMsP95` remains in `deltas` as an informational signal, but it is not a
+regression gate because scanner subprocess runtime is host-dependent.
 
 ## Fixture schema
 

--- a/evals/policy_scanner/compare_policy_scanner_eval.py
+++ b/evals/policy_scanner/compare_policy_scanner_eval.py
@@ -193,15 +193,6 @@ def compare_scorecards(baseline_report: Dict[str, Any], candidate_report: Dict[s
             reason="false positives exceed the 10 percent budget",
         )
 
-    baseline_runtime = number(baseline, "runtimeMsP95")
-    if baseline_runtime > 0 and number(candidate, "runtimeMsP95") > baseline_runtime * 1.5:
-        append_metric_change(
-            regressions,
-            metric="runtimeMsP95",
-            baseline=baseline.get("runtimeMsP95"),
-            candidate=candidate.get("runtimeMsP95"),
-            reason="p95 runtime exceeded 1.5x baseline",
-        )
     if known_failure_delta > 0:
         append_metric_change(
             regressions,

--- a/lib/policy-scanner.sh
+++ b/lib/policy-scanner.sh
@@ -45,6 +45,7 @@ SCANNED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 validate_policy_rule_catalog() {
   local catalog_path="${1:-}"
   local validation_errors=""
+  local regex_syntax_errors=""
 
   if [ -z "$catalog_path" ]; then
     echo "ERROR: policy rule catalog path is empty" >&2
@@ -136,6 +137,23 @@ validate_policy_rule_catalog() {
   if [ -n "$validation_errors" ]; then
     echo "ERROR: policy rule catalog validation failed: $catalog_path" >&2
     printf '%s\n' "$validation_errors" >&2
+    return 1
+  fi
+
+  regex_syntax_errors=$(jq -r '.rules[] | "\(.ruleId)\t\(.regex)"' "$catalog_path" | while IFS=$'\t' read -r rule_id regex; do
+    local grep_status=0
+    set +e
+    printf '' | grep -Eq -- "$regex" >/dev/null 2>&1
+    grep_status=$?
+    set -e
+    if [ "$grep_status" -eq 2 ]; then
+      printf 'rule %s has invalid regex syntax\n' "$rule_id"
+    fi
+  done)
+
+  if [ -n "$regex_syntax_errors" ]; then
+    echo "ERROR: policy rule catalog validation failed: $catalog_path" >&2
+    printf '%s\n' "$regex_syntax_errors" >&2
     return 1
   fi
 }

--- a/platforms/claude-code/lib/policy-scanner.sh
+++ b/platforms/claude-code/lib/policy-scanner.sh
@@ -45,6 +45,7 @@ SCANNED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 validate_policy_rule_catalog() {
   local catalog_path="${1:-}"
   local validation_errors=""
+  local regex_syntax_errors=""
 
   if [ -z "$catalog_path" ]; then
     echo "ERROR: policy rule catalog path is empty" >&2
@@ -136,6 +137,23 @@ validate_policy_rule_catalog() {
   if [ -n "$validation_errors" ]; then
     echo "ERROR: policy rule catalog validation failed: $catalog_path" >&2
     printf '%s\n' "$validation_errors" >&2
+    return 1
+  fi
+
+  regex_syntax_errors=$(jq -r '.rules[] | "\(.ruleId)\t\(.regex)"' "$catalog_path" | while IFS=$'\t' read -r rule_id regex; do
+    local grep_status=0
+    set +e
+    printf '' | grep -Eq -- "$regex" >/dev/null 2>&1
+    grep_status=$?
+    set -e
+    if [ "$grep_status" -eq 2 ]; then
+      printf 'rule %s has invalid regex syntax\n' "$rule_id"
+    fi
+  done)
+
+  if [ -n "$regex_syntax_errors" ]; then
+    echo "ERROR: policy rule catalog validation failed: $catalog_path" >&2
+    printf '%s\n' "$regex_syntax_errors" >&2
     return 1
   fi
 }

--- a/tests/test-policy-scanner-eval-compare.sh
+++ b/tests/test-policy-scanner-eval-compare.sh
@@ -64,3 +64,27 @@ for key in (
     if key not in deltas:
         raise SystemExit(f"missing delta metric: {key}")
 PY
+
+SLOW_CANDIDATE="$WORK/policy-candidate-slow-runtime.json"
+SLOW_COMPARE="$WORK/policy-compare-slow-runtime.json"
+jq '.summary.runtimeMsP95 = (.summary.runtimeMsP95 * 10)' "$CANDIDATE" > "$SLOW_CANDIDATE"
+
+python3 "$ROOT_DIR/evals/policy_scanner/compare_policy_scanner_eval.py" \
+  --baseline "$ROOT_DIR/evals/policy_scanner/baselines/current.json" \
+  --candidate "$SLOW_CANDIDATE" \
+  > "$SLOW_COMPARE"
+
+python3 - "$SLOW_COMPARE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+runtime_regressions = [item for item in report.get("regressions", []) if item.get("metric") == "runtimeMsP95"]
+if runtime_regressions:
+    raise SystemExit(f"runtime delta should not create regressions: {runtime_regressions}")
+if report["status"] == "worse":
+    raise SystemExit("runtime-only delta should not make candidate worse")
+if "runtimeMsP95" not in report.get("deltas", {}):
+    raise SystemExit("runtime delta should remain visible in deltas")
+PY

--- a/tests/test-policy-scanner.sh
+++ b/tests/test-policy-scanner.sh
@@ -343,6 +343,21 @@ else
   fi
 fi
 
+INVALID_REGEX_CATALOG="$WORK/invalid-regex-policy-rules.json"
+jq '(.rules[0].regex) = "["' "$CATALOG" > "$INVALID_REGEX_CATALOG"
+INVALID_REGEX_DIR="$WORK/invalid-regex-catalog"
+mkdir -p "$INVALID_REGEX_DIR"
+cp "$FIXTURES/clean.patch" "$INVALID_REGEX_DIR/combined.patch"
+if SIGNUM_POLICY_RULE_CATALOG="$INVALID_REGEX_CATALOG" "$SCRIPT" "$INVALID_REGEX_DIR/combined.patch" >/dev/null 2>"$WORK/invalid-regex-catalog.err"; then
+  fail "scanner fails closed for invalid catalog regex" "scanner unexpectedly succeeded"
+else
+  if grep -q "invalid regex syntax" "$WORK/invalid-regex-catalog.err"; then
+    pass "scanner fails closed for invalid catalog regex"
+  else
+    fail "scanner fails closed for invalid catalog regex" "$(cat "$WORK/invalid-regex-catalog.err")"
+  fi
+fi
+
 CONFLICT_DIR="$WORK/conflicting-catalog"
 mkdir -p "$CONFLICT_DIR"
 cp "$FIXTURES/clean.patch" "$CONFLICT_DIR/combined.patch"


### PR DESCRIPTION
## Why

- Follow up on two late Codex Review comments that arrived after PR #74 was already merged.
- Keep the eval foundation deterministic and fail-closed before starting `signum-evolve` work.

## What changed

- Validate every catalog regex with `grep -E` during policy scanner catalog startup validation.
- Fail closed on invalid regex syntax instead of letting `grep` errors silently drop findings.
- Keep `runtimeMsP95` in policy scanner comparison `deltas`, but stop treating runtime-only variance as a regression/status signal.
- Mirror the scanner change into `platforms/claude-code/lib/policy-scanner.sh`.
- Add regression coverage for invalid regex catalogs and runtime-only comparison deltas.

## Review focus

- `lib/policy-scanner.sh`: regex syntax validation and fail-closed behavior.
- `evals/policy_scanner/compare_policy_scanner_eval.py`: runtime metric is informational only.
- `tests/test-policy-scanner.sh` and `tests/test-policy-scanner-eval-compare.sh`: coverage for both Codex Review findings.

## Testing

Passed:
- `bash tests/test-policy-scanner.sh`
- `bash tests/test-policy-scanner-evals.sh`
- `bash tests/test-policy-scanner-eval-compare.sh`
- `bash tests/test-claude-overlay-runtime-parity.sh`
- `bash scripts/run-deterministic-tests.sh`
- Manual invalid-regex reproduction: scanner now exits `1` with `invalid regex syntax`.
- Manual runtime-only comparison reproduction: `runtimeMsP95` delta remains visible, but `regressions=[]` and status stays `equivalent`.

## Not tested

- No live `signum-evolve` flow, because this is only a follow-up fix for the eval foundation.

## Risks

- narrow - Runtime deltas are still reported, but no longer affect candidate regression status.

## Rollout / migration

- No migration required.

## Breaking changes

- None.

## Follow-ups

- Start `signum-evolve v0` after this review-fix PR lands.

## Constraints

- No scanner behavior changes beyond rejecting invalid catalogs earlier.
- No Codex prompt change.
- No CI wiring change.
- No baseline update.
- No external dependency added.
