### PR TITLE
[codex] Add Go support to Codebase Awareness scanner

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -81,7 +81,7 @@ Hard stop if `openQuestions` is non-empty — the user must answer before procee
 ### Phase 2: EXECUTE
 
 1. **Baseline capture** — orchestrator runs lint/typecheck/tests BEFORE any changes and saves `baseline.json` under the active contract artifact root.
-2. **Codebase Awareness context** — when enabled with `SIGNUM_CODEBASE_AWARENESS=hint|warn|gate`, orchestrator writes the derived project cache under `.signum/cache/` and run-scoped `implementation_context.json` / `reuse_candidates.json` under the active contract artifact root. The rebuildable project cache includes `codebase-index-v1.json`, `style-profile-v1.json`, and `file-digests-v1.json`; the digest cache supports bounded/incremental lexical scanning only and does not introduce AST, semantic, or adapter scanning.
+2. **Codebase Awareness context** — when enabled with `SIGNUM_CODEBASE_AWARENESS=hint|warn|gate`, orchestrator writes the derived project cache under `.signum/cache/` and run-scoped `implementation_context.json` / `reuse_candidates.json` under the active contract artifact root. The rebuildable project cache includes `codebase-index-v1.json`, `style-profile-v1.json`, and `file-digests-v1.json`; the digest cache supports bounded/incremental lexical scanning only and does not introduce AST or semantic scanning.
 3. **Engineer agent** (sonnet) implements the contract. When Codebase Awareness artifacts exist, the Engineer records `reuse_decision.json` before code changes; `warn` and `gate` modes require it by protocol.
 4. **Reuse decision validation** — after the Engineer returns, `warn` mode emits warnings for missing or invalid `reuse_decision.json` and continues; `gate` mode blocks EXECUTE on missing or invalid decisions. PACK summarizes this evidence later in `reuse_summary.json`.
 5. **Scope gate** — deterministic check that all modified files are within `inScope` or `allowNewFilesUnder`. Pipeline stops on scope violation.
@@ -119,6 +119,8 @@ Canonical run artifacts live under the active contract artifact root `.signum/co
 `.signum/cache/file-digests-v1.json` is a rebuildable project-level Codebase Awareness cache. It is not active contract root evidence, not run-scoped evidence, and not a proofpack payload. The scanner may use it with `--previous-digests` as a bounded incremental foundation, but the current cache remains lexical and does not add AST or semantic scanning.
 
 The scanner defaults are bounded: `--max-files 10000`, `--max-bytes 50000000`, and `--max-file-size 1048576`. Files over the per-file cap are skipped, and repository-level caps mark the scan as truncated while still producing degraded cache/index artifacts.
+
+Codebase Awareness has shallow Go lexical/symbol support. It detects `go.mod`, `go.work`, `.go` files, Go package names/imports, exported symbols, `internal/`, `cmd/`, `pkg/`, `testdata/`, and `*_test.go` conventions. Go import resolution is local and module-path based when possible; it does not run `go list`, perform AST or type checking, or add Rust/C# adapters.
 
 | File | Phase | Contents |
 |------|-------|----------|

--- a/platforms/claude-code/docs/reference.md
+++ b/platforms/claude-code/docs/reference.md
@@ -81,7 +81,7 @@ Hard stop if `openQuestions` is non-empty — the user must answer before procee
 ### Phase 2: EXECUTE
 
 1. **Baseline capture** — orchestrator runs lint/typecheck/tests BEFORE any changes and saves `baseline.json` under the active contract artifact root.
-2. **Codebase Awareness context** — when enabled with `SIGNUM_CODEBASE_AWARENESS=hint|warn|gate`, orchestrator writes the derived project cache under `.signum/cache/` and run-scoped `implementation_context.json` / `reuse_candidates.json` under the active contract artifact root. The rebuildable project cache includes `codebase-index-v1.json`, `style-profile-v1.json`, and `file-digests-v1.json`; the digest cache supports bounded/incremental lexical scanning only and does not introduce AST, semantic, or adapter scanning.
+2. **Codebase Awareness context** — when enabled with `SIGNUM_CODEBASE_AWARENESS=hint|warn|gate`, orchestrator writes the derived project cache under `.signum/cache/` and run-scoped `implementation_context.json` / `reuse_candidates.json` under the active contract artifact root. The rebuildable project cache includes `codebase-index-v1.json`, `style-profile-v1.json`, and `file-digests-v1.json`; the digest cache supports bounded/incremental lexical scanning only and does not introduce AST or semantic scanning.
 3. **Engineer agent** (sonnet) implements the contract. When Codebase Awareness artifacts exist, the Engineer records `reuse_decision.json` before code changes; `warn` and `gate` modes require it by protocol.
 4. **Reuse decision validation** — after the Engineer returns, `warn` mode emits warnings for missing or invalid `reuse_decision.json` and continues; `gate` mode blocks EXECUTE on missing or invalid decisions. PACK summarizes this evidence later in `reuse_summary.json`.
 5. **Scope gate** — deterministic check that all modified files are within `inScope` or `allowNewFilesUnder`. Pipeline stops on scope violation.
@@ -119,6 +119,8 @@ Canonical run artifacts live under the active contract artifact root `.signum/co
 `.signum/cache/file-digests-v1.json` is a rebuildable project-level Codebase Awareness cache. It is not active contract root evidence, not run-scoped evidence, and not a proofpack payload. The scanner may use it with `--previous-digests` as a bounded incremental foundation, but the current cache remains lexical and does not add AST or semantic scanning.
 
 The scanner defaults are bounded: `--max-files 10000`, `--max-bytes 50000000`, and `--max-file-size 1048576`. Files over the per-file cap are skipped, and repository-level caps mark the scan as truncated while still producing degraded cache/index artifacts.
+
+Codebase Awareness has shallow Go lexical/symbol support. It detects `go.mod`, `go.work`, `.go` files, Go package names/imports, exported symbols, `internal/`, `cmd/`, `pkg/`, `testdata/`, and `*_test.go` conventions. Go import resolution is local and module-path based when possible; it does not run `go list`, perform AST or type checking, or add Rust/C# adapters.
 
 | File | Phase | Contents |
 |------|-------|----------|

--- a/platforms/codex/SKILL.md
+++ b/platforms/codex/SKILL.md
@@ -128,7 +128,9 @@ Within that active contract root, create and use:
 
 Also ensure root `.signum/` is ignored by git when appropriate.
 
-Project-level Codebase Awareness caches under `.signum/cache/`, including `file-digests-v1.json`, are rebuildable scanner cache, not active contract root evidence and not proofpack payloads. The digest cache supports bounded/incremental lexical scanning only; it does not add AST, semantic, or adapter scanning. Scanner defaults are bounded at `--max-files 10000`, `--max-bytes 50000000`, and `--max-file-size 1048576`.
+Project-level Codebase Awareness caches under `.signum/cache/`, including `file-digests-v1.json`, are rebuildable scanner cache, not active contract root evidence and not proofpack payloads. The digest cache supports bounded/incremental lexical scanning only; it does not add AST or semantic scanning. Scanner defaults are bounded at `--max-files 10000`, `--max-bytes 50000000`, and `--max-file-size 1048576`.
+
+Codebase Awareness has shallow Go lexical/symbol support. It detects `go.mod`, `go.work`, `.go` files, Go package names/imports, exported symbols, `internal/`, `cmd/`, `pkg/`, `testdata/`, and `*_test.go` conventions. Go import resolution is local and module-path based when possible; it does not run `go list`, perform AST or type checking, or add Rust/C# adapters.
 
 ## Phase 1: CONTRACT
 

--- a/scripts/codebase_awareness/build_candidates.py
+++ b/scripts/codebase_awareness/build_candidates.py
@@ -72,6 +72,22 @@ SCOPE_KEYS = {"acceptancecriteria", "acceptance", "inscope", "scope"}
 RISK_KEYS = {"policy", "policyhints", "risk", "risklevel", "risks"}
 SHARED_DIR_HINTS = {"common", "lib", "shared", "utils"}
 VALIDATION_TOKENS = {"assert", "check", "parse", "schema", "valid", "validate", "validation", "validator"}
+GENERIC_DOMAIN_TOKENS = {
+    "add",
+    "code",
+    "existing",
+    "flow",
+    "go",
+    "golang",
+    "helper",
+    "helpers",
+    "javascript",
+    "python",
+    "rust",
+    "shell",
+    "task",
+    "typescript",
+}
 
 SUGGESTED_ACTION_BY_KIND = {
     "config-pattern": "follow-pattern",
@@ -468,6 +484,14 @@ def add_draft(
     draft["record"].append(record)
 
 
+def shared_symbol_record(record: dict[str, Any], name: str) -> dict[str, Any]:
+    symbol_record = dict(record)
+    symbol_record["name"] = name
+    symbol_record["tokens"] = split_identifier(name)
+    symbol_record["symbols"] = [name]
+    return symbol_record
+
+
 def build_drafts(codebase_index: dict[str, Any], style_profile: dict[str, Any]) -> dict[tuple[str, str, str], dict[str, Any]]:
     drafts: dict[tuple[str, str, str], dict[str, Any]] = {}
 
@@ -501,7 +525,7 @@ def build_drafts(codebase_index: dict[str, Any], style_profile: dict[str, Any]) 
                     language=language,
                     source_artifact="codebase-index-v1.json",
                     source_section="sharedCandidates",
-                    record=record,
+                    record=shared_symbol_record(record, name),
                     base_why=["symbol is exposed from a shared candidate module"],
                 )
 
@@ -707,6 +731,35 @@ def go_internal_allowed(candidate_path: str, target_paths: list[str]) -> bool | 
     return False
 
 
+def validation_domain_overlap(intent_tokens: set[str], candidate_tokens: set[str]) -> list[str]:
+    return sorted((intent_tokens & candidate_tokens) - VALIDATION_TOKENS - GENERIC_DOMAIN_TOKENS)
+
+
+def validation_symbol_tokens(draft: dict[str, Any], symbol_text: str, candidate_tokens: set[str]) -> set[str]:
+    tokens = tokenize_text(symbol_text)
+    if tokens:
+        if tokens & VALIDATION_TOKENS:
+            return tokens
+        if candidate_tokens & VALIDATION_TOKENS:
+            return tokens | (candidate_tokens & VALIDATION_TOKENS)
+        return set()
+
+    helper_tokens: set[str] = set()
+    for record in draft.get("record", []):
+        if not isinstance(record, dict):
+            continue
+        for symbol in as_list(record.get("symbols")):
+            name = symbol if isinstance(symbol, str) else record_symbol(symbol)
+            symbol_tokens = tokenize_text(name or "")
+            if symbol_tokens & VALIDATION_TOKENS:
+                helper_tokens.update(symbol_tokens)
+    if helper_tokens:
+        return helper_tokens
+    if candidate_tokens & VALIDATION_TOKENS:
+        return candidate_tokens
+    return set()
+
+
 def score_draft(draft: dict[str, Any], task_intent: dict[str, Any], languages: set[str]) -> dict[str, Any] | None:
     intent_tokens = set(task_intent.get("tokens", []))
     target_paths = [str(path) for path in task_intent.get("targetPaths", [])]
@@ -784,18 +837,17 @@ def score_draft(draft: dict[str, Any], task_intent: dict[str, Any], languages: s
         score += 0.03
         confidence += 0.015
 
-    if (
-        kind in {"existing-helper", "shared-module"}
-        and (intent_tokens & VALIDATION_TOKENS)
-        and (candidate_tokens & VALIDATION_TOKENS)
-        and ("email" not in intent_tokens or "email" in candidate_tokens)
-    ):
-        why.append("validation-specific helper signal")
-        score += 0.12
-        confidence += 0.06
-    if kind in {"existing-helper", "shared-module"} and "email" in intent_tokens and "email" in candidate_tokens:
-        score += 0.06
-        confidence += 0.03
+    validation_tokens = validation_symbol_tokens(draft, symbol_text, candidate_tokens)
+    if kind in {"existing-helper", "shared-module"} and (intent_tokens & VALIDATION_TOKENS) and validation_tokens:
+        why.append("validation helper signal")
+        domain_overlap = validation_domain_overlap(intent_tokens, validation_tokens)
+        if domain_overlap:
+            why.append(f"domain terms matched validation helper: {','.join(domain_overlap[:6])}")
+            score += 0.12 + min(0.12, 0.06 * len(domain_overlap))
+            confidence += 0.06 + min(0.06, 0.03 * len(domain_overlap))
+        else:
+            score += 0.08
+            confidence += 0.04
 
     internal_allowed = go_internal_allowed(path, target_paths)
     if internal_allowed is True:

--- a/scripts/codebase_awareness/build_candidates.py
+++ b/scripts/codebase_awareness/build_candidates.py
@@ -71,6 +71,7 @@ SUMMARY_KEYS = {"goal", "objective", "summary", "task", "title"}
 SCOPE_KEYS = {"acceptancecriteria", "acceptance", "inscope", "scope"}
 RISK_KEYS = {"policy", "policyhints", "risk", "risklevel", "risks"}
 SHARED_DIR_HINTS = {"common", "lib", "shared", "utils"}
+VALIDATION_TOKENS = {"assert", "check", "parse", "schema", "valid", "validate", "validation", "validator"}
 
 SUGGESTED_ACTION_BY_KIND = {
     "config-pattern": "follow-pattern",
@@ -372,7 +373,9 @@ def is_test_path(path: str | None) -> bool:
     return (
         "test" in parts
         or "tests" in parts
+        or "testdata" in parts
         or name.startswith("test_")
+        or name.endswith("_test.go")
         or name.endswith("_test.py")
         or ".test." in name
         or ".spec." in name
@@ -439,6 +442,25 @@ def add_draft(
             draft["pairedTests"].append(test_path)
     if isinstance(record, dict) and record.get("exported") is True:
         draft["exported"] = True
+    if isinstance(record, dict) and "exported-symbols" in as_list(record.get("reasons")):
+        draft["exported"] = True
+    if isinstance(record, dict):
+        for hint in as_list(record.get("boundaryHints")):
+            if not isinstance(hint, dict):
+                continue
+            kind_value = str(hint.get("kind") or "")
+            if kind_value == "go-internal":
+                risk = "Go internal package boundary; verify the importing path is allowed before reuse."
+                if risk not in draft["risks"]:
+                    draft["risks"].append(risk)
+            elif kind_value == "go-pkg":
+                why = "pkg/ is a weak Go reusable package convention"
+                if why not in draft["why"]:
+                    draft["why"].append(why)
+            elif kind_value == "go-cmd":
+                risk = "Go cmd/ package is an executable entrypoint boundary, not a generic helper."
+                if risk not in draft["risks"]:
+                    draft["risks"].append(risk)
     if kind == "duplicate-risk":
         reason = "similar or repeated code fingerprint reported by scanner"
         if reason not in draft["risks"]:
@@ -519,6 +541,22 @@ def build_drafts(codebase_index: dict[str, Any], style_profile: dict[str, Any]) 
             source_section="modules",
             record=record,
             base_why=["module is present in scanner index"],
+        )
+
+    for record in as_list(codebase_index.get("moduleBoundaries")):
+        path = record_path(record)
+        if not path:
+            continue
+        add_draft(
+            drafts,
+            kind="module-boundary",
+            path=path,
+            symbol=None,
+            language=record_language(record, path),
+            source_artifact="codebase-index-v1.json",
+            source_section="moduleBoundaries",
+            record=record,
+            base_why=["scanner reported module boundary convention"],
         )
 
     for record in as_list(codebase_index.get("imports")):
@@ -634,6 +672,8 @@ def desired_languages(task_intent: dict[str, Any], codebase_index: dict[str, Any
             languages.add(language)
     token_map = {
         "javascript": "javascript",
+        "go": "go",
+        "golang": "go",
         "js": "javascript",
         "py": "python",
         "python": "python",
@@ -650,6 +690,23 @@ def desired_languages(task_intent: dict[str, Any], codebase_index: dict[str, Any
     return languages
 
 
+def go_internal_allowed(candidate_path: str, target_paths: list[str]) -> bool | None:
+    parts = Path(candidate_path).parts
+    if "internal" not in parts:
+        return None
+    internal_index = parts.index("internal")
+    allowed_root = "/".join(parts[:internal_index])
+    if not target_paths:
+        return None
+    if not allowed_root:
+        return True
+    for target in target_paths:
+        normalized = str(target).strip("/")
+        if normalized == allowed_root or normalized.startswith(f"{allowed_root}/"):
+            return True
+    return False
+
+
 def score_draft(draft: dict[str, Any], task_intent: dict[str, Any], languages: set[str]) -> dict[str, Any] | None:
     intent_tokens = set(task_intent.get("tokens", []))
     target_paths = [str(path) for path in task_intent.get("targetPaths", [])]
@@ -663,6 +720,8 @@ def score_draft(draft: dict[str, Any], task_intent: dict[str, Any], languages: s
     score = 0.05
     confidence = 0.32
     why: list[str] = []
+    risks = [str(risk) for risk in draft.get("risks", []) if risk]
+    kind = str(draft.get("kind"))
     for item in draft.get("why", []):
         if item and item not in why:
             why.append(str(item))
@@ -725,7 +784,28 @@ def score_draft(draft: dict[str, Any], task_intent: dict[str, Any], languages: s
         score += 0.03
         confidence += 0.015
 
-    kind = str(draft.get("kind"))
+    if (
+        kind in {"existing-helper", "shared-module"}
+        and (intent_tokens & VALIDATION_TOKENS)
+        and (candidate_tokens & VALIDATION_TOKENS)
+        and ("email" not in intent_tokens or "email" in candidate_tokens)
+    ):
+        why.append("validation-specific helper signal")
+        score += 0.12
+        confidence += 0.06
+    if kind in {"existing-helper", "shared-module"} and "email" in intent_tokens and "email" in candidate_tokens:
+        score += 0.06
+        confidence += 0.03
+
+    internal_allowed = go_internal_allowed(path, target_paths)
+    if internal_allowed is True:
+        why.append("within Go internal package boundary")
+        confidence += 0.02
+    elif internal_allowed is False:
+        risks.append("Go internal package boundary may reject imports from the contract target path.")
+        score -= 0.08
+        confidence -= 0.04
+
     if kind in {"test-pattern", "error-handling-pattern", "config-pattern", "local-pattern"}:
         score += 0.08
         confidence += 0.05
@@ -764,7 +844,7 @@ def score_draft(draft: dict[str, Any], task_intent: dict[str, Any], languages: s
         "whyRelevant": dedupe_preserve_order(why),
         "suggestedAction": SUGGESTED_ACTION_BY_KIND.get(kind, "inspect-before-editing"),
         "exampleCallsites": sorted(set(draft.get("exampleCallsites", [])))[:8],
-        "risks": sorted(set(draft.get("risks", [])))[:8],
+        "risks": sorted(set(risks))[:8],
         "source": draft.get("source"),
     }
 
@@ -823,6 +903,7 @@ def dominant_conventions(style_profile: dict[str, Any]) -> dict[str, list[str]]:
         "logging": [summarize_convention(item) for item in as_list(style_profile.get("logging"))][:6],
         "config": [summarize_convention(item) for item in as_list(style_profile.get("config"))][:6],
         "validation": [summarize_convention(item) for item in as_list(style_profile.get("validation"))][:6],
+        "go": [summarize_convention(item) for item in as_list(style_profile.get("goConventions"))][:6],
     }
 
 
@@ -858,11 +939,14 @@ def nearby_modules(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return nearby
 
 
-def module_boundaries(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def module_boundaries(candidates: list[dict[str, Any]], codebase_index: dict[str, Any]) -> list[dict[str, Any]]:
     boundaries = []
+    seen: set[tuple[str, str]] = set()
     for candidate in candidates:
         if candidate.get("kind") != "module-boundary":
             continue
+        key = (str(candidate.get("path") or ""), "")
+        seen.add(key)
         boundaries.append(
             {
                 "path": candidate.get("path"),
@@ -871,6 +955,26 @@ def module_boundaries(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "whyRelevant": candidate.get("whyRelevant", [])[:3],
             }
         )
+        if len(boundaries) >= 6:
+            return boundaries
+    for record in as_list(codebase_index.get("moduleBoundaries")):
+        if not isinstance(record, dict):
+            continue
+        path = str(record.get("path") or "")
+        kind = str(record.get("kind") or "")
+        key = (path, kind)
+        if not path or key in seen:
+            continue
+        seen.add(key)
+        entry = {
+            "path": path,
+            "language": record.get("language"),
+            "kind": kind,
+            "whyRelevant": [str(record.get("value") or kind)],
+        }
+        if "weak" in record:
+            entry["weak"] = record.get("weak")
+        boundaries.append(entry)
         if len(boundaries) >= 6:
             break
     return boundaries
@@ -956,7 +1060,7 @@ def build_outputs(
         "targetAreas": target_areas(task_intent, candidates),
         "nearbyModules": nearby_modules(candidates),
         "dominantConventions": dominant_conventions(style_profile),
-        "moduleBoundaries": module_boundaries(candidates),
+        "moduleBoundaries": module_boundaries(candidates, codebase_index),
         "candidateSummary": candidate_summary(candidates),
         "notes": notes,
     }

--- a/scripts/codebase_awareness/build_index.py
+++ b/scripts/codebase_awareness/build_index.py
@@ -39,6 +39,7 @@ IGNORE_DIRS = {
     "dist",
     "node_modules",
     "target",
+    "vendor",
     "venv",
 }
 BUILD_OUTPUT_DIRS = {"bin", "obj"}
@@ -56,6 +57,7 @@ GENERATED_MARKER_RE = re.compile(
       @generated\b
       | auto-generated\b
       | automatically\ generated\b
+      | code\ generated\b
       | generated\ by\b
       | this\ file\ (?:is|was)\ generated\b
       | do\ not\ edit\b
@@ -87,6 +89,7 @@ SOURCE_LANGUAGES = {"go", "javascript", "python", "rust", "shell", "typescript"}
 MANIFEST_NAMES = {
     "Cargo.toml": "cargo",
     "go.mod": "go",
+    "go.work": "go-work",
     "package-lock.json": "npm",
     "package.json": "npm",
     "pnpm-lock.yaml": "npm",
@@ -98,6 +101,7 @@ MANIFEST_NAMES = {
 }
 SHARED_DIR_HINTS = {"common", "lib", "shared", "utils"}
 VALIDATION_TOKENS = {"assert", "check", "parse", "schema", "valid", "validate", "validation", "validator"}
+GO_TEST_FUNCTION_RE = re.compile(r"^\s*func\s+((?:Test|Benchmark|Fuzz)[A-Za-z0-9_]*)\s*\(", re.MULTILINE)
 
 
 @dataclass(frozen=True)
@@ -201,6 +205,7 @@ def language_for_path(rel: str) -> str | None:
         return {
             "cargo": "toml",
             "go": "go",
+            "go-work": "go",
             "npm": "json" if path.suffix == ".json" else "yaml",
             "python": "toml" if path.suffix == ".toml" else "python",
         }.get(MANIFEST_NAMES[path.name])
@@ -385,10 +390,19 @@ def is_test_path(rel: str) -> bool:
         "test" in parts
         or "tests" in parts
         or name.startswith("test_")
+        or name.endswith("_test.go")
         or name.endswith("_test.py")
         or ".test." in name
         or ".spec." in name
     )
+
+
+def is_go_test_path(rel: str) -> bool:
+    return Path(rel).name.endswith("_test.go")
+
+
+def is_test_fixture_path(rel: str) -> bool:
+    return "testdata" in Path(rel).parts
 
 
 def module_kind(rel: str) -> str:
@@ -401,7 +415,119 @@ def module_kind(rel: str) -> str:
     return "support"
 
 
+def is_exported_go_identifier(name: str) -> bool:
+    return bool(name) and "A" <= name[0] <= "Z"
+
+
+def extract_go_package_name(text: str) -> str | None:
+    match = re.search(r"^\s*package\s+([A-Za-z_][A-Za-z0-9_]*)\b", text, flags=re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def normalize_go_receiver(receiver: str) -> str | None:
+    receiver = receiver.strip()
+    if not receiver:
+        return None
+    parts = receiver.split()
+    raw_type = parts[-1] if parts else receiver
+    raw_type = raw_type.lstrip("*")
+    raw_type = raw_type.split(".")[-1]
+    raw_type = raw_type.split("[", 1)[0]
+    raw_type = re.sub(r"[^A-Za-z0-9_]", "", raw_type)
+    return raw_type or None
+
+
+def go_symbol_entry(
+    *,
+    name: str,
+    kind: str,
+    rel: str,
+    line_number: int,
+    receiver: str | None = None,
+) -> dict[str, Any]:
+    tokens = set(split_identifier(name))
+    if receiver:
+        tokens.update(split_identifier(receiver))
+    return {
+        "name": name,
+        "kind": kind,
+        "language": "go",
+        "path": rel,
+        "line": line_number,
+        "exported": is_exported_go_identifier(name),
+        "tokens": sorted(tokens),
+        "receiver": receiver,
+    }
+
+
+def extract_go_symbols(rel: str, text: str) -> list[dict[str, Any]]:
+    symbols: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str | None]] = set()
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        func_match = re.search(
+            r"^\s*func\s+(?:\((?P<receiver>[^)]*)\)\s*)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+            line,
+        )
+        if func_match:
+            receiver = normalize_go_receiver(func_match.group("receiver") or "")
+            name = func_match.group("name")
+            kind = "method" if receiver else "function"
+            key = (kind, name, receiver)
+            if key not in seen:
+                seen.add(key)
+                symbols.append(
+                    go_symbol_entry(
+                        name=name,
+                        kind=kind,
+                        rel=rel,
+                        line_number=line_number,
+                        receiver=receiver,
+                    )
+                )
+            continue
+
+        type_match = re.search(r"^\s*type\s+([A-Za-z_][A-Za-z0-9_]*)\b", line)
+        if type_match:
+            name = type_match.group(1)
+            key = ("type", name, None)
+            if key not in seen:
+                seen.add(key)
+                symbols.append(go_symbol_entry(name=name, kind="type", rel=rel, line_number=line_number))
+            continue
+
+        value_match = re.search(r"^\s*(const|var)\s+([A-Za-z_][A-Za-z0-9_]*)\b", line)
+        if value_match:
+            kind = "constant" if value_match.group(1) == "const" else "variable"
+            name = value_match.group(2)
+            key = (kind, name, None)
+            if key not in seen:
+                seen.add(key)
+                symbols.append(go_symbol_entry(name=name, kind=kind, rel=rel, line_number=line_number))
+            continue
+
+        grouped_value_match = re.search(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:=|[A-Za-z_\*])", line)
+        if grouped_value_match and symbols:
+            previous_kind = symbols[-1].get("kind")
+            if previous_kind in {"constant", "variable"}:
+                name = grouped_value_match.group(1)
+                key = (str(previous_kind), name, None)
+                if key not in seen:
+                    seen.add(key)
+                    symbols.append(
+                        go_symbol_entry(
+                            name=name,
+                            kind=str(previous_kind),
+                            rel=rel,
+                            line_number=line_number,
+                        )
+                    )
+    return symbols
+
+
 def extract_symbols(rel: str, language: str | None, text: str) -> list[dict[str, Any]]:
+    if language == "go":
+        return extract_go_symbols(rel, text)
+
     patterns: list[tuple[str, str, str]] = []
     if language in {"javascript", "typescript"}:
         patterns = [
@@ -473,7 +599,188 @@ def extract_import_specs(language: str | None, text: str) -> list[str]:
     return sorted(set(specs))
 
 
-def resolve_import(source_rel: str, spec: str, known_files: set[str]) -> str | None:
+def strip_go_line_comment(line: str) -> str:
+    in_string = False
+    escaped = False
+    quote = ""
+    for index, char in enumerate(line):
+        if in_string:
+            if escaped:
+                escaped = False
+                continue
+            if char == "\\":
+                escaped = True
+                continue
+            if char == quote:
+                in_string = False
+                quote = ""
+            continue
+        if char in {"\"", "`"}:
+            in_string = True
+            quote = char
+            continue
+        if char == "/" and index + 1 < len(line) and line[index + 1] == "/":
+            return line[:index]
+    return line
+
+
+def parse_go_import_line(line: str) -> dict[str, Any] | None:
+    line = strip_go_line_comment(line).strip().rstrip(";")
+    if not line or line == ")":
+        return None
+    match = re.match(
+        r"^(?:(?P<alias>\.|\_|[A-Za-z_][A-Za-z0-9_]*)\s+)?(?P<quote>\"[^\"]+\"|`[^`]+`)$",
+        line,
+    )
+    if not match:
+        return None
+    alias = match.group("alias")
+    imported = match.group("quote")[1:-1]
+    if alias == "_":
+        import_kind = "blank"
+    elif alias == ".":
+        import_kind = "dot"
+    elif alias:
+        import_kind = "aliased"
+    else:
+        import_kind = "package"
+    return {
+        "imported": imported,
+        "alias": alias,
+        "importKind": import_kind,
+        "tokens": sorted(set(split_identifier(imported))),
+    }
+
+
+def extract_go_import_records(text: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    in_block = False
+    for line in text.splitlines():
+        stripped = strip_go_line_comment(line).strip()
+        if not in_block:
+            single = re.match(r"^import\s+(?!\()(.*)$", stripped)
+            if single:
+                record = parse_go_import_line(single.group(1))
+                if record:
+                    records.append(record)
+                continue
+            if re.match(r"^import\s*\($", stripped):
+                in_block = True
+                continue
+        else:
+            if stripped.startswith(")"):
+                in_block = False
+                continue
+            record = parse_go_import_line(stripped)
+            if record:
+                records.append(record)
+    unique: dict[tuple[str, str | None], dict[str, Any]] = {}
+    for record in records:
+        unique[(str(record.get("imported")), record.get("alias"))] = record
+    return [unique[key] for key in sorted(unique)]
+
+
+def extract_import_records(language: str | None, text: str) -> list[dict[str, Any]]:
+    if language == "go":
+        return extract_go_import_records(text)
+    return [
+        {
+            "imported": spec,
+            "tokens": sorted(set(split_identifier(spec))),
+        }
+        for spec in extract_import_specs(language, text)
+    ]
+
+
+def normalize_rel_parts(value: str) -> str:
+    parts: list[str] = []
+    for part in value.split("/"):
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if parts:
+                parts.pop()
+            continue
+        parts.append(part)
+    return "/".join(parts)
+
+
+def parse_go_mod_module_path(text: str) -> str | None:
+    match = re.search(r"^\s*module\s+([^\s]+)", text, flags=re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def parse_go_work_uses(text: str) -> list[str]:
+    uses: list[str] = []
+    in_block = False
+    for line in text.splitlines():
+        stripped = strip_go_line_comment(line).strip()
+        if not stripped:
+            continue
+        if in_block:
+            if stripped.startswith(")"):
+                in_block = False
+                continue
+            value = stripped.strip("\"`")
+            if value:
+                uses.append(value)
+            continue
+        match = re.match(r"^use\s+(.+)$", stripped)
+        if not match:
+            continue
+        rest = match.group(1).strip()
+        if rest.startswith("("):
+            in_block = True
+            rest = rest[1:].strip()
+            if not rest:
+                continue
+        if rest and rest != ")":
+            uses.append(rest.strip("\"`"))
+    return sorted(set(uses))
+
+
+def collect_go_modules(indexed_files: list[ScanFile]) -> list[tuple[str, str]]:
+    modules: list[tuple[str, str]] = []
+    for scanned_file in indexed_files:
+        if Path(scanned_file.rel).name != "go.mod":
+            continue
+        module_path = parse_go_mod_module_path(scanned_file.text)
+        if not module_path:
+            continue
+        directory = Path(scanned_file.rel).parent.as_posix()
+        modules.append(("" if directory == "." else directory, module_path))
+    return sorted(modules, key=lambda item: (-len(item[1]), item[0], item[1]))
+
+
+def resolve_go_import(
+    spec: str,
+    go_modules: list[tuple[str, str]],
+    go_package_dirs: set[str],
+) -> str | None:
+    for module_dir, module_path in go_modules:
+        if spec == module_path:
+            candidate = module_dir
+        elif spec.startswith(f"{module_path}/"):
+            suffix = spec[len(module_path) + 1 :]
+            candidate = normalize_rel_parts(f"{module_dir}/{suffix}" if module_dir else suffix)
+        else:
+            continue
+        if candidate in go_package_dirs:
+            return candidate or "."
+    return None
+
+
+def resolve_import(
+    source_rel: str,
+    spec: str,
+    known_files: set[str],
+    *,
+    language: str | None,
+    go_modules: list[tuple[str, str]],
+    go_package_dirs: set[str],
+) -> str | None:
+    if language == "go":
+        return resolve_go_import(spec, go_modules, go_package_dirs)
     if not spec.startswith("."):
         return None
     base = (Path(source_rel).parent / spec).as_posix()
@@ -497,18 +804,7 @@ def resolve_import(source_rel: str, spec: str, known_files: set[str]) -> str | N
         f"{base}/index.cjs",
         f"{base}/__init__.py",
     ]
-    normalized = []
-    for candidate in candidates:
-        parts: list[str] = []
-        for part in candidate.split("/"):
-            if part in {"", "."}:
-                continue
-            if part == "..":
-                if parts:
-                    parts.pop()
-                continue
-            parts.append(part)
-        normalized.append("/".join(parts))
+    normalized = [normalize_rel_parts(candidate) for candidate in candidates]
     for candidate in normalized:
         if candidate in known_files:
             return candidate
@@ -516,6 +812,8 @@ def resolve_import(source_rel: str, spec: str, known_files: set[str]) -> str | N
 
 
 def test_framework_for_path(rel: str, text: str, language: str | None) -> str | None:
+    if language == "go" and is_go_test_path(rel):
+        return "go-test"
     if language in {"javascript", "typescript"}:
         if re.search(r"\bdescribe\s*\(|\bit\s*\(|\btest\s*\(", text):
             return "jest-or-vitest"
@@ -530,7 +828,17 @@ def test_framework_for_path(rel: str, text: str, language: str | None) -> str | 
 
 
 def paired_tests_for(rel: str, tests: list[dict[str, Any]]) -> list[str]:
-    stem = Path(rel).stem
+    path = Path(rel)
+    if path.suffix == "" or str(rel).endswith("/"):
+        package_dir = str(rel).rstrip("/")
+        return sorted(
+            str(test.get("path"))
+            for test in tests
+            if Path(str(test.get("path"))).parent.as_posix() == package_dir
+        )
+    stem = path.stem
+    if stem.endswith("_test"):
+        stem = stem[: -len("_test")]
     if stem.endswith(".test") or stem.endswith(".spec"):
         stem = stem.rsplit(".", 1)[0]
     pairs: list[str] = []
@@ -539,6 +847,56 @@ def paired_tests_for(rel: str, tests: list[dict[str, Any]]) -> list[str]:
         if stem and stem in tokens_for_path(test_path):
             pairs.append(test_path)
     return sorted(set(pairs))
+
+
+def go_boundary_hints_for_path(rel: str) -> list[dict[str, Any]]:
+    path = Path(rel)
+    parts = path.parts
+    hints: list[dict[str, Any]] = []
+    if "internal" in parts:
+        index = parts.index("internal")
+        allowed_root = "/".join(parts[:index]) or "."
+        hints.append(
+            {
+                "kind": "go-internal",
+                "value": "internal package boundary",
+                "allowedRoot": allowed_root,
+                "weak": False,
+            }
+        )
+    if parts and parts[0] == "cmd":
+        hints.append(
+            {
+                "kind": "go-cmd",
+                "value": "executable entrypoint convention",
+                "weak": False,
+            }
+        )
+    if parts and parts[0] == "pkg":
+        hints.append(
+            {
+                "kind": "go-pkg",
+                "value": "reusable package directory convention",
+                "weak": True,
+            }
+        )
+    if "testdata" in parts:
+        hints.append(
+            {
+                "kind": "go-testdata",
+                "value": "test fixture data convention",
+                "weak": False,
+            }
+        )
+    if path.name.endswith("_test.go"):
+        hints.append(
+            {
+                "kind": "go-test-file",
+                "value": "*_test.go test convention",
+                "weak": False,
+            }
+        )
+    return hints
 
 
 def extract_manifest(rel: str, text: str) -> dict[str, Any] | None:
@@ -551,6 +909,17 @@ def extract_manifest(rel: str, text: str) -> dict[str, Any] | None:
         "language": language_for_path(rel),
         "tokens": tokens_for_path(rel),
     }
+    if path.name == "go.mod":
+        module_path = parse_go_mod_module_path(text)
+        if module_path:
+            manifest["modulePath"] = module_path
+            manifest["tokens"] = sorted(set(manifest["tokens"]) | set(split_identifier(module_path)))
+    if path.name == "go.work":
+        workspace_uses = parse_go_work_uses(text)
+        if workspace_uses:
+            manifest["workspaceUses"] = workspace_uses
+            use_tokens = {token for use in workspace_uses for token in split_identifier(use)}
+            manifest["tokens"] = sorted(set(manifest["tokens"]) | use_tokens)
     if path.name == "package.json":
         try:
             data = json.loads(text)
@@ -602,7 +971,9 @@ def build_style_profile(
         path = str(test.get("path", ""))
         language = str(test.get("language") or "")
         name = Path(path).name
-        if ".test." in name:
+        if name.endswith("_test.go"):
+            by_pattern[(language, "*_test.go")].append(path)
+        elif ".test." in name:
             by_pattern[(language, "*.test.*")].append(path)
         elif ".spec." in name:
             by_pattern[(language, "*.spec.*")].append(path)
@@ -619,6 +990,7 @@ def build_style_profile(
     logging: list[dict[str, Any]] = []
     validation: list[dict[str, Any]] = []
     config: list[dict[str, Any]] = []
+    go_conventions: list[dict[str, Any]] = []
     for rel, text in sorted(file_text.items()):
         language = language_for_path(rel)
         if re.search(r"\bthrow\s+new\s+Error\b|\btry\s*\{|\bcatch\s*\(", text):
@@ -629,6 +1001,11 @@ def build_style_profile(
             logging.append(convention_entry("logging", "runtime logging call", language, [rel]))
         if re.search(r"\b(process\.env|os\.environ|getenv)\b", text):
             config.append(convention_entry("config", "environment variable access", language, [rel]))
+        if language == "go" and is_go_test_path(rel):
+            go_conventions.append(convention_entry("go-test-command", "go test", "go", [rel]))
+            package_name = extract_go_package_name(text)
+            if package_name and not package_name.endswith("_test"):
+                go_conventions.append(convention_entry("go-test-scope", "package-local tests", "go", [rel]))
 
     for manifest in manifests:
         config.append(convention_entry("config", f"{manifest.get('kind')} manifest", manifest.get("language"), [str(manifest.get("path"))]))
@@ -641,6 +1018,17 @@ def build_style_profile(
         path = str(module.get("path"))
         if set(module.get("tokens", [])) & VALIDATION_TOKENS:
             validation_paths.add(path)
+        if module.get("language") == "go":
+            for hint in module.get("boundaryHints", []):
+                if isinstance(hint, dict):
+                    go_conventions.append(
+                        convention_entry(
+                            "go-boundary",
+                            str(hint.get("value") or hint.get("kind")),
+                            "go",
+                            [path],
+                        )
+                    )
     for path in sorted(validation_paths):
         validation.append(convention_entry("validation", "validation naming or helper", language_for_path(path), [path]))
 
@@ -648,8 +1036,9 @@ def build_style_profile(
     compact_logging = compact_conventions(logging)
     compact_config = compact_conventions(config)
     compact_validation = compact_conventions(validation)
+    compact_go_conventions = compact_conventions(go_conventions)
     confidence = 0.45
-    for section in (test_conventions, compact_error_handling, compact_logging, compact_config, compact_validation):
+    for section in (test_conventions, compact_error_handling, compact_logging, compact_config, compact_validation, compact_go_conventions):
         if section:
             confidence += 0.08
     if primary_languages:
@@ -666,6 +1055,7 @@ def build_style_profile(
         "logging": compact_logging,
         "config": compact_config,
         "validation": compact_validation,
+        "goConventions": compact_go_conventions,
     }
 
 
@@ -685,6 +1075,122 @@ def compact_conventions(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     ]
 
 
+def build_go_package_modules(
+    modules: list[dict[str, Any]],
+    symbols: list[dict[str, Any]],
+    tests: list[dict[str, Any]],
+    importers_by_target: dict[str, list[str]],
+) -> list[dict[str, Any]]:
+    files_by_dir: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for module in modules:
+        path = str(module.get("path") or "")
+        if module.get("language") != "go" or not path.endswith(".go"):
+            continue
+        if is_test_fixture_path(path):
+            continue
+        directory = str(module.get("directory") or "")
+        files_by_dir[directory].append(module)
+
+    symbols_by_dir: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for symbol in symbols:
+        if symbol.get("language") != "go":
+            continue
+        path = str(symbol.get("path") or "")
+        if is_go_test_path(path):
+            continue
+        symbols_by_dir[Path(path).parent.as_posix() if Path(path).parent.as_posix() != "." else ""].append(symbol)
+
+    go_package_modules: list[dict[str, Any]] = []
+    for directory, package_files in sorted(files_by_dir.items()):
+        source_files = sorted(
+            str(item.get("path"))
+            for item in package_files
+            if str(item.get("path") or "").endswith(".go") and not is_go_test_path(str(item.get("path") or ""))
+        )
+        test_files = sorted(
+            str(item.get("path"))
+            for item in package_files
+            if is_go_test_path(str(item.get("path") or ""))
+        )
+        if not source_files and not test_files:
+            continue
+        package_counts = Counter(
+            str(item.get("package"))
+            for item in package_files
+            if isinstance(item.get("package"), str) and item.get("package")
+        )
+        package_name = ""
+        if package_counts:
+            package_name = sorted(package_counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
+        package_symbols = [
+            str(symbol.get("name"))
+            for symbol in symbols_by_dir.get(directory, [])
+            if symbol.get("exported") and isinstance(symbol.get("name"), str)
+        ]
+        tokens = set(tokens_for_path(directory or package_name or "."))
+        if package_name:
+            tokens.update(split_identifier(package_name))
+        for symbol_name in package_symbols:
+            tokens.update(split_identifier(symbol_name))
+        imported_by = sorted(set(importers_by_target.get(directory, [])))
+        boundary_hints = go_boundary_hints_for_path(directory)
+        module: dict[str, Any] = {
+            "path": directory or ".",
+            "name": package_name or Path(directory).name or ".",
+            "directory": Path(directory).parent.as_posix() if directory and Path(directory).parent.as_posix() != "." else "",
+            "language": "go",
+            "kind": "package",
+            "package": package_name or None,
+            "files": sorted(source_files + test_files),
+            "sourceFiles": source_files,
+            "testFiles": test_files,
+            "tokens": sorted(tokens),
+            "lineCount": sum(int(item.get("lineCount", 0)) for item in package_files),
+            "symbols": sorted(set(package_symbols)),
+            "exportedSymbolCount": len(set(package_symbols)),
+        }
+        if imported_by:
+            module["importedBy"] = imported_by
+            module["importCount"] = len(imported_by)
+        if test_files:
+            module["pairedTests"] = test_files
+        if boundary_hints:
+            module["boundaryHints"] = boundary_hints
+            module["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in boundary_hints)
+        if any(hint.get("kind") == "go-internal" for hint in boundary_hints):
+            module["internalBoundary"] = True
+        if any(hint.get("kind") == "go-cmd" for hint in boundary_hints):
+            module["entrypointBoundary"] = True
+        if any(hint.get("kind") == "go-pkg" for hint in boundary_hints):
+            module["weakReusablePackageConvention"] = True
+        if package_symbols and source_files:
+            module["publicAPICandidate"] = True
+        go_package_modules.append(module)
+    return go_package_modules
+
+
+def collect_module_boundaries(modules: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    boundaries: list[dict[str, Any]] = []
+    for module in modules:
+        for hint in module.get("boundaryHints", []):
+            if not isinstance(hint, dict):
+                continue
+            entry = {
+                "path": module.get("path"),
+                "language": module.get("language"),
+                "kind": hint.get("kind"),
+                "value": hint.get("value"),
+                "weak": hint.get("weak", False),
+            }
+            if hint.get("allowedRoot"):
+                entry["allowedRoot"] = hint.get("allowedRoot")
+            boundaries.append(entry)
+    return sorted(
+        boundaries,
+        key=lambda item: (str(item.get("path")), str(item.get("kind")), str(item.get("value"))),
+    )
+
+
 def build_index(
     project_root_arg: str,
     generated_at: str,
@@ -692,6 +1198,12 @@ def build_index(
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
     indexed_files = [file for file in scan.files if file.indexed]
     known_files = {file.rel for file in indexed_files}
+    go_modules = collect_go_modules(indexed_files)
+    go_package_dirs = {
+        Path(file.rel).parent.as_posix() if Path(file.rel).parent.as_posix() != "." else ""
+        for file in indexed_files
+        if file.language == "go" and file.rel.endswith(".go") and not is_test_fixture_path(file.rel)
+    }
     file_text: dict[str, str] = {}
     modules: list[dict[str, Any]] = []
     symbols: list[dict[str, Any]] = []
@@ -706,6 +1218,8 @@ def build_index(
         if text:
             file_text[rel] = text
         kind = module_kind(rel)
+        package_name = extract_go_package_name(text) if language == "go" else None
+        boundary_hints = go_boundary_hints_for_path(rel) if language == "go" or is_test_fixture_path(rel) else []
         module = {
             "path": rel,
             "name": Path(rel).stem,
@@ -715,28 +1229,56 @@ def build_index(
             "tokens": tokens_for_path(rel),
             "lineCount": len(text.splitlines()) if text else 0,
         }
+        if package_name:
+            module["package"] = package_name
+        if language == "go" and kind == "test" and package_name:
+            module["targetPackage"] = package_name[: -len("_test")] if package_name.endswith("_test") else package_name
+        if language == "go" and boundary_hints:
+            module["boundaryHints"] = boundary_hints
+            module["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in boundary_hints)
+        if is_test_fixture_path(rel):
+            module["testFixture"] = True
         modules.append(module)
         file_symbols = extract_symbols(rel, language, text)
         symbols.extend(file_symbols)
-        for spec in extract_import_specs(language, text):
-            imports.append(
-                {
-                    "path": rel,
-                    "language": language,
-                    "imported": spec,
-                    "resolvedPath": resolve_import(rel, spec, known_files),
-                    "tokens": sorted(set(split_identifier(spec))),
-                }
+        for import_record in extract_import_records(language, text):
+            spec = str(import_record.get("imported") or "")
+            if not spec:
+                continue
+            resolved_path = resolve_import(
+                rel,
+                spec,
+                known_files,
+                language=language,
+                go_modules=go_modules,
+                go_package_dirs=go_package_dirs,
             )
+            item = {
+                "path": rel,
+                "language": language,
+                "imported": spec,
+                "resolvedPath": resolved_path,
+                "tokens": import_record.get("tokens", sorted(set(split_identifier(spec)))),
+            }
+            for key in ("alias", "importKind"):
+                if key in import_record:
+                    item[key] = import_record.get(key)
+            imports.append(item)
         if kind == "test":
-            tests.append(
-                {
-                    "path": rel,
-                    "language": language,
-                    "framework": test_framework_for_path(rel, text, language),
-                    "tokens": tokens_for_path(rel),
-                }
-            )
+            test_entry = {
+                "path": rel,
+                "language": language,
+                "framework": test_framework_for_path(rel, text, language),
+                "tokens": tokens_for_path(rel),
+            }
+            if language == "go":
+                if package_name:
+                    test_entry["package"] = package_name
+                    test_entry["targetPackage"] = package_name[: -len("_test")] if package_name.endswith("_test") else package_name
+                test_functions = sorted(set(GO_TEST_FUNCTION_RE.findall(text)))
+                if test_functions:
+                    test_entry["testFunctions"] = test_functions
+            tests.append(test_entry)
         manifest = extract_manifest(rel, text)
         if manifest:
             manifests.append(manifest)
@@ -758,6 +1300,8 @@ def build_index(
         if paired_tests and path not in tests_by_path:
             module["pairedTests"] = paired_tests
 
+    modules.extend(build_go_package_modules(modules, symbols, tests, importers_by_target))
+
     symbols_by_path: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for symbol in symbols:
         symbols_by_path[str(symbol.get("path"))].append(symbol)
@@ -766,37 +1310,62 @@ def build_index(
     for module in modules:
         path = str(module.get("path"))
         parts = set(Path(path).parts)
-        exported_symbols = [
-            symbol.get("name")
-            for symbol in symbols_by_path.get(path, [])
-            if symbol.get("exported") and isinstance(symbol.get("name"), str)
-        ]
+        if module.get("language") == "go" and module.get("kind") != "package":
+            continue
+        if module.get("language") == "go" and module.get("kind") == "package":
+            exported_symbols = [
+                symbol
+                for symbol in module.get("symbols", [])
+                if isinstance(symbol, str)
+            ]
+        else:
+            exported_symbols = [
+                symbol.get("name")
+                for symbol in symbols_by_path.get(path, [])
+                if symbol.get("exported") and isinstance(symbol.get("name"), str)
+            ]
         reasons = []
         if parts & SHARED_DIR_HINTS:
             reasons.append("shared-directory-name")
+        if module.get("language") == "go" and module.get("weakReusablePackageConvention"):
+            reasons.append("go-pkg-weak-convention")
+        if module.get("language") == "go" and module.get("internalBoundary"):
+            reasons.append("go-internal-boundary")
         if module.get("importCount", 0):
             reasons.append("imported-by-local-files")
         if module.get("pairedTests"):
             reasons.append("paired-test")
-        has_primary_shared_signal = bool((parts & SHARED_DIR_HINTS) or module.get("importCount", 0) or module.get("pairedTests"))
-        if not has_primary_shared_signal:
-            continue
         if exported_symbols:
             reasons.append("exported-symbols")
-        if module.get("kind") not in {"source", "support"}:
+        if module.get("language") == "go" and module.get("kind") == "package":
+            if module.get("entrypointBoundary") and not module.get("importCount", 0):
+                continue
+            has_primary_shared_signal = bool(
+                module.get("importCount", 0)
+                or module.get("pairedTests")
+                or exported_symbols
+            )
+        else:
+            has_primary_shared_signal = bool((parts & SHARED_DIR_HINTS) or module.get("importCount", 0) or module.get("pairedTests"))
+        if not has_primary_shared_signal:
             continue
-        shared_candidates.append(
-            {
-                "path": path,
-                "language": module.get("language"),
-                "symbols": sorted(exported_symbols),
-                "usageCount": int(module.get("importCount", 0)),
-                "importedBy": module.get("importedBy", []),
-                "pairedTests": module.get("pairedTests", []),
-                "reasons": reasons,
-                "tokens": module.get("tokens", []),
-            }
-        )
+        if module.get("kind") not in {"source", "support", "package"}:
+            continue
+        candidate = {
+            "path": path,
+            "language": module.get("language"),
+            "symbols": sorted(exported_symbols),
+            "usageCount": int(module.get("importCount", 0)),
+            "importedBy": module.get("importedBy", []),
+            "pairedTests": module.get("pairedTests", []),
+            "reasons": reasons,
+            "tokens": module.get("tokens", []),
+        }
+        if module.get("language") == "go":
+            for key in ("package", "boundaryHints", "boundaryKinds", "internalBoundary", "weakReusablePackageConvention", "publicAPICandidate"):
+                if key in module:
+                    candidate[key] = module.get(key)
+        shared_candidates.append(candidate)
 
     symbol_name_counts = Counter(str(symbol.get("name")) for symbol in symbols if symbol.get("name"))
     duplicate_fingerprints = []
@@ -831,7 +1400,33 @@ def build_index(
                 if set(module.get("tokens", [])) & VALIDATION_TOKENS
             }
         ),
+        "goInternalPackages": sorted(
+            str(module.get("path"))
+            for module in modules
+            if module.get("language") == "go" and module.get("internalBoundary")
+        ),
+        "goCommandEntrypoints": sorted(
+            str(module.get("path"))
+            for module in modules
+            if module.get("language") == "go" and module.get("entrypointBoundary")
+        ),
+        "goReusablePackageDirs": sorted(
+            str(module.get("path"))
+            for module in modules
+            if module.get("language") == "go" and module.get("weakReusablePackageConvention")
+        ),
+        "goTestdataPaths": sorted(
+            str(module.get("path"))
+            for module in modules
+            if module.get("testFixture")
+        ),
+        "goPublicAPICandidates": sorted(
+            str(module.get("path"))
+            for module in modules
+            if module.get("language") == "go" and module.get("publicAPICandidate")
+        ),
     }
+    module_boundaries = collect_module_boundaries(modules)
 
     language_counts = Counter(
         str(module.get("language"))
@@ -876,6 +1471,7 @@ def build_index(
         "imports": sorted(imports, key=lambda item: (str(item.get("path")), str(item.get("imported")))),
         "tests": sorted(tests, key=lambda item: str(item.get("path"))),
         "conventions": conventions,
+        "moduleBoundaries": module_boundaries,
         "duplicateFingerprints": duplicate_fingerprints,
         "manifests": sorted(manifests, key=lambda item: str(item.get("path"))),
         "scanStats": scan_stats,

--- a/tests/fixtures/codebase-awareness/contracts/go-token-validation-contract.json
+++ b/tests/fixtures/codebase-awareness/contracts/go-token-validation-contract.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.0",
+  "contractId": "go-token-validation-contract",
+  "goal": "Add token validation to Go authentication flow",
+  "riskLevel": "low",
+  "inScope": [
+    "internal/auth"
+  ],
+  "acceptanceCriteria": [
+    "Token values are rejected when malformed",
+    "Existing Go token validation helpers are reused when relevant"
+  ],
+  "openQuestions": [],
+  "requiredInputsProvided": true
+}

--- a/tests/fixtures/codebase-awareness/contracts/go-validation-contract.json
+++ b/tests/fixtures/codebase-awareness/contracts/go-validation-contract.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.0",
+  "contractId": "go-validation-contract",
+  "goal": "Add email validation to Go user signup flow",
+  "riskLevel": "low",
+  "inScope": [
+    "internal/users"
+  ],
+  "acceptanceCriteria": [
+    "Signup rejects malformed email values",
+    "Existing Go validation helpers are reused when relevant"
+  ],
+  "openQuestions": [],
+  "requiredInputsProvided": true
+}

--- a/tests/fixtures/codebase-awareness/go-basic/cmd/api/main.go
+++ b/tests/fixtures/codebase-awareness/go-basic/cmd/api/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	auth "example.com/signum-go-basic/internal/auth"
+	"example.com/signum-go-basic/pkg/validation"
+	_ "github.com/acme/external/driver"
+	_ "net/http/pprof"
+)
+
+func main() {
+	service := &auth.Service{}
+	if err := run(context.Background(), service, "ops@example.com"); err != nil {
+		fmt.Println(err)
+	}
+}
+
+func run(ctx context.Context, service *auth.Service, email string) error {
+	if !service.ValidateToken("token") {
+		return auth.ErrInvalidToken
+	}
+	if !validation.ValidateEmail(email) {
+		return fmt.Errorf("invalid email")
+	}
+	_ = ctx
+	return nil
+}

--- a/tests/fixtures/codebase-awareness/go-basic/go.mod
+++ b/tests/fixtures/codebase-awareness/go-basic/go.mod
@@ -1,0 +1,3 @@
+module example.com/signum-go-basic
+
+go 1.22

--- a/tests/fixtures/codebase-awareness/go-basic/go.work
+++ b/tests/fixtures/codebase-awareness/go-basic/go.work
@@ -1,0 +1,6 @@
+go 1.22
+
+use (
+	./services/api
+	./libs/shared
+)

--- a/tests/fixtures/codebase-awareness/go-basic/internal/auth/token.go
+++ b/tests/fixtures/codebase-awareness/go-basic/internal/auth/token.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+const DefaultTimeout = 30 * time.Second
+
+var ErrInvalidToken = errors.New("invalid token")
+
+type User struct {
+	Email string
+	Role  Role
+}
+
+type Store interface {
+	Save(User) error
+}
+
+type Role string
+
+type Service struct{}
+
+type Repository struct{}
+
+func ValidateToken(value string) bool {
+	return parseToken(value) != ""
+}
+
+func parseToken(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func (s *Service) ValidateToken(value string) bool {
+	return ValidateToken(value)
+}
+
+func (r Repository) Save(user User) error {
+	if user.Email == "" {
+		return ErrInvalidToken
+	}
+	return nil
+}

--- a/tests/fixtures/codebase-awareness/go-basic/internal/auth/token_test.go
+++ b/tests/fixtures/codebase-awareness/go-basic/internal/auth/token_test.go
@@ -1,0 +1,22 @@
+package auth
+
+import "testing"
+
+func TestValidateToken(t *testing.T) {
+	if !ValidateToken("token") {
+		t.Fatal("expected token to validate")
+	}
+}
+
+func BenchmarkValidateToken(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ValidateToken("token")
+	}
+}
+
+func FuzzValidateToken(f *testing.F) {
+	f.Add("token")
+	f.Fuzz(func(t *testing.T, value string) {
+		_ = ValidateToken(value)
+	})
+}

--- a/tests/fixtures/codebase-awareness/go-basic/internal/users/signup.go
+++ b/tests/fixtures/codebase-awareness/go-basic/internal/users/signup.go
@@ -1,0 +1,21 @@
+package users
+
+import (
+	"context"
+
+	cfg "example.com/signum-go-basic/internal/auth"
+	"example.com/signum-go-basic/pkg/validation"
+)
+
+type SignupService struct {
+	Auth *cfg.Service
+}
+
+func (s SignupService) Signup(ctx context.Context, email string) bool {
+	_ = ctx
+	_ = cfg.DefaultTimeout
+	if s.Auth != nil && !s.Auth.ValidateToken("token") {
+		return false
+	}
+	return validation.ValidateEmail(email)
+}

--- a/tests/fixtures/codebase-awareness/go-basic/pkg/validation/email.go
+++ b/tests/fixtures/codebase-awareness/go-basic/pkg/validation/email.go
@@ -1,0 +1,11 @@
+package validation
+
+import "strings"
+
+func ValidateEmail(value string) bool {
+	return value != "" && strings.Contains(value, "@")
+}
+
+func normalizeEmail(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}

--- a/tests/fixtures/codebase-awareness/go-basic/pkg/validation/email_test.go
+++ b/tests/fixtures/codebase-awareness/go-basic/pkg/validation/email_test.go
@@ -1,0 +1,9 @@
+package validation
+
+import "testing"
+
+func TestValidateEmail(t *testing.T) {
+	if !ValidateEmail("dev@example.com") {
+		t.Fatal("expected email to validate")
+	}
+}

--- a/tests/fixtures/codebase-awareness/go-basic/pkg/validation/testdata/valid.txt
+++ b/tests/fixtures/codebase-awareness/go-basic/pkg/validation/testdata/valid.txt
@@ -1,0 +1,1 @@
+dev@example.com

--- a/tests/test-codebase-go-adapter.sh
+++ b/tests/test-codebase-go-adapter.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+SCANNER="$ROOT_DIR/scripts/build_codebase_index.py"
+MATCHER="$ROOT_DIR/scripts/build_reuse_candidates.py"
+FIXTURE="$ROOT_DIR/tests/fixtures/codebase-awareness/go-basic"
+CONTRACT="$ROOT_DIR/tests/fixtures/codebase-awareness/contracts/go-validation-contract.json"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+passed=0
+failed=0
+
+pass() {
+  printf '  PASS: %s\n' "$1"
+  passed=$((passed + 1))
+}
+
+fail() {
+  printf '  FAIL: %s -- %s\n' "$1" "$2"
+  failed=$((failed + 1))
+}
+
+make_project() {
+  local name="$1"
+  local project="$WORK/$name"
+  cp -R "$FIXTURE" "$project"
+  printf '%s\n' "$project"
+}
+
+run_scanner() {
+  local project="$1"
+  shift
+  (
+    cd "$project"
+    python3 "$SCANNER" \
+      --project-root "." \
+      --output ".signum/cache/codebase-index-v1.json" \
+      --style-output ".signum/cache/style-profile-v1.json" \
+      --digests-output ".signum/cache/file-digests-v1.json" \
+      --generated-at "2026-01-01T00:00:00Z" \
+      "$@"
+  )
+}
+
+run_matcher() {
+  local project="$1"
+  mkdir -p "$project/.signum/contracts/go-validation"
+  cp "$CONTRACT" "$project/.signum/contracts/go-validation/contract.json"
+  (
+    cd "$project"
+    python3 "$MATCHER" \
+      --project-root "." \
+      --contract ".signum/contracts/go-validation/contract.json" \
+      --codebase-index ".signum/cache/codebase-index-v1.json" \
+      --style-profile ".signum/cache/style-profile-v1.json" \
+      --output ".signum/contracts/go-validation/reuse_candidates.json" \
+      --implementation-context ".signum/contracts/go-validation/implementation_context.json" \
+      --max-candidates 8 \
+      --generated-at "2026-01-01T00:00:00Z"
+  )
+}
+
+PROJECT_A="$(make_project run-a)"
+
+INDEX_A="$PROJECT_A/.signum/cache/codebase-index-v1.json"
+STYLE_A="$PROJECT_A/.signum/cache/style-profile-v1.json"
+DIGEST_A="$PROJECT_A/.signum/cache/file-digests-v1.json"
+REUSE_A="$PROJECT_A/.signum/contracts/go-validation/reuse_candidates.json"
+CONTEXT_A="$PROJECT_A/.signum/contracts/go-validation/implementation_context.json"
+
+echo "=== Go scanner run ==="
+if run_scanner "$PROJECT_A"; then
+  pass "scanner exits 0 on Go fixture"
+else
+  fail "scanner exits 0 on Go fixture" "command failed"
+fi
+
+if [ -f "$INDEX_A" ] && [ -f "$STYLE_A" ] && [ -f "$DIGEST_A" ]; then
+  pass "scanner writes Go index, style, and digest artifacts"
+else
+  fail "scanner writes Go index, style, and digest artifacts" "missing output"
+fi
+
+echo ""
+echo "=== Go scanner artifact contract ==="
+if python3 - "$INDEX_A" "$STYLE_A" "$DIGEST_A" "$PROJECT_A" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+index = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+style = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+digests = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+project = sys.argv[4]
+errors = []
+
+def has_record(section, **expected):
+    for item in index.get(section, []):
+        if all(item.get(key) == value for key, value in expected.items()):
+            return item
+    return None
+
+def symbol(name, kind=None, path=None):
+    for item in index.get("symbols", []):
+        if item.get("name") != name:
+            continue
+        if kind and item.get("kind") != kind:
+            continue
+        if path and item.get("path") != path:
+            continue
+        return item
+    return None
+
+if not any(item.get("language") == "go" and item.get("fileCount") >= 6 for item in index.get("languageDetections", [])):
+    errors.append("Go language detection missing")
+
+go_mod = has_record("manifests", path="go.mod", kind="go", language="go")
+if not go_mod or go_mod.get("modulePath") != "example.com/signum-go-basic":
+    errors.append("go.mod modulePath missing")
+if go_mod and not {"signum", "basic"}.issubset(set(go_mod.get("tokens", []))):
+    errors.append("go.mod module tokens missing")
+
+go_work = has_record("manifests", path="go.work", kind="go-work", language="go")
+if not go_work or go_work.get("workspaceUses") != ["./libs/shared", "./services/api"]:
+    errors.append("go.work workspaceUses missing")
+
+validate = symbol("ValidateToken", "function", "internal/auth/token.go")
+parse = symbol("parseToken", "function", "internal/auth/token.go")
+method = symbol("ValidateToken", "method", "internal/auth/token.go")
+save = symbol("Save", "method", "internal/auth/token.go")
+if not validate or validate.get("exported") is not True or validate.get("receiver") is not None:
+    errors.append("ValidateToken function extraction/export failed")
+if not parse or parse.get("exported") is not False:
+    errors.append("parseToken unexported extraction failed")
+if not method or method.get("receiver") != "Service" or method.get("exported") is not True:
+    errors.append("Service method receiver extraction failed")
+if not save or save.get("receiver") != "Repository":
+    errors.append("Repository value receiver extraction failed")
+for name in ("User", "Store", "Role", "DefaultTimeout", "ErrInvalidToken"):
+    if not symbol(name, path="internal/auth/token.go"):
+        errors.append(f"missing Go symbol {name}")
+
+imports = index.get("imports", [])
+def import_record(path, imported):
+    return next((item for item in imports if item.get("path") == path and item.get("imported") == imported), None)
+
+if not import_record("cmd/api/main.go", "context"):
+    errors.append("single/block stdlib import missing")
+auth_import = import_record("cmd/api/main.go", "example.com/signum-go-basic/internal/auth")
+if not auth_import or auth_import.get("alias") != "auth" or auth_import.get("resolvedPath") != "internal/auth":
+    errors.append("aliased local auth import did not resolve")
+cfg_import = import_record("internal/users/signup.go", "example.com/signum-go-basic/internal/auth")
+if not cfg_import or cfg_import.get("alias") != "cfg" or cfg_import.get("resolvedPath") != "internal/auth":
+    errors.append("cfg local auth import did not resolve")
+validation_imports = [
+    item for item in imports
+    if item.get("imported") == "example.com/signum-go-basic/pkg/validation"
+]
+if sorted(item.get("resolvedPath") for item in validation_imports) != ["pkg/validation", "pkg/validation"]:
+    errors.append("local validation imports did not resolve to package directory")
+blank_import = import_record("cmd/api/main.go", "net/http/pprof")
+if not blank_import or blank_import.get("alias") != "_" or blank_import.get("resolvedPath") is not None:
+    errors.append("blank stdlib import extraction failed")
+github_import = import_record("cmd/api/main.go", "github.com/acme/external/driver")
+if not github_import or github_import.get("resolvedPath") is not None:
+    errors.append("external github import should not resolve locally")
+
+tests = index.get("tests", [])
+auth_test = next((item for item in tests if item.get("path") == "internal/auth/token_test.go"), None)
+if not auth_test or auth_test.get("framework") != "go-test" or auth_test.get("targetPackage") != "auth":
+    errors.append("Go auth test record missing framework/targetPackage")
+if auth_test and set(auth_test.get("testFunctions", [])) != {"TestValidateToken", "BenchmarkValidateToken", "FuzzValidateToken"}:
+    errors.append("Go test functions not detected")
+if not next((item for item in tests if item.get("path") == "pkg/validation/email_test.go" and item.get("framework") == "go-test"), None):
+    errors.append("Go validation test record missing")
+
+modules = index.get("modules", [])
+pkg_module = next((item for item in modules if item.get("path") == "pkg/validation" and item.get("kind") == "package"), None)
+internal_module = next((item for item in modules if item.get("path") == "internal/auth" and item.get("kind") == "package"), None)
+cmd_module = next((item for item in modules if item.get("path") == "cmd/api" and item.get("kind") == "package"), None)
+if not pkg_module or pkg_module.get("weakReusablePackageConvention") is not True:
+    errors.append("pkg/ weak package boundary missing")
+if not internal_module or internal_module.get("internalBoundary") is not True:
+    errors.append("internal/ boundary missing")
+if not cmd_module or cmd_module.get("entrypointBoundary") is not True:
+    errors.append("cmd/ boundary missing")
+
+boundaries = index.get("moduleBoundaries", [])
+if not any(item.get("path") == "internal/auth" and item.get("kind") == "go-internal" for item in boundaries):
+    errors.append("go-internal module boundary missing")
+if not any(item.get("path") == "cmd/api" and item.get("kind") == "go-cmd" for item in boundaries):
+    errors.append("go-cmd module boundary missing")
+if not any(item.get("path") == "pkg/validation" and item.get("kind") == "go-pkg" and item.get("weak") is True for item in boundaries):
+    errors.append("go-pkg weak module boundary missing")
+if "pkg/validation/testdata/valid.txt" not in index.get("conventions", {}).get("goTestdataPaths", []):
+    errors.append("testdata convention missing")
+
+shared = index.get("sharedCandidates", [])
+validation_candidate = next((item for item in shared if item.get("path") == "pkg/validation"), None)
+if not validation_candidate:
+    errors.append("pkg/validation shared candidate missing")
+else:
+    reasons = set(validation_candidate.get("reasons", []))
+    if not {"imported-by-local-files", "paired-test", "exported-symbols"}.issubset(reasons):
+        errors.append("pkg/validation shared candidate lacks strong evidence")
+    if validation_candidate.get("usageCount") != 2:
+        errors.append("pkg/validation usageCount should be 2")
+    if validation_candidate.get("importedBy") != ["cmd/api/main.go", "internal/users/signup.go"]:
+        errors.append("pkg/validation importedBy mismatch")
+    if validation_candidate.get("pairedTests") != ["pkg/validation/email_test.go"]:
+        errors.append("pkg/validation pairedTests mismatch")
+internal_candidate = next((item for item in shared if item.get("path") == "internal/auth"), None)
+if not internal_candidate or internal_candidate.get("internalBoundary") is not True:
+    errors.append("internal/auth candidate is not boundary-aware")
+
+style_tests = style.get("testConventions", [])
+if not any(item.get("language") == "go" and item.get("value") == "*_test.go" for item in style_tests):
+    errors.append("Go *_test.go style convention missing")
+style_go = style.get("goConventions", [])
+if not any(item.get("value") == "go test" for item in style_go):
+    errors.append("Go go test style convention missing")
+if not any(item.get("value") == "package-local tests" for item in style_go):
+    errors.append("Go package-local test convention missing")
+
+digest_files = digests.get("files", {})
+for rel in ("go.mod", "cmd/api/main.go", "internal/auth/token.go", "internal/auth/token_test.go", "pkg/validation/email.go"):
+    record = digest_files.get(rel)
+    if not record or record.get("indexed") is not True:
+        errors.append(f"missing indexed digest for {rel}")
+for key in digest_files:
+    if key.startswith("/") or project in key:
+        errors.append(f"non-portable digest key {key}")
+
+if project in json.dumps(index) or project in json.dumps(style) or project in json.dumps(digests):
+    errors.append("temp project path leaked")
+
+if errors:
+    for error in errors:
+        print(error, file=sys.stderr)
+    raise SystemExit(1)
+PY
+then
+  pass "Go scanner emits expected language, manifest, symbol, import, test, boundary, shared, and digest signals"
+else
+  fail "Go scanner emits expected language, manifest, symbol, import, test, boundary, shared, and digest signals" "Python assertion failed"
+fi
+
+echo ""
+echo "=== Go matcher behavior ==="
+if run_matcher "$PROJECT_A"; then
+  pass "matcher exits 0 for Go contract"
+else
+  fail "matcher exits 0 for Go contract" "command failed"
+fi
+
+if python3 - "$REUSE_A" "$CONTEXT_A" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+reuse = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+context = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+errors = []
+candidates = reuse.get("candidates", [])
+top = candidates[0] if candidates else {}
+if reuse.get("contractId") != "go-validation-contract":
+    errors.append("Go contractId mismatch")
+if top.get("path") != "pkg/validation" or top.get("kind") not in {"existing-helper", "shared-module"}:
+    errors.append("top Go candidate should surface pkg/validation helper/module")
+if top.get("symbol") not in {None, "ValidateEmail"}:
+    errors.append("top Go candidate symbol mismatch")
+why = " ".join(top.get("whyRelevant", [])).lower()
+for term in ("validation", "shared candidate", "imported", "paired test"):
+    if term not in why:
+        errors.append(f"top Go candidate missing whyRelevant evidence: {term}")
+if "pkg/" in why and not any(term in why for term in ("imported", "paired test", "symbol")):
+    errors.append("Go candidate relies only on pkg path")
+if not any(candidate.get("path") == "internal/auth" and candidate.get("risks") for candidate in candidates):
+    errors.append("internal/auth candidate should carry boundary risk")
+if "go" not in context.get("primaryLanguages", []):
+    errors.append("implementation context missing Go primary language")
+if not context.get("dominantConventions", {}).get("go"):
+    errors.append("implementation context missing Go conventions")
+if not context.get("moduleBoundaries"):
+    errors.append("implementation context missing module boundaries")
+
+if errors:
+    for error in errors:
+        print(error, file=sys.stderr)
+    raise SystemExit(1)
+PY
+then
+  pass "Go matcher surfaces validation helper with evidence-based relevance"
+else
+  fail "Go matcher surfaces validation helper with evidence-based relevance" "Python assertion failed"
+fi
+
+echo ""
+echo "=== Skip behavior ==="
+PROJECT_C="$(make_project skip)"
+mkdir -p "$PROJECT_C/vendor/example.com/generated" "$PROJECT_C/pkg/generated"
+printf 'package generated\n\nfunc IgnoredVendor() {}\n' > "$PROJECT_C/vendor/example.com/generated/vendor.go"
+printf '// Code generated by fixture. DO NOT EDIT.\npackage generated\n\nfunc IgnoredGenerated() {}\n' > "$PROJECT_C/pkg/generated/generated.go"
+printf 'go\000binary\n' > "$PROJECT_C/pkg/generated/binary.bin"
+if run_scanner "$PROJECT_C"; then
+  pass "scanner exits 0 with Go skip fixtures"
+else
+  fail "scanner exits 0 with Go skip fixtures" "command failed"
+fi
+if python3 - "$PROJECT_C/.signum/cache/file-digests-v1.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+digests = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+files = digests.get("files", {})
+errors = []
+if any(path.startswith("vendor/") for path in files):
+    errors.append("vendor path should be ignored")
+generated = files.get("pkg/generated/generated.go")
+if not generated or generated.get("indexed") is not False or generated.get("reason") != "generated":
+    errors.append("generated Go file should be skipped")
+binary = files.get("pkg/generated/binary.bin")
+if not binary or binary.get("indexed") is not False or binary.get("reason") != "binary":
+    errors.append("binary file should be skipped")
+if errors:
+    for error in errors:
+        print(error, file=sys.stderr)
+    raise SystemExit(1)
+PY
+then
+  pass "generated, vendor, and binary skip behavior remains intact"
+else
+  fail "generated, vendor, and binary skip behavior remains intact" "Python assertion failed"
+fi
+
+echo ""
+echo "=== Determinism ==="
+SNAPSHOT_INDEX="$WORK/codebase-index-a.json"
+SNAPSHOT_STYLE="$WORK/style-profile-a.json"
+SNAPSHOT_DIGEST="$WORK/file-digests-a.json"
+cp "$INDEX_A" "$SNAPSHOT_INDEX"
+cp "$STYLE_A" "$SNAPSHOT_STYLE"
+cp "$DIGEST_A" "$SNAPSHOT_DIGEST"
+if run_scanner "$PROJECT_A"; then
+  pass "second Go scanner run exits 0 on same project"
+else
+  fail "second Go scanner run exits 0 on same project" "command failed"
+fi
+if cmp -s "$INDEX_A" "$SNAPSHOT_INDEX" && cmp -s "$STYLE_A" "$SNAPSHOT_STYLE" && cmp -s "$DIGEST_A" "$SNAPSHOT_DIGEST"; then
+  pass "Go scanner artifacts are byte-stable with fixed generatedAt"
+else
+  fail "Go scanner artifacts are byte-stable with fixed generatedAt" "scanner outputs changed"
+fi
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi
+
+echo "ok: Go Codebase Awareness adapter is deterministic and evidence-based"

--- a/tests/test-codebase-go-adapter.sh
+++ b/tests/test-codebase-go-adapter.sh
@@ -275,6 +275,10 @@ why = " ".join(top.get("whyRelevant", [])).lower()
 for term in ("validation", "shared candidate", "imported", "paired test"):
     if term not in why:
         errors.append(f"top Go candidate missing whyRelevant evidence: {term}")
+if "validation helper signal" not in why:
+    errors.append("top Go candidate missing generic validation helper signal")
+if "domain terms matched validation helper:" not in why:
+    errors.append("top Go candidate missing generic validation domain overlap")
 if "pkg/" in why and not any(term in why for term in ("imported", "paired test", "symbol")):
     errors.append("Go candidate relies only on pkg path")
 if not any(candidate.get("path") == "internal/auth" and candidate.get("risks") for candidate in candidates):

--- a/tests/test-reuse-candidates.sh
+++ b/tests/test-reuse-candidates.sh
@@ -44,8 +44,9 @@ setup_project() {
 setup_go_project() {
   local project="$1"
   cp -R "$GO_FIXTURE" "$project"
-  mkdir -p "$project/.signum/contracts/go-validation"
+  mkdir -p "$project/.signum/contracts/go-validation" "$project/.signum/contracts/go-token-validation"
   cp "$CONTRACTS/go-validation-contract.json" "$project/.signum/contracts/go-validation/contract.json"
+  cp "$CONTRACTS/go-token-validation-contract.json" "$project/.signum/contracts/go-token-validation/contract.json"
 }
 
 run_scanner() {
@@ -93,6 +94,22 @@ run_go_matcher() {
   )
 }
 
+run_go_token_matcher() {
+  local project="$1"
+  (
+    cd "$project"
+    python3 "$MATCHER" \
+      --project-root "." \
+      --contract ".signum/contracts/go-token-validation/contract.json" \
+      --codebase-index ".signum/cache/codebase-index-v1.json" \
+      --style-profile ".signum/cache/style-profile-v1.json" \
+      --output ".signum/contracts/go-token-validation/reuse_candidates.json" \
+      --implementation-context ".signum/contracts/go-token-validation/implementation_context.json" \
+      --max-candidates 8 \
+      --generated-at "2026-01-01T00:00:00Z"
+  )
+}
+
 PROJECT_A="$WORK/run-a/basic-mixed"
 PROJECT_B="$WORK/run-b/basic-mixed"
 mkdir -p "$(dirname "$PROJECT_A")" "$(dirname "$PROJECT_B")"
@@ -114,6 +131,7 @@ mkdir -p "$(dirname "$PROJECT_GO")"
 setup_go_project "$PROJECT_GO"
 GO_REUSE="$PROJECT_GO/.signum/contracts/go-validation/reuse_candidates.json"
 GO_CONTEXT="$PROJECT_GO/.signum/contracts/go-validation/implementation_context.json"
+GO_TOKEN_REUSE="$PROJECT_GO/.signum/contracts/go-token-validation/reuse_candidates.json"
 
 echo "=== Scanner prerequisite ==="
 if run_scanner "$PROJECT_A"; then
@@ -392,6 +410,10 @@ why = " ".join(top.get("whyRelevant", [])).lower()
 for term in ("validation", "shared candidate", "imported", "paired test"):
     if term not in why:
         errors.append(f"missing Go whyRelevant evidence: {term}")
+if "validation helper signal" not in why:
+    errors.append("generic validation helper signal missing")
+if "domain terms matched validation helper:" not in why:
+    errors.append("generic domain overlap explanation missing")
 if "pkg/" in why and not any(term in why for term in ("imported", "paired test", "symbol")):
     errors.append("pkg path used without stronger Go evidence")
 internal = [candidate for candidate in candidates if candidate.get("path") == "internal/auth"]
@@ -412,6 +434,48 @@ then
   pass "Go contract surfaces validation helper with non-path-only evidence"
 else
   fail "Go contract surfaces validation helper with non-path-only evidence" "Python assertion failed"
+fi
+
+echo ""
+echo "=== Generic validation scoring ==="
+if run_go_token_matcher "$PROJECT_GO"; then
+  pass "matcher supports non-email Go validation contract"
+else
+  fail "matcher supports non-email Go validation contract" "command failed"
+fi
+
+if python3 - "$GO_TOKEN_REUSE" "$MATCHER" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+reuse = json.loads(Path(sys.argv[1]).read_text())
+matcher_source = Path(sys.argv[2]).read_text()
+errors = []
+candidates = reuse.get("candidates", [])
+token_candidates = [
+    candidate for candidate in candidates
+    if candidate.get("path") in {"internal/auth", "internal/auth/token.go"}
+    and candidate.get("symbol") in {None, "ValidateToken"}
+]
+if not token_candidates:
+    errors.append("token validation helper candidate missing")
+if not any("validation helper signal" in " ".join(candidate.get("whyRelevant", [])).lower() for candidate in token_candidates):
+    errors.append("non-email validation helper did not get generic validation boost")
+if not any("domain terms matched validation helper: token" in " ".join(candidate.get("whyRelevant", [])).lower() for candidate in token_candidates):
+    errors.append("non-email validation helper did not explain token domain overlap")
+if re.search(r"""['"]email['"]""", matcher_source):
+    errors.append("matcher source contains hard-coded email literal")
+if errors:
+    for error in errors:
+        print(error, file=sys.stderr)
+    raise SystemExit(1)
+PY
+then
+  pass "generic validation scoring works without hard-coded domain literals"
+else
+  fail "generic validation scoring works without hard-coded domain literals" "Python assertion failed"
 fi
 
 echo ""

--- a/tests/test-reuse-candidates.sh
+++ b/tests/test-reuse-candidates.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
 SCANNER="$ROOT_DIR/scripts/build_codebase_index.py"
 MATCHER="$ROOT_DIR/scripts/build_reuse_candidates.py"
 FIXTURE="$ROOT_DIR/tests/fixtures/codebase-awareness/basic-mixed"
+GO_FIXTURE="$ROOT_DIR/tests/fixtures/codebase-awareness/go-basic"
 CONTRACTS="$ROOT_DIR/tests/fixtures/codebase-awareness/contracts"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
@@ -40,6 +41,13 @@ setup_project() {
   cp "$CONTRACTS/python-test-contract.json" "$project/.signum/contracts/python/contract.json"
 }
 
+setup_go_project() {
+  local project="$1"
+  cp -R "$GO_FIXTURE" "$project"
+  mkdir -p "$project/.signum/contracts/go-validation"
+  cp "$CONTRACTS/go-validation-contract.json" "$project/.signum/contracts/go-validation/contract.json"
+}
+
 run_scanner() {
   local project="$1"
   (
@@ -69,6 +77,22 @@ run_matcher() {
   )
 }
 
+run_go_matcher() {
+  local project="$1"
+  (
+    cd "$project"
+    python3 "$MATCHER" \
+      --project-root "." \
+      --contract ".signum/contracts/go-validation/contract.json" \
+      --codebase-index ".signum/cache/codebase-index-v1.json" \
+      --style-profile ".signum/cache/style-profile-v1.json" \
+      --output ".signum/contracts/go-validation/reuse_candidates.json" \
+      --implementation-context ".signum/contracts/go-validation/implementation_context.json" \
+      --max-candidates 8 \
+      --generated-at "2026-01-01T00:00:00Z"
+  )
+}
+
 PROJECT_A="$WORK/run-a/basic-mixed"
 PROJECT_B="$WORK/run-b/basic-mixed"
 mkdir -p "$(dirname "$PROJECT_A")" "$(dirname "$PROJECT_B")"
@@ -85,6 +109,11 @@ REUSE_B="$PROJECT_B/.signum/contracts/example/reuse_candidates.json"
 CONTEXT_B="$PROJECT_B/.signum/contracts/example/implementation_context.json"
 PY_REUSE="$PROJECT_A/.signum/contracts/python/reuse_candidates.json"
 PY_CONTEXT="$PROJECT_A/.signum/contracts/python/implementation_context.json"
+PROJECT_GO="$WORK/go/go-basic"
+mkdir -p "$(dirname "$PROJECT_GO")"
+setup_go_project "$PROJECT_GO"
+GO_REUSE="$PROJECT_GO/.signum/contracts/go-validation/reuse_candidates.json"
+GO_CONTEXT="$PROJECT_GO/.signum/contracts/go-validation/implementation_context.json"
 
 echo "=== Scanner prerequisite ==="
 if run_scanner "$PROJECT_A"; then
@@ -328,6 +357,61 @@ then
   pass "secondary python contract surfaces test pattern"
 else
   fail "secondary python contract surfaces test pattern" "Python assertion failed"
+fi
+
+echo ""
+echo "=== Go contract ==="
+if run_scanner "$PROJECT_GO"; then
+  pass "Go scanner prerequisite exits 0"
+else
+  fail "Go scanner prerequisite exits 0" "command failed"
+fi
+if run_go_matcher "$PROJECT_GO"; then
+  pass "matcher supports Go validation contract"
+else
+  fail "matcher supports Go validation contract" "command failed"
+fi
+
+if python3 - "$GO_REUSE" "$GO_CONTEXT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+reuse = json.loads(Path(sys.argv[1]).read_text())
+context = json.loads(Path(sys.argv[2]).read_text())
+errors = []
+candidates = reuse.get("candidates", [])
+top = candidates[0] if candidates else {}
+if reuse.get("contractId") != "go-validation-contract":
+    errors.append("go contractId")
+if top.get("path") != "pkg/validation":
+    errors.append("top Go candidate should be pkg/validation")
+if top.get("kind") not in {"existing-helper", "shared-module"}:
+    errors.append("top Go candidate kind")
+why = " ".join(top.get("whyRelevant", [])).lower()
+for term in ("validation", "shared candidate", "imported", "paired test"):
+    if term not in why:
+        errors.append(f"missing Go whyRelevant evidence: {term}")
+if "pkg/" in why and not any(term in why for term in ("imported", "paired test", "symbol")):
+    errors.append("pkg path used without stronger Go evidence")
+internal = [candidate for candidate in candidates if candidate.get("path") == "internal/auth"]
+if not internal or not any(candidate.get("risks") for candidate in internal):
+    errors.append("internal boundary risk missing")
+if "go" not in context.get("primaryLanguages", []):
+    errors.append("Go primary language missing")
+if not context.get("dominantConventions", {}).get("go"):
+    errors.append("Go conventions missing")
+if not context.get("moduleBoundaries"):
+    errors.append("Go module boundaries missing")
+if errors:
+    for error in errors:
+        print(error, file=sys.stderr)
+    raise SystemExit(1)
+PY
+then
+  pass "Go contract surfaces validation helper with non-path-only evidence"
+else
+  fail "Go contract surfaces validation helper with non-path-only evidence" "Python assertion failed"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- Adds shallow stdlib-only Go lexical support to the Codebase Awareness scanner.
- Adds Go package/module boundary hints, package-level shared candidates, and matcher support for Go reuse candidates.
- Adds a Go fixture repository, Go matcher contract fixture, and focused Go adapter regression test.
- Documents Go support and explicit limits in root, Claude overlay, and Codex skill docs.

## Go signals added
- `go.mod` manifest parsing with `modulePath`.
- `go.work` manifest parsing with `workspaceUses`.
- `.go` and `*_test.go` language/test detection.
- Package names, imports, aliases, blank imports, functions, methods, receiver names, types, consts, vars, exported flags, and Go test functions.
- Local module import resolution to package directories without `go list`.
- `internal/`, `cmd/`, `pkg/`, `testdata/`, exported package API, and package-local test conventions.
- Evidence-based Go shared candidates using import fan-in, exported symbols, and paired tests.

## Explicit non-goals
- No Rust or C# adapter.
- No Tree-sitter, embeddings, Semgrep, CodeQL, Faiss, network calls, or `go` command execution.
- No verdict mapping changes.
- No `duplicate_scan.json`, `reuse_summary.json`, proofpack, or PACK behavior/schema changes.
- No true incremental per-file extraction reuse.
- No automatic refactors.

## Validation
- `git diff --check`
- `git status --short`
- `git ls-files --others --exclude-standard`
- `python3 -m compileall -q scripts/codebase_awareness scripts/build_codebase_index.py scripts/build_reuse_candidates.py scripts/validate_reuse_decision.py scripts/audit_codebase_reuse.py scripts/evaluate_codebase_awareness_audit.py scripts/build_reuse_summary.py`
- `bash tests/test-codebase-index.sh`
- `bash tests/test-codebase-digests-cache.sh`
- `bash tests/test-codebase-go-adapter.sh`
- `bash tests/test-reuse-candidates.sh`
- `bash tests/test-reuse-decision-validator.sh`
- `bash tests/test-codebase-reuse-audit.sh`
- `bash tests/test-codebase-reuse-summary.sh`
- `bash tests/test-codebase-awareness-execute-wiring.sh`
- `bash tests/test-codebase-awareness-audit-wiring.sh`
- `bash tests/test-codebase-awareness-verdict-mapping.sh`
- `bash tests/test-codebase-awareness-pack-wiring.sh`
- `CDPATH= bash tests/test-artifact-path-inventory.sh`
- `bash tests/test-helper-output-paths.sh`
- `CDPATH= bash tests/test-signum-command-renderer.sh`
- `CDPATH= bash tests/test-signum-fragment-parity.sh`
- `CDPATH= bash tests/test-claude-overlay-runtime-parity.sh`
- `CDPATH= bash tests/test-claude-overlay-doc-mirror.sh`
- `CDPATH= bash tests/test-claude-overlay-pack-parity.sh`
- `CDPATH= bash tests/test-signum-command-structure.sh`
- `CDPATH= bash tests/test-codex-skill-canonical-paths.sh`
- `CDPATH= bash tests/test-codex-plugin-metadata.sh`
- `bash scripts/run-deterministic-tests.sh`
