### PR TITLE
ci(codex): add review-ready gate

### DIFF
--- a/.github/workflows/codex-review-ready.yml
+++ b/.github/workflows/codex-review-ready.yml
@@ -1,0 +1,62 @@
+name: Codex Review Ready
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+      - dismissed
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+      - deleted
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  codex-review-ready:
+    name: codex-review-ready-reconcile
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+
+    steps:
+      - name: Reconcile Codex Review ready status
+        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+        # pinned from heurema/repo-governance/actions/codex-review-ready@main
+        uses: heurema/repo-governance/actions/codex-review-ready@5f109136c7a4e9f5a06fdc9422b1aa65d9695b29
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          review-author-logins: chatgpt-codex-connector
+          ignore-outdated: 'true'
+          status-context: codex-review-ready
+          poll-seconds: '1800'
+          poll-interval-seconds: '10'
+          timeout-state: failure
+
+      - name: Reconcile open PRs on schedule or dispatch
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        # pinned from heurema/repo-governance/actions/codex-review-ready@main
+        uses: heurema/repo-governance/actions/codex-review-ready@5f109136c7a4e9f5a06fdc9422b1aa65d9695b29
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          review-author-logins: chatgpt-codex-connector
+          ignore-outdated: 'true'
+          status-context: codex-review-ready
+          poll-seconds: '0'
+          poll-interval-seconds: '10'
+          timeout-state: pending
+          max-open-prs: '50'

--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -10,16 +10,6 @@ on:
       - labeled
       - unlabeled
       - ready_for_review
-  pull_request_review:
-    types:
-      - submitted
-      - edited
-      - dismissed
-  pull_request_review_comment:
-    types:
-      - created
-      - edited
-      - deleted
 
 permissions:
   contents: read
@@ -42,7 +32,7 @@ jobs:
 
       - name: Run PR intake gate
         # pinned from heurema/repo-governance/actions/pr-intake-gate@main
-        uses: heurema/repo-governance/actions/pr-intake-gate@655ca032dabaed8d66537ae2ac4890a71dc3bd94
+        uses: heurema/repo-governance/actions/pr-intake-gate@5f109136c7a4e9f5a06fdc9422b1aa65d9695b29
         with:
           policy-path: .github/pr-intake-gate.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/fixtures/github-action-pins.json
+++ b/tests/fixtures/github-action-pins.json
@@ -8,6 +8,32 @@
   ],
   "pins": [
     {
+      "file": ".github/workflows/codex-review-ready.yml",
+      "occurrence": 1,
+      "uses": "heurema/repo-governance/actions/codex-review-ready@5f109136c7a4e9f5a06fdc9422b1aa65d9695b29",
+      "kind": "external_action",
+      "action": "heurema/repo-governance/actions/codex-review-ready",
+      "status": "pinned",
+      "originalRef": "main",
+      "pinnedSha": "5f109136c7a4e9f5a06fdc9422b1aa65d9695b29",
+      "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
+      "resolution": "git rev-parse heurema/repo-governance main",
+      "peeledTagUsed": false
+    },
+    {
+      "file": ".github/workflows/codex-review-ready.yml",
+      "occurrence": 2,
+      "uses": "heurema/repo-governance/actions/codex-review-ready@5f109136c7a4e9f5a06fdc9422b1aa65d9695b29",
+      "kind": "external_action",
+      "action": "heurema/repo-governance/actions/codex-review-ready",
+      "status": "pinned",
+      "originalRef": "main",
+      "pinnedSha": "5f109136c7a4e9f5a06fdc9422b1aa65d9695b29",
+      "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
+      "resolution": "git rev-parse heurema/repo-governance main",
+      "peeledTagUsed": false
+    },
+    {
       "file": ".github/workflows/ci.yml",
       "occurrence": 1,
       "uses": "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
@@ -49,12 +75,12 @@
     {
       "file": ".github/workflows/pr-intake-gate.yml",
       "occurrence": 2,
-      "uses": "heurema/repo-governance/actions/pr-intake-gate@655ca032dabaed8d66537ae2ac4890a71dc3bd94",
+      "uses": "heurema/repo-governance/actions/pr-intake-gate@5f109136c7a4e9f5a06fdc9422b1aa65d9695b29",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/pr-intake-gate",
       "status": "pinned",
       "originalRef": "main",
-      "pinnedSha": "655ca032dabaed8d66537ae2ac4890a71dc3bd94",
+      "pinnedSha": "5f109136c7a4e9f5a06fdc9422b1aa65d9695b29",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
       "resolution": "git rev-parse heurema/repo-governance main",
       "peeledTagUsed": false

--- a/tests/fixtures/github-runner-labels.json
+++ b/tests/fixtures/github-runner-labels.json
@@ -9,6 +9,17 @@
   "mutableLatestAllowlist": [],
   "runners": [
     {
+      "file": ".github/workflows/codex-review-ready.yml",
+      "occurrence": 1,
+      "context": "jobs.codex-review-ready",
+      "runsOn": "ubuntu-24.04",
+      "classification": "fixed_github_hosted_runner",
+      "status": "pinned",
+      "originalLabel": "ubuntu-latest",
+      "pinnedLabel": "ubuntu-24.04",
+      "reason": "Codex Review Ready uses Python standard library only; pinned to fixed GitHub-hosted Ubuntu 24.04 image for reproducible status reconciliation."
+    },
+    {
       "file": ".github/workflows/ci.yml",
       "occurrence": 1,
       "context": "jobs.deterministic-tests",


### PR DESCRIPTION
## Summary

- Add pinned `codex-review-ready` workflow using repo-governance `5f109136c7a4e9f5a06fdc9422b1aa65d9695b29`.
- Update `pr-intake-gate` to the same repo-governance SHA.
- Keep `pr-intake-gate` on `pull_request_target` only; review/comment events now belong to the read/status-only ready reconciler.
- Update GitHub action pin inventory.

## Issue ID

- N/A. Operational follow-up from late Codex Review comments on `heurema/signum#74`.

## Test plan

- `tests/test-github-action-pinning.sh`
- `git diff --check`
- Ruby YAML parse for changed workflows