### PR TITLE
ci(codex): bump repo-governance action pin

### DIFF
--- a/.github/workflows/codex-review-ready.yml
+++ b/.github/workflows/codex-review-ready.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Reconcile Codex Review ready status
         if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
         # pinned from heurema/repo-governance/actions/codex-review-ready@main
-        uses: heurema/repo-governance/actions/codex-review-ready@5f109136c7a4e9f5a06fdc9422b1aa65d9695b29
+        uses: heurema/repo-governance/actions/codex-review-ready@a1f0c72edbbbe0513471b973e5afc799e7c51da1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           review-author-logins: chatgpt-codex-connector
@@ -50,7 +50,7 @@ jobs:
       - name: Reconcile open PRs on schedule or dispatch
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         # pinned from heurema/repo-governance/actions/codex-review-ready@main
-        uses: heurema/repo-governance/actions/codex-review-ready@5f109136c7a4e9f5a06fdc9422b1aa65d9695b29
+        uses: heurema/repo-governance/actions/codex-review-ready@a1f0c72edbbbe0513471b973e5afc799e7c51da1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           review-author-logins: chatgpt-codex-connector

--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run PR intake gate
         # pinned from heurema/repo-governance/actions/pr-intake-gate@main
-        uses: heurema/repo-governance/actions/pr-intake-gate@5f109136c7a4e9f5a06fdc9422b1aa65d9695b29
+        uses: heurema/repo-governance/actions/pr-intake-gate@a1f0c72edbbbe0513471b973e5afc799e7c51da1
         with:
           policy-path: .github/pr-intake-gate.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/fixtures/github-action-pins.json
+++ b/tests/fixtures/github-action-pins.json
@@ -10,12 +10,12 @@
     {
       "file": ".github/workflows/codex-review-ready.yml",
       "occurrence": 1,
-      "uses": "heurema/repo-governance/actions/codex-review-ready@5f109136c7a4e9f5a06fdc9422b1aa65d9695b29",
+      "uses": "heurema/repo-governance/actions/codex-review-ready@a1f0c72edbbbe0513471b973e5afc799e7c51da1",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/codex-review-ready",
       "status": "pinned",
       "originalRef": "main",
-      "pinnedSha": "5f109136c7a4e9f5a06fdc9422b1aa65d9695b29",
+      "pinnedSha": "a1f0c72edbbbe0513471b973e5afc799e7c51da1",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
       "resolution": "git rev-parse heurema/repo-governance main",
       "peeledTagUsed": false
@@ -23,12 +23,12 @@
     {
       "file": ".github/workflows/codex-review-ready.yml",
       "occurrence": 2,
-      "uses": "heurema/repo-governance/actions/codex-review-ready@5f109136c7a4e9f5a06fdc9422b1aa65d9695b29",
+      "uses": "heurema/repo-governance/actions/codex-review-ready@a1f0c72edbbbe0513471b973e5afc799e7c51da1",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/codex-review-ready",
       "status": "pinned",
       "originalRef": "main",
-      "pinnedSha": "5f109136c7a4e9f5a06fdc9422b1aa65d9695b29",
+      "pinnedSha": "a1f0c72edbbbe0513471b973e5afc799e7c51da1",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
       "resolution": "git rev-parse heurema/repo-governance main",
       "peeledTagUsed": false
@@ -75,12 +75,12 @@
     {
       "file": ".github/workflows/pr-intake-gate.yml",
       "occurrence": 2,
-      "uses": "heurema/repo-governance/actions/pr-intake-gate@5f109136c7a4e9f5a06fdc9422b1aa65d9695b29",
+      "uses": "heurema/repo-governance/actions/pr-intake-gate@a1f0c72edbbbe0513471b973e5afc799e7c51da1",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/pr-intake-gate",
       "status": "pinned",
       "originalRef": "main",
-      "pinnedSha": "5f109136c7a4e9f5a06fdc9422b1aa65d9695b29",
+      "pinnedSha": "a1f0c72edbbbe0513471b973e5afc799e7c51da1",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
       "resolution": "git rev-parse heurema/repo-governance main",
       "peeledTagUsed": false


### PR DESCRIPTION
## Summary

- Bump pinned `repo-governance` action refs to `a1f0c72edbbbe0513471b973e5afc799e7c51da1`.
- Pick up the `codex-review-ready` guidance that tells agents to resolve linked GitHub review conversations after handling Codex findings.
- Keep workflow behavior and required contexts unchanged.

## Issue ID

- Follow-up to heurema/repo-governance#14.

## Test plan

- `tests/test-github-action-pinning.sh`
- `git diff --check`
- Ruby YAML parse for `.github/workflows/*.yml`

## Risk

- narrow - pinned action SHA bump only.