### PR TITLE
[codex] Add Rust support to Codebase Awareness scanner

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -120,7 +120,7 @@ Canonical run artifacts live under the active contract artifact root `.signum/co
 
 The scanner defaults are bounded: `--max-files 10000`, `--max-bytes 50000000`, and `--max-file-size 1048576`. Files over the per-file cap are skipped, and repository-level caps mark the scan as truncated while still producing degraded cache/index artifacts.
 
-Codebase Awareness has shallow Go lexical/symbol support. It detects `go.mod`, `go.work`, `.go` files, Go package names/imports, exported symbols, `internal/`, `cmd/`, `pkg/`, `testdata/`, and `*_test.go` conventions. Go import resolution is local and module-path based when possible; it does not run `go list`, perform AST or type checking, or add Rust/C# adapters.
+Codebase Awareness has shallow Go and Rust lexical/symbol support. For Go, it detects `go.mod`, `go.work`, `.go` files, Go package names/imports, exported symbols, `internal/`, `cmd/`, `pkg/`, `testdata/`, and `*_test.go` conventions. Go import resolution is local and module-path based when possible. For Rust, it detects `Cargo.toml` manifests and workspaces, Cargo package/dependency hints, Rust modules/imports, `pub` symbols, crate and module boundary hints, integration tests under `tests/`, and inline `#[cfg(test)]` tests. It does not run `go list`, Cargo, `rustc`, or `cargo metadata`; it does not perform AST parsing, type checking, semantic resolution, or add C# support.
 
 | File | Phase | Contents |
 |------|-------|----------|

--- a/platforms/claude-code/docs/reference.md
+++ b/platforms/claude-code/docs/reference.md
@@ -120,7 +120,7 @@ Canonical run artifacts live under the active contract artifact root `.signum/co
 
 The scanner defaults are bounded: `--max-files 10000`, `--max-bytes 50000000`, and `--max-file-size 1048576`. Files over the per-file cap are skipped, and repository-level caps mark the scan as truncated while still producing degraded cache/index artifacts.
 
-Codebase Awareness has shallow Go lexical/symbol support. It detects `go.mod`, `go.work`, `.go` files, Go package names/imports, exported symbols, `internal/`, `cmd/`, `pkg/`, `testdata/`, and `*_test.go` conventions. Go import resolution is local and module-path based when possible; it does not run `go list`, perform AST or type checking, or add Rust/C# adapters.
+Codebase Awareness has shallow Go and Rust lexical/symbol support. For Go, it detects `go.mod`, `go.work`, `.go` files, Go package names/imports, exported symbols, `internal/`, `cmd/`, `pkg/`, `testdata/`, and `*_test.go` conventions. Go import resolution is local and module-path based when possible. For Rust, it detects `Cargo.toml` manifests and workspaces, Cargo package/dependency hints, Rust modules/imports, `pub` symbols, crate and module boundary hints, integration tests under `tests/`, and inline `#[cfg(test)]` tests. It does not run `go list`, Cargo, `rustc`, or `cargo metadata`; it does not perform AST parsing, type checking, semantic resolution, or add C# support.
 
 | File | Phase | Contents |
 |------|-------|----------|

--- a/platforms/codex/SKILL.md
+++ b/platforms/codex/SKILL.md
@@ -130,7 +130,7 @@ Also ensure root `.signum/` is ignored by git when appropriate.
 
 Project-level Codebase Awareness caches under `.signum/cache/`, including `file-digests-v1.json`, are rebuildable scanner cache, not active contract root evidence and not proofpack payloads. The digest cache supports bounded/incremental lexical scanning only; it does not add AST or semantic scanning. Scanner defaults are bounded at `--max-files 10000`, `--max-bytes 50000000`, and `--max-file-size 1048576`.
 
-Codebase Awareness has shallow Go lexical/symbol support. It detects `go.mod`, `go.work`, `.go` files, Go package names/imports, exported symbols, `internal/`, `cmd/`, `pkg/`, `testdata/`, and `*_test.go` conventions. Go import resolution is local and module-path based when possible; it does not run `go list`, perform AST or type checking, or add Rust/C# adapters.
+Codebase Awareness has shallow Go and Rust lexical/symbol support. For Go, it detects `go.mod`, `go.work`, `.go` files, Go package names/imports, exported symbols, `internal/`, `cmd/`, `pkg/`, `testdata/`, and `*_test.go` conventions. Go import resolution is local and module-path based when possible. For Rust, it detects `Cargo.toml` manifests and workspaces, Cargo package/dependency hints, Rust modules/imports, `pub` symbols, crate and module boundary hints, integration tests under `tests/`, and inline `#[cfg(test)]` tests. It does not run `go list`, Cargo, `rustc`, or `cargo metadata`; it does not perform AST parsing, type checking, semantic resolution, or add C# support.
 
 ## Phase 1: CONTRACT
 

--- a/scripts/codebase_awareness/build_candidates.py
+++ b/scripts/codebase_awareness/build_candidates.py
@@ -393,6 +393,7 @@ def is_test_path(path: str | None) -> bool:
         or name.startswith("test_")
         or name.endswith("_test.go")
         or name.endswith("_test.py")
+        or name.endswith("_test.rs")
         or ".test." in name
         or ".spec." in name
     )
@@ -477,6 +478,37 @@ def add_draft(
                 risk = "Go cmd/ package is an executable entrypoint boundary, not a generic helper."
                 if risk not in draft["risks"]:
                     draft["risks"].append(risk)
+            elif kind_value == "rust-binary-crate-root":
+                risk = "Rust binary src/main.rs is not a generic helper."
+                if risk not in draft["risks"]:
+                    draft["risks"].append(risk)
+            elif kind_value == "rust-crate-local-visibility" and kind != "existing-helper":
+                risk = "Rust module contains crate-local visibility; inspect symbol visibility before cross-crate reuse."
+                if risk not in draft["risks"]:
+                    draft["risks"].append(risk)
+        boundary_risk = record.get("risk")
+        if isinstance(boundary_risk, str) and boundary_risk and boundary_risk not in draft["risks"]:
+            draft["risks"].append(boundary_risk)
+        visibility = str(record.get("visibility") or "")
+        record_language = str(record.get("language") or language or "")
+        if record_language == "rust":
+            if visibility.startswith("pub("):
+                risk = "Rust crate-local visibility may not be reusable outside its crate"
+                if risk not in draft["risks"]:
+                    draft["risks"].append(risk)
+            elif visibility == "private" and kind == "existing-helper":
+                risk = "Rust private symbol is not reusable outside its module without changing visibility"
+                if risk not in draft["risks"]:
+                    draft["risks"].append(risk)
+        for risk in as_list(record.get("visibilityRisks")):
+            if kind == "existing-helper":
+                continue
+            if isinstance(risk, str) and risk and risk not in draft["risks"]:
+                draft["risks"].append(risk)
+    if (language == "rust" or stable_path.endswith(".rs")) and stable_path.endswith("/src/main.rs"):
+        risk = "Rust binary src/main.rs is not a generic helper"
+        if risk not in draft["risks"]:
+            draft["risks"].append(risk)
     if kind == "duplicate-risk":
         reason = "similar or repeated code fingerprint reported by scanner"
         if reason not in draft["risks"]:
@@ -489,6 +521,13 @@ def shared_symbol_record(record: dict[str, Any], name: str) -> dict[str, Any]:
     symbol_record["name"] = name
     symbol_record["tokens"] = split_identifier(name)
     symbol_record["symbols"] = [name]
+    symbol_record.pop("visibilityRisks", None)
+    symbol_record.pop("crateLocalSymbols", None)
+    symbol_record["boundaryHints"] = [
+        hint
+        for hint in as_list(record.get("boundaryHints"))
+        if not (isinstance(hint, dict) and hint.get("kind") == "rust-crate-local-visibility")
+    ]
     return symbol_record
 
 
@@ -532,6 +571,8 @@ def build_drafts(codebase_index: dict[str, Any], style_profile: dict[str, Any]) 
     for record in as_list(codebase_index.get("symbols")):
         path = record_path(record)
         if is_test_path(path):
+            continue
+        if isinstance(record, dict) and record.get("testOnly"):
             continue
         symbol = record_symbol(record)
         if not path and not symbol:
@@ -664,6 +705,7 @@ def build_drafts(codebase_index: dict[str, Any], style_profile: dict[str, Any]) 
         )
 
     style_sections = {
+        "boundaries": "module-boundary",
         "testConventions": "test-pattern",
         "errorHandling": "error-handling-pattern",
         "logging": "local-pattern",
@@ -696,11 +738,14 @@ def desired_languages(task_intent: dict[str, Any], codebase_index: dict[str, Any
             languages.add(language)
     token_map = {
         "javascript": "javascript",
+        "cargo": "rust",
         "go": "go",
         "golang": "go",
         "js": "javascript",
         "py": "python",
         "python": "python",
+        "rs": "rust",
+        "rust": "rust",
         "ts": "typescript",
         "typescript": "typescript",
     }

--- a/scripts/codebase_awareness/build_index.py
+++ b/scripts/codebase_awareness/build_index.py
@@ -20,6 +20,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
+    tomllib = None
+
 DEFAULT_MAX_FILES = 10_000
 DEFAULT_MAX_BYTES = 50_000_000
 DEFAULT_MAX_FILE_SIZE = 1_048_576
@@ -87,6 +92,7 @@ LANGUAGE_BY_SUFFIX = {
 
 SOURCE_LANGUAGES = {"go", "javascript", "python", "rust", "shell", "typescript"}
 MANIFEST_NAMES = {
+    "Cargo.lock": "cargo-lock",
     "Cargo.toml": "cargo",
     "go.mod": "go",
     "go.work": "go-work",
@@ -204,6 +210,7 @@ def language_for_path(rel: str) -> str | None:
     if path.name in MANIFEST_NAMES:
         return {
             "cargo": "toml",
+            "cargo-lock": "toml",
             "go": "go",
             "go-work": "go",
             "npm": "json" if path.suffix == ".json" else "yaml",
@@ -392,6 +399,7 @@ def is_test_path(rel: str) -> bool:
         or name.startswith("test_")
         or name.endswith("_test.go")
         or name.endswith("_test.py")
+        or name.endswith("_test.rs")
         or ".test." in name
         or ".spec." in name
     )
@@ -524,9 +532,253 @@ def extract_go_symbols(rel: str, text: str) -> list[dict[str, Any]]:
     return symbols
 
 
+def parse_toml_document(text: str) -> dict[str, Any]:
+    if tomllib is not None:
+        try:
+            data = tomllib.loads(text)
+        except tomllib.TOMLDecodeError:
+            data = {}
+        if isinstance(data, dict):
+            return data
+    return parse_toml_fallback(text)
+
+
+def parse_toml_fallback(text: str) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    section: list[str] = []
+    array_section: tuple[list[str], dict[str, Any]] | None = None
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("[[") and line.endswith("]]"):
+            section = [part.strip() for part in line[2:-2].split(".") if part.strip()]
+            container = data
+            for part in section[:-1]:
+                child = container.setdefault(part, {})
+                if not isinstance(child, dict):
+                    child = {}
+                    container[part] = child
+                container = child
+            entries = container.setdefault(section[-1], [])
+            if not isinstance(entries, list):
+                entries = []
+                container[section[-1]] = entries
+            item: dict[str, Any] = {}
+            entries.append(item)
+            array_section = (section, item)
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = [part.strip() for part in line[1:-1].split(".") if part.strip()]
+            array_section = None
+            continue
+        if "=" not in line:
+            continue
+        key, value = [part.strip() for part in line.split("=", 1)]
+        parsed: Any
+        if value.startswith('"') and value.endswith('"'):
+            parsed = value[1:-1]
+        elif value.startswith("[") and value.endswith("]"):
+            parsed = [
+                item.strip().strip('"').strip("'")
+                for item in value[1:-1].split(",")
+                if item.strip()
+            ]
+        else:
+            parsed = value.strip('"').strip("'")
+
+        if array_section is not None and array_section[0] == section:
+            array_section[1][key] = parsed
+            continue
+        container = data
+        for part in section:
+            child = container.setdefault(part, {})
+            if not isinstance(child, dict):
+                child = {}
+                container[part] = child
+            container = child
+        container[key] = parsed
+    return data
+
+
+def normalize_rust_visibility(raw: str | None) -> str:
+    if not raw:
+        return "private"
+    compact = re.sub(r"\s+", " ", raw.strip())
+    compact = compact.replace("pub (", "pub(")
+    compact = re.sub(r"\(\s+", "(", compact)
+    compact = re.sub(r"\s+\)", ")", compact)
+    return compact
+
+
+def rust_visibility_exported(visibility: str) -> bool:
+    return visibility == "pub"
+
+
+def rust_line_without_comment(line: str) -> str:
+    return line.split("//", 1)[0]
+
+
+def rust_brace_delta(line: str) -> int:
+    stripped = rust_line_without_comment(line)
+    return stripped.count("{") - stripped.count("}")
+
+
+def rust_impl_type(line: str) -> str | None:
+    pattern = re.compile(
+        r"""
+        ^\s*impl
+        (?:\s*<[^>{}]*>)?
+        \s+
+        (?:
+          [A-Za-z_][\w:<>]*
+          \s+for\s+
+        )?
+        (?P<type>[A-Za-z_][\w:]*)
+        (?:\s*<[^>{}]*>)?
+        (?:\s+where\b.*)?
+        \s*\{
+        """,
+        re.VERBOSE,
+    )
+    match = pattern.search(line)
+    if not match:
+        return None
+    return match.group("type").split("::")[-1]
+
+
+def rust_symbol_record(
+    *,
+    rel: str,
+    line_number: int,
+    kind: str,
+    name: str,
+    visibility: str,
+    impl_type: str | None = None,
+    test_only: bool = False,
+) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "name": name,
+        "kind": kind,
+        "language": "rust",
+        "path": rel,
+        "line": line_number,
+        "exported": rust_visibility_exported(visibility),
+        "visibility": visibility,
+        "tokens": sorted(set(split_identifier(name))),
+    }
+    if impl_type:
+        record["implType"] = impl_type
+        record["tokens"] = sorted(set(record["tokens"]) | set(split_identifier(impl_type)))
+    if test_only:
+        record["testOnly"] = True
+    return record
+
+
+def extract_rust_symbols(rel: str, text: str) -> list[dict[str, Any]]:
+    vis = r"(?P<vis>pub(?:\s*\([^)]*\))?)?"
+    fn_pattern = re.compile(
+        rf"^\s*{vis}\s*(?:(?:async|unsafe|const)\s+)*fn\s+(?P<name>[A-Za-z_][\w]*)\b"
+    )
+    type_pattern = re.compile(
+        rf"^\s*{vis}\s*(?P<kind>struct|enum|trait|type)\s+(?P<name>[A-Za-z_][\w]*)\b"
+    )
+    const_pattern = re.compile(
+        rf"^\s*{vis}\s*(?P<kind>const|static)\s+(?P<name>[A-Za-z_][\w]*)\b"
+    )
+    mod_pattern = re.compile(
+        rf"^\s*{vis}\s*mod\s+(?P<name>[A-Za-z_][\w]*)\s*(?:;|\{{)"
+    )
+    cfg_test_re = re.compile(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]")
+    test_attr_re = re.compile(r"#\s*\[\s*(?:(?:tokio|async_std)::)?test\s*\]")
+    symbols: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    brace_depth = 0
+    impl_stack: list[tuple[int, str]] = []
+    test_module_stack: list[int] = []
+    pending_cfg_test = False
+    pending_test_attr = False
+
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        while impl_stack and brace_depth < impl_stack[-1][0]:
+            impl_stack.pop()
+        while test_module_stack and brace_depth < test_module_stack[-1]:
+            test_module_stack.pop()
+
+        if cfg_test_re.search(line):
+            pending_cfg_test = True
+            brace_depth += rust_brace_delta(line)
+            continue
+
+        if test_attr_re.search(line):
+            pending_test_attr = True
+            brace_depth += rust_brace_delta(line)
+            continue
+
+        cfg_test_item = pending_cfg_test
+        pending_cfg_test = False
+        test_mod_line = bool(cfg_test_item and re.search(r"^\s*(?:pub\s+)?mod\s+[A-Za-z_][\w]*\s*\{", line))
+        if test_mod_line:
+            test_module_stack.append(brace_depth + 1)
+        test_attr_item = pending_test_attr
+        pending_test_attr = False
+        in_test_module = bool(test_module_stack) or cfg_test_item or test_attr_item
+
+        impl_type = rust_impl_type(line)
+        if impl_type and not in_test_module:
+            impl_stack.append((brace_depth + 1, impl_type))
+        active_impl = impl_stack[-1][1] if impl_stack and brace_depth >= impl_stack[-1][0] else None
+
+        if not in_test_module:
+            for pattern, default_kind in (
+                (fn_pattern, "function"),
+                (type_pattern, None),
+                (const_pattern, None),
+                (mod_pattern, "module"),
+            ):
+                match = pattern.search(line)
+                if not match:
+                    continue
+                name = match.group("name")
+                visibility = normalize_rust_visibility(match.groupdict().get("vis"))
+                kind = default_kind or match.group("kind")
+                if kind == "fn":
+                    kind = "function"
+                if kind == "const":
+                    kind = "constant"
+                if kind == "static":
+                    kind = "static"
+                if kind == "function" and active_impl:
+                    kind = "method"
+                key = (kind, name, active_impl or "")
+                if key in seen:
+                    continue
+                seen.add(key)
+                symbols.append(
+                    rust_symbol_record(
+                        rel=rel,
+                        line_number=line_number,
+                        kind=kind,
+                        name=name,
+                        visibility=visibility,
+                        impl_type=active_impl if kind == "method" else None,
+                    )
+                )
+                break
+
+        brace_depth += rust_brace_delta(line)
+        while impl_stack and brace_depth < impl_stack[-1][0]:
+            impl_stack.pop()
+        while test_module_stack and brace_depth < test_module_stack[-1]:
+            test_module_stack.pop()
+    return symbols
+
+
 def extract_symbols(rel: str, language: str | None, text: str) -> list[dict[str, Any]]:
     if language == "go":
         return extract_go_symbols(rel, text)
+    if language == "rust":
+        return extract_rust_symbols(rel, text)
 
     patterns: list[tuple[str, str, str]] = []
     if language in {"javascript", "typescript"}:
@@ -680,9 +932,130 @@ def extract_go_import_records(text: str) -> list[dict[str, Any]]:
     return [unique[key] for key in sorted(unique)]
 
 
+def split_top_level_commas(value: str) -> list[str]:
+    items: list[str] = []
+    depth = 0
+    start = 0
+    for index, char in enumerate(value):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth = max(0, depth - 1)
+        elif char == "," and depth == 0:
+            item = value[start:index].strip()
+            if item:
+                items.append(item)
+            start = index + 1
+    item = value[start:].strip()
+    if item:
+        items.append(item)
+    return items
+
+
+def find_matching_brace(value: str, start: int) -> int | None:
+    depth = 0
+    for index in range(start, len(value)):
+        char = value[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def clean_rust_use_spec(spec: str) -> str:
+    spec = re.sub(r"\s+as\s+[A-Za-z_][\w]*$", "", spec.strip())
+    spec = spec.strip(":")
+    spec = re.sub(r"\s+", "", spec)
+    return spec
+
+
+def expand_rust_use_tree(value: str) -> list[str]:
+    value = value.strip()
+    brace_index = value.find("{")
+    if brace_index == -1:
+        cleaned = clean_rust_use_spec(value)
+        return [cleaned] if cleaned else []
+    end = find_matching_brace(value, brace_index)
+    if end is None:
+        cleaned = clean_rust_use_spec(value)
+        return [cleaned] if cleaned else []
+
+    prefix = value[:brace_index]
+    suffix = value[end + 1 :]
+    inner = value[brace_index + 1 : end]
+    expanded: list[str] = []
+    for item in split_top_level_commas(inner):
+        for child in expand_rust_use_tree(item):
+            if child == "self":
+                combined = prefix.rstrip(":")
+            elif prefix.endswith("::"):
+                combined = f"{prefix}{child}"
+            elif prefix:
+                combined = f"{prefix}::{child}"
+            else:
+                combined = child
+            combined = clean_rust_use_spec(f"{combined}{suffix}")
+            if combined:
+                expanded.append(combined)
+    return sorted(set(expanded))
+
+
+def extract_rust_import_records(text: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    use_pattern = re.compile(r"^\s*(?P<vis>pub(?:\s*\([^)]*\))?)?\s*use\s+(?P<body>[^;]+);")
+    mod_pattern = re.compile(r"^\s*(?P<vis>pub(?:\s*\([^)]*\))?)?\s*mod\s+(?P<name>[A-Za-z_][\w]*)\s*(?:;|\{)")
+    seen: set[tuple[str, str, int]] = set()
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        use_match = use_pattern.search(line)
+        if use_match:
+            visibility = normalize_rust_visibility(use_match.group("vis"))
+            kind = "pub use" if visibility == "pub" else "use"
+            for spec in expand_rust_use_tree(use_match.group("body")):
+                key = (kind, spec, line_number)
+                if key in seen:
+                    continue
+                seen.add(key)
+                records.append(
+                    {
+                        "imported": spec,
+                        "kind": kind,
+                        "visibility": visibility,
+                        "exported": visibility == "pub",
+                        "tokens": sorted(set(split_identifier(spec))),
+                        "line": line_number,
+                    }
+                )
+            continue
+
+        mod_match = mod_pattern.search(line)
+        if mod_match:
+            visibility = normalize_rust_visibility(mod_match.group("vis"))
+            name = mod_match.group("name")
+            key = ("mod", name, line_number)
+            if key in seen:
+                continue
+            seen.add(key)
+            records.append(
+                {
+                    "imported": name,
+                    "kind": "mod",
+                    "visibility": visibility,
+                    "exported": visibility == "pub",
+                    "tokens": sorted(set(split_identifier(name))),
+                    "line": line_number,
+                }
+            )
+    return sorted(records, key=lambda item: (int(item.get("line", 0)), str(item.get("imported"))))
+
+
 def extract_import_records(language: str | None, text: str) -> list[dict[str, Any]]:
     if language == "go":
         return extract_go_import_records(text)
+    if language == "rust":
+        return extract_rust_import_records(text)
     return [
         {
             "imported": spec,
@@ -770,6 +1143,96 @@ def resolve_go_import(
     return None
 
 
+def rust_src_root(crate: dict[str, Any] | None) -> str:
+    if not crate:
+        return "src"
+    root = str(crate.get("root") or "")
+    return f"{root}/src" if root else "src"
+
+
+def rust_crate_for_path(rel: str, rust_context: dict[str, Any]) -> dict[str, Any] | None:
+    crates = rust_context.get("crates")
+    if not isinstance(crates, list):
+        return None
+    matches = []
+    for crate in crates:
+        if not isinstance(crate, dict):
+            continue
+        root = str(crate.get("root") or "")
+        if not root or rel == root or rel.startswith(f"{root}/"):
+            matches.append(crate)
+    if not matches:
+        return None
+    return sorted(matches, key=lambda item: len(str(item.get("root") or "")), reverse=True)[0]
+
+
+def rust_module_path_candidates(base_dir: str, module_parts: list[str]) -> list[str]:
+    candidates: list[str] = []
+    for count in range(len(module_parts), -1, -1):
+        parts = module_parts[:count]
+        if not parts:
+            candidates.extend(
+                [
+                    f"{base_dir}/lib.rs",
+                    f"{base_dir}/main.rs",
+                    f"{base_dir}/mod.rs",
+                ]
+            )
+            continue
+        module_path = "/".join(parts)
+        candidates.extend(
+            [
+                f"{base_dir}/{module_path}.rs",
+                f"{base_dir}/{module_path}/mod.rs",
+                f"{base_dir}/{module_path}/lib.rs",
+            ]
+        )
+    return [normalize_rel_parts(candidate) for candidate in candidates]
+
+
+def resolve_rust_import(
+    source_rel: str,
+    imported: str,
+    known_files: set[str],
+    rust_context: dict[str, Any],
+) -> str | None:
+    if not imported:
+        return None
+    parts = [part for part in imported.split("::") if part and part not in {"*"}]
+    if not parts:
+        return None
+    crate = rust_crate_for_path(source_rel, rust_context)
+    crate_by_name = rust_context.get("crateByName")
+    if not isinstance(crate_by_name, dict):
+        crate_by_name = {}
+
+    first = parts[0]
+    rest = parts[1:]
+    if first == "crate":
+        base = rust_src_root(crate)
+        module_parts = rest
+    elif first == "self":
+        base = Path(source_rel).parent.as_posix()
+        module_parts = rest
+    elif first == "super":
+        base = Path(source_rel).parent.parent.as_posix()
+        module_parts = rest
+    elif first in crate_by_name:
+        target = crate_by_name[first]
+        base = rust_src_root(target if isinstance(target, dict) else None)
+        module_parts = rest
+    elif crate:
+        base = rust_src_root(crate)
+        module_parts = parts
+    else:
+        return None
+
+    for candidate in rust_module_path_candidates(base, module_parts):
+        if candidate in known_files:
+            return candidate
+    return None
+
+
 def resolve_import(
     source_rel: str,
     spec: str,
@@ -778,9 +1241,14 @@ def resolve_import(
     language: str | None,
     go_modules: list[tuple[str, str]],
     go_package_dirs: set[str],
+    rust_context: dict[str, Any] | None = None,
 ) -> str | None:
     if language == "go":
         return resolve_go_import(spec, go_modules, go_package_dirs)
+    if language == "rust":
+        if isinstance(rust_context, dict):
+            return resolve_rust_import(source_rel, spec, known_files, rust_context)
+        return None
     if not spec.startswith("."):
         return None
     base = (Path(source_rel).parent / spec).as_posix()
@@ -824,7 +1292,39 @@ def test_framework_for_path(rel: str, text: str, language: str | None) -> str | 
         return "python-test"
     if language == "shell":
         return "shell"
+    if language == "rust":
+        if "#[tokio::test]" in text:
+            return "tokio-test"
+        if "#[async_std::test]" in text:
+            return "async-std-test"
+        return "rust-test"
     return None
+
+
+def rust_test_info(rel: str, text: str, language: str | None) -> dict[str, Any]:
+    if language != "rust":
+        return {"hasTests": False, "testFunctions": [], "hasCfgTest": False}
+    has_cfg_test = bool(re.search(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]", text))
+    test_functions: list[str] = []
+    pending_test = False
+    for line in text.splitlines():
+        if re.search(r"#\s*\[\s*(?:test|tokio::test|async_std::test)\s*\]", line):
+            pending_test = True
+            continue
+        if pending_test:
+            match = re.search(r"^\s*(?:async\s+)?fn\s+([A-Za-z_][\w]*)\b", line)
+            if match:
+                test_functions.append(match.group(1))
+                pending_test = False
+                continue
+            if line.strip() and not line.strip().startswith("#"):
+                pending_test = False
+    has_tests = has_cfg_test or bool(test_functions) or is_test_path(rel)
+    return {
+        "hasTests": has_tests,
+        "testFunctions": sorted(set(test_functions)),
+        "hasCfgTest": has_cfg_test,
+    }
 
 
 def paired_tests_for(rel: str, tests: list[dict[str, Any]]) -> list[str]:
@@ -920,6 +1420,56 @@ def extract_manifest(rel: str, text: str) -> dict[str, Any] | None:
             manifest["workspaceUses"] = workspace_uses
             use_tokens = {token for use in workspace_uses for token in split_identifier(use)}
             manifest["tokens"] = sorted(set(manifest["tokens"]) | use_tokens)
+    if path.name == "Cargo.toml":
+        data = parse_toml_document(text)
+        package = data.get("package") if isinstance(data, dict) else None
+        workspace = data.get("workspace") if isinstance(data, dict) else None
+        if isinstance(package, dict):
+            name = package.get("name")
+            if isinstance(name, str) and name:
+                manifest["packageName"] = name
+        if isinstance(workspace, dict):
+            members = workspace.get("members")
+            if isinstance(members, list):
+                manifest["workspaceMembers"] = sorted(str(member) for member in members if isinstance(member, str))
+        dependency_sections = {
+            "dependencies": "dependencies",
+            "dev-dependencies": "devDependencies",
+            "build-dependencies": "buildDependencies",
+        }
+        for source_key, output_key in dependency_sections.items():
+            section = data.get(source_key) if isinstance(data, dict) else None
+            if isinstance(section, dict):
+                manifest[output_key] = sorted(str(key) for key in section)
+        lib = data.get("lib") if isinstance(data, dict) else None
+        if isinstance(lib, dict):
+            hint = {str(key): str(value) for key, value in sorted(lib.items()) if isinstance(value, (str, int, bool))}
+            manifest["lib"] = hint or True
+        bins = data.get("bin") if isinstance(data, dict) else None
+        if isinstance(bins, list):
+            bin_targets = []
+            for item in bins:
+                if isinstance(item, dict):
+                    name = item.get("name")
+                    path_value = item.get("path")
+                    target = {}
+                    if isinstance(name, str):
+                        target["name"] = name
+                    if isinstance(path_value, str):
+                        target["path"] = path_value
+                    if target:
+                        bin_targets.append(target)
+            if bin_targets:
+                manifest["bin"] = sorted(bin_targets, key=lambda item: (str(item.get("name", "")), str(item.get("path", ""))))
+        token_values = [str(manifest.get("packageName", ""))]
+        token_values.extend(str(item) for item in manifest.get("workspaceMembers", []))
+        token_values.extend(str(item) for item in manifest.get("dependencies", []))
+        manifest["tokens"] = sorted(set(manifest["tokens"]) | set(split_identifier(" ".join(token_values))))
+    if path.name == "Cargo.lock":
+        packages = sorted(set(re.findall(r'^\s*name\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)))
+        if packages:
+            manifest["packages"] = packages[:50]
+            manifest["tokens"] = sorted(set(manifest["tokens"]) | set(split_identifier(" ".join(packages[:50]))))
     if path.name == "package.json":
         try:
             data = json.loads(text)
@@ -936,6 +1486,120 @@ def extract_manifest(rel: str, text: str) -> dict[str, Any] | None:
             if isinstance(dev_deps, dict):
                 manifest["devDependencies"] = sorted(str(key) for key in dev_deps)
     return manifest
+
+
+def rust_crate_name_for_package(package_name: str) -> str:
+    return package_name.replace("-", "_")
+
+
+def build_rust_context(manifests: list[dict[str, Any]], known_files: set[str]) -> dict[str, Any]:
+    workspace_members: set[str] = set()
+    for manifest in manifests:
+        if manifest.get("kind") != "cargo":
+            continue
+        base = Path(str(manifest.get("path") or "")).parent
+        base_rel = "" if base.as_posix() == "." else base.as_posix()
+        for member in manifest.get("workspaceMembers", []):
+            if not isinstance(member, str) or not member:
+                continue
+            member_path = normalize_rel_parts(f"{base_rel}/{member}" if base_rel else member)
+            workspace_members.add(member_path)
+
+    crates: list[dict[str, Any]] = []
+    for manifest in manifests:
+        if manifest.get("kind") != "cargo":
+            continue
+        path = str(manifest.get("path") or "")
+        root = Path(path).parent.as_posix()
+        if root == ".":
+            root = ""
+        package_name = manifest.get("packageName")
+        if not isinstance(package_name, str):
+            package_name = Path(root).name if root else ""
+        if not package_name and root not in workspace_members:
+            continue
+        crate = {
+            "root": root,
+            "manifestPath": path,
+            "packageName": package_name,
+            "crateName": rust_crate_name_for_package(package_name) if package_name else "",
+            "workspaceMember": root in workspace_members,
+        }
+        crates.append(crate)
+
+    crate_by_name: dict[str, dict[str, Any]] = {}
+    for crate in crates:
+        for key in (crate.get("crateName"), crate.get("packageName")):
+            if isinstance(key, str) and key:
+                crate_by_name[key] = crate
+
+    return {
+        "crates": sorted(crates, key=lambda item: str(item.get("root") or "")),
+        "crateByName": crate_by_name,
+        "workspaceMembers": sorted(workspace_members),
+        "knownFiles": sorted(known_files),
+    }
+
+
+def rust_module_role(rel: str, crate: dict[str, Any] | None) -> str | None:
+    if not crate:
+        if rel.startswith("crates/"):
+            return "crates-directory"
+        if Path(rel).parts and "tests" in Path(rel).parts:
+            return "integration-test"
+        return None
+    src_root = rust_src_root(crate)
+    if rel == f"{src_root}/lib.rs":
+        return "library-crate-root"
+    if rel == f"{src_root}/main.rs":
+        return "binary-crate-root"
+    if Path(rel).parts and "tests" in Path(rel).parts:
+        return "integration-test"
+    if Path(rel).name == "mod.rs":
+        return "module-root"
+    return None
+
+
+def rust_module_fields(rel: str, text: str, rust_context: dict[str, Any]) -> dict[str, Any]:
+    crate = rust_crate_for_path(rel, rust_context)
+    fields: dict[str, Any] = {}
+    if crate:
+        if crate.get("root"):
+            fields["crateRoot"] = crate.get("root")
+        if crate.get("crateName"):
+            fields["crateName"] = crate.get("crateName")
+        if crate.get("packageName"):
+            fields["packageName"] = crate.get("packageName")
+        if crate.get("workspaceMember"):
+            fields["workspaceMember"] = True
+    role = rust_module_role(rel, crate)
+    hints: list[dict[str, Any]] = []
+    if role == "library-crate-root":
+        hints.append({"kind": "rust-library-crate-root", "value": "Rust library crate root", "weak": False})
+    elif role == "binary-crate-root":
+        hints.append({"kind": "rust-binary-crate-root", "value": "Rust binary crate root", "weak": False})
+    elif role == "integration-test":
+        hints.append({"kind": "rust-integration-test", "value": "Rust integration test", "weak": False})
+    elif role == "crates-directory":
+        hints.append({"kind": "rust-crates-directory", "value": "crates/ directory convention", "weak": True})
+    if crate and crate.get("workspaceMember") and crate.get("root"):
+        hints.append(
+            {
+                "kind": "rust-workspace-member",
+                "value": "Cargo workspace member",
+                "weak": False,
+                "path": crate.get("root"),
+            }
+        )
+    if re.search(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]", text):
+        fields["hasInlineCfgTest"] = True
+        hints.append({"kind": "rust-inline-cfg-test", "value": "inline #[cfg(test)] tests", "weak": False})
+    if hints:
+        fields["boundaryHints"] = hints
+        fields["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in hints)
+    if role:
+        fields["rustRole"] = role
+    return fields
 
 
 def convention_entry(name: str, value: str, language: str | None, evidence: list[str]) -> dict[str, Any]:
@@ -983,6 +1647,10 @@ def build_style_profile(
             by_pattern[(language, "*_test.py")].append(path)
         elif "tests" in Path(path).parts:
             by_pattern[(language, "tests/ directory")].append(path)
+    for rel, text in sorted(file_text.items()):
+        language = language_for_path(rel)
+        if language == "rust" and re.search(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]", text):
+            by_pattern[(language, "inline #[cfg(test)]")].append(rel)
     for (language, pattern), evidence in sorted(by_pattern.items()):
         test_conventions.append(convention_entry("test-file-pattern", pattern, language or None, evidence))
 
@@ -991,6 +1659,7 @@ def build_style_profile(
     validation: list[dict[str, Any]] = []
     config: list[dict[str, Any]] = []
     go_conventions: list[dict[str, Any]] = []
+    rust_boundaries: list[dict[str, Any]] = []
     for rel, text in sorted(file_text.items()):
         language = language_for_path(rel)
         if re.search(r"\bthrow\s+new\s+Error\b|\btry\s*\{|\bcatch\s*\(", text):
@@ -1006,9 +1675,25 @@ def build_style_profile(
             package_name = extract_go_package_name(text)
             if package_name and not package_name.endswith("_test"):
                 go_conventions.append(convention_entry("go-test-scope", "package-local tests", "go", [rel]))
+        if language == "rust":
+            if rel.endswith("/src/lib.rs") or rel == "src/lib.rs":
+                rust_boundaries.append(convention_entry("boundary", "Rust library crate root", "rust", [rel]))
+            if rel.endswith("/src/main.rs") or rel == "src/main.rs":
+                rust_boundaries.append(convention_entry("boundary", "Rust binary crate root", "rust", [rel]))
+            if "tests" in Path(rel).parts:
+                rust_boundaries.append(convention_entry("boundary", "Rust integration tests directory", "rust", [rel]))
 
     for manifest in manifests:
         config.append(convention_entry("config", f"{manifest.get('kind')} manifest", manifest.get("language"), [str(manifest.get("path"))]))
+        if manifest.get("kind") == "cargo" and manifest.get("workspaceMembers"):
+            rust_boundaries.append(
+                convention_entry(
+                    "boundary",
+                    "Cargo workspace members",
+                    "rust",
+                    [str(manifest.get("path"))] + [str(item) for item in manifest.get("workspaceMembers", [])],
+                )
+            )
 
     validation_paths: set[str] = set()
     for symbol in symbols:
@@ -1031,14 +1716,25 @@ def build_style_profile(
                     )
     for path in sorted(validation_paths):
         validation.append(convention_entry("validation", "validation naming or helper", language_for_path(path), [path]))
+    crate_local_paths = sorted(
+        {
+            str(symbol.get("path"))
+            for symbol in symbols
+            if str(symbol.get("language")) == "rust"
+            and str(symbol.get("visibility") or "").startswith("pub(")
+        }
+    )
+    for path in crate_local_paths:
+        rust_boundaries.append(convention_entry("boundary", "Rust crate-local visibility", "rust", [path]))
 
     compact_error_handling = compact_conventions(error_handling)
     compact_logging = compact_conventions(logging)
     compact_config = compact_conventions(config)
     compact_validation = compact_conventions(validation)
     compact_go_conventions = compact_conventions(go_conventions)
+    compact_rust_boundaries = compact_conventions(rust_boundaries)
     confidence = 0.45
-    for section in (test_conventions, compact_error_handling, compact_logging, compact_config, compact_validation, compact_go_conventions):
+    for section in (test_conventions, compact_error_handling, compact_logging, compact_config, compact_validation, compact_go_conventions, compact_rust_boundaries):
         if section:
             confidence += 0.08
     if primary_languages:
@@ -1056,6 +1752,7 @@ def build_style_profile(
         "config": compact_config,
         "validation": compact_validation,
         "goConventions": compact_go_conventions,
+        "boundaries": compact_rust_boundaries,
     }
 
 
@@ -1176,7 +1873,7 @@ def collect_module_boundaries(modules: list[dict[str, Any]]) -> list[dict[str, A
             if not isinstance(hint, dict):
                 continue
             entry = {
-                "path": module.get("path"),
+                "path": hint.get("path") or module.get("path"),
                 "language": module.get("language"),
                 "kind": hint.get("kind"),
                 "value": hint.get("value"),
@@ -1184,6 +1881,8 @@ def collect_module_boundaries(modules: list[dict[str, Any]]) -> list[dict[str, A
             }
             if hint.get("allowedRoot"):
                 entry["allowedRoot"] = hint.get("allowedRoot")
+            if hint.get("risk"):
+                entry["risk"] = hint.get("risk")
             boundaries.append(entry)
     return sorted(
         boundaries,
@@ -1209,7 +1908,13 @@ def build_index(
     symbols: list[dict[str, Any]] = []
     imports: list[dict[str, Any]] = []
     tests: list[dict[str, Any]] = []
-    manifests: list[dict[str, Any]] = []
+    manifest_by_path: dict[str, dict[str, Any]] = {}
+    for scanned_file in indexed_files:
+        manifest = extract_manifest(scanned_file.rel, scanned_file.text)
+        if manifest:
+            manifest_by_path[scanned_file.rel] = manifest
+    manifests: list[dict[str, Any]] = list(manifest_by_path.values())
+    rust_context = build_rust_context(manifests, known_files)
 
     for scanned_file in indexed_files:
         rel = scanned_file.rel
@@ -1236,6 +1941,8 @@ def build_index(
         if language == "go" and boundary_hints:
             module["boundaryHints"] = boundary_hints
             module["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in boundary_hints)
+        if language == "rust":
+            module.update(rust_module_fields(rel, text, rust_context))
         if is_test_fixture_path(rel):
             module["testFixture"] = True
         modules.append(module)
@@ -1252,6 +1959,7 @@ def build_index(
                 language=language,
                 go_modules=go_modules,
                 go_package_dirs=go_package_dirs,
+                rust_context=rust_context,
             )
             item = {
                 "path": rel,
@@ -1260,16 +1968,17 @@ def build_index(
                 "resolvedPath": resolved_path,
                 "tokens": import_record.get("tokens", sorted(set(split_identifier(spec)))),
             }
-            for key in ("alias", "importKind"):
+            for key in ("alias", "importKind", "kind", "visibility", "exported", "line"):
                 if key in import_record:
                     item[key] = import_record.get(key)
             imports.append(item)
-        if kind == "test":
+        rust_tests = rust_test_info(rel, text, language)
+        if kind == "test" or rust_tests.get("hasTests"):
             test_entry = {
                 "path": rel,
                 "language": language,
                 "framework": test_framework_for_path(rel, text, language),
-                "tokens": tokens_for_path(rel),
+                "tokens": sorted(set(tokens_for_path(rel)) | ({"test"} if language == "rust" else set())),
             }
             if language == "go":
                 if package_name:
@@ -1278,10 +1987,11 @@ def build_index(
                 test_functions = sorted(set(GO_TEST_FUNCTION_RE.findall(text)))
                 if test_functions:
                     test_entry["testFunctions"] = test_functions
+            if rust_tests.get("testFunctions"):
+                test_entry["testFunctions"] = rust_tests["testFunctions"]
+            if rust_tests.get("hasCfgTest"):
+                test_entry["inlineCfgTest"] = True
             tests.append(test_entry)
-        manifest = extract_manifest(rel, text)
-        if manifest:
-            manifests.append(manifest)
 
     importers_by_target: dict[str, list[str]] = defaultdict(list)
     for item in imports:
@@ -1297,7 +2007,7 @@ def build_index(
             module["importedBy"] = imported_by
             module["importCount"] = len(imported_by)
         paired_tests = paired_tests_for(path, tests)
-        if paired_tests and path not in tests_by_path:
+        if paired_tests and (path not in tests_by_path or tests_by_path.get(path, {}).get("inlineCfgTest")):
             module["pairedTests"] = paired_tests
 
     modules.extend(build_go_package_modules(modules, symbols, tests, importers_by_target))
@@ -1305,6 +2015,39 @@ def build_index(
     symbols_by_path: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for symbol in symbols:
         symbols_by_path[str(symbol.get("path"))].append(symbol)
+
+    for module in modules:
+        if module.get("language") != "rust":
+            continue
+        path = str(module.get("path") or "")
+        if not path:
+            continue
+        hints = list(module.get("boundaryHints", []))
+        exported = sorted(
+            str(symbol.get("name"))
+            for symbol in symbols_by_path.get(path, [])
+            if symbol.get("exported") and isinstance(symbol.get("name"), str)
+        )
+        if exported:
+            hints.append({"kind": "rust-public-api", "value": "Rust public API candidate", "weak": False})
+        crate_local = sorted(
+            str(symbol.get("name"))
+            for symbol in symbols_by_path.get(path, [])
+            if str(symbol.get("visibility") or "").startswith("pub(") and isinstance(symbol.get("name"), str)
+        )
+        if crate_local:
+            hints.append(
+                {
+                    "kind": "rust-crate-local-visibility",
+                    "value": "Rust crate-local visibility",
+                    "weak": False,
+                    "risk": "pub(crate)/pub(super) visibility may not be reusable outside the crate",
+                }
+            )
+            module["crateLocalSymbols"] = crate_local
+        if hints:
+            module["boundaryHints"] = hints
+            module["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in hints if isinstance(hint, dict))
 
     shared_candidates: list[dict[str, Any]] = []
     for module in modules:
@@ -1345,6 +2088,14 @@ def build_index(
                 or module.get("pairedTests")
                 or exported_symbols
             )
+        elif module.get("language") == "rust":
+            if module.get("workspaceMember"):
+                reasons.append("workspace-member")
+            has_primary_shared_signal = bool(
+                exported_symbols
+                or module.get("importCount", 0)
+                or module.get("pairedTests")
+            )
         else:
             has_primary_shared_signal = bool((parts & SHARED_DIR_HINTS) or module.get("importCount", 0) or module.get("pairedTests"))
         if not has_primary_shared_signal:
@@ -1365,6 +2116,12 @@ def build_index(
             for key in ("package", "boundaryHints", "boundaryKinds", "internalBoundary", "weakReusablePackageConvention", "publicAPICandidate"):
                 if key in module:
                     candidate[key] = module.get(key)
+        if module.get("language") == "rust":
+            for key in ("crateName", "crateRoot", "packageName", "boundaryHints", "boundaryKinds", "workspaceMember", "crateLocalSymbols"):
+                if key in module:
+                    candidate[key] = module.get(key)
+            if module.get("crateLocalSymbols"):
+                candidate["visibilityRisks"] = ["pub(crate)/pub(super) symbols are crate-local"]
         shared_candidates.append(candidate)
 
     symbol_name_counts = Counter(str(symbol.get("name")) for symbol in symbols if symbol.get("name"))
@@ -1424,6 +2181,11 @@ def build_index(
             str(module.get("path"))
             for module in modules
             if module.get("language") == "go" and module.get("publicAPICandidate")
+        ),
+        "rustBoundaryPaths": sorted(
+            str(module.get("path"))
+            for module in modules
+            if module.get("language") == "rust" and module.get("boundaryHints")
         ),
     }
     module_boundaries = collect_module_boundaries(modules)

--- a/tests/fixtures/codebase-awareness/contracts/rust-validation-contract.json
+++ b/tests/fixtures/codebase-awareness/contracts/rust-validation-contract.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "1.0",
+  "contractId": "rust-validation-contract",
+  "goal": "Add email validation to Rust signup flow",
+  "riskLevel": "low",
+  "inScope": ["crates/api/src/signup.rs"],
+  "outOfScope": ["crates/shared/src/validation.rs"],
+  "assumptions": ["Existing Rust validation helpers should be considered before adding new signup validation code."],
+  "acceptanceCriteria": [
+    {
+      "id": "AC-1",
+      "description": "Signup flow validates email input before accepting the request."
+    },
+    {
+      "id": "AC-2",
+      "description": "Reuse an existing Rust validation helper when scanner evidence shows one is already available."
+    }
+  ],
+  "openQuestions": [],
+  "requiredInputsProvided": true
+}

--- a/tests/fixtures/codebase-awareness/rust-basic/Cargo.toml
+++ b/tests/fixtures/codebase-awareness/rust-basic/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["crates/shared", "crates/api", "crates/cli"]
+resolver = "2"

--- a/tests/fixtures/codebase-awareness/rust-basic/crates/api/Cargo.toml
+++ b/tests/fixtures/codebase-awareness/rust-basic/crates/api/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+shared = { path = "../shared" }

--- a/tests/fixtures/codebase-awareness/rust-basic/crates/api/src/lib.rs
+++ b/tests/fixtures/codebase-awareness/rust-basic/crates/api/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod signup;

--- a/tests/fixtures/codebase-awareness/rust-basic/crates/api/src/signup.rs
+++ b/tests/fixtures/codebase-awareness/rust-basic/crates/api/src/signup.rs
@@ -1,0 +1,9 @@
+use shared::validation::validate_email;
+
+pub struct SignupRequest {
+    pub email: String,
+}
+
+pub async fn create_signup(request: SignupRequest) -> bool {
+    validate_email(&request.email)
+}

--- a/tests/fixtures/codebase-awareness/rust-basic/crates/cli/Cargo.toml
+++ b/tests/fixtures/codebase-awareness/rust-basic/crates/cli/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "cli"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "signum-rust-basic"
+path = "src/main.rs"
+
+[dependencies]
+shared = { path = "../shared" }

--- a/tests/fixtures/codebase-awareness/rust-basic/crates/cli/src/main.rs
+++ b/tests/fixtures/codebase-awareness/rust-basic/crates/cli/src/main.rs
@@ -1,0 +1,5 @@
+use shared::validation::validate_email;
+
+fn main() {
+    let _ = validate_email("cli@example.com");
+}

--- a/tests/fixtures/codebase-awareness/rust-basic/crates/shared/Cargo.toml
+++ b/tests/fixtures/codebase-awareness/rust-basic/crates/shared/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "shared"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"

--- a/tests/fixtures/codebase-awareness/rust-basic/crates/shared/src/lib.rs
+++ b/tests/fixtures/codebase-awareness/rust-basic/crates/shared/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod validation;
+
+pub use validation::validate_email;

--- a/tests/fixtures/codebase-awareness/rust-basic/crates/shared/src/validation.rs
+++ b/tests/fixtures/codebase-awareness/rust-basic/crates/shared/src/validation.rs
@@ -1,0 +1,41 @@
+pub struct EmailAddress {
+    value: String,
+}
+
+pub enum ValidationError {
+    MissingAtSign,
+}
+
+pub trait Validator {
+    fn validate(&self, value: &str) -> bool;
+}
+
+pub type UserId = String;
+
+pub const DEFAULT_TIMEOUT: u64 = 30;
+
+static CACHE_NAME: &str = "validation";
+
+pub fn validate_email(value: &str) -> bool {
+    value.contains("@")
+}
+
+pub(crate) fn normalize_email(value: &str) -> String {
+    value.trim().to_lowercase()
+}
+
+impl EmailAddress {
+    pub fn validate(&self) -> bool {
+        validate_email(&self.value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_email() {
+        assert!(validate_email("a@example.com"));
+    }
+}

--- a/tests/fixtures/codebase-awareness/rust-basic/tests/integration_signup.rs
+++ b/tests/fixtures/codebase-awareness/rust-basic/tests/integration_signup.rs
@@ -1,0 +1,10 @@
+use api::signup::{create_signup, SignupRequest};
+
+#[tokio::test]
+async fn accepts_signup_email() {
+    let request = SignupRequest {
+        email: "a@example.com".to_string(),
+    };
+
+    assert!(create_signup(request).await);
+}

--- a/tests/test-codebase-rust-adapter.sh
+++ b/tests/test-codebase-rust-adapter.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+SCANNER="$ROOT_DIR/scripts/build_codebase_index.py"
+MATCHER="$ROOT_DIR/scripts/build_reuse_candidates.py"
+FIXTURE="$ROOT_DIR/tests/fixtures/codebase-awareness/rust-basic"
+CONTRACT="$ROOT_DIR/tests/fixtures/codebase-awareness/contracts/rust-validation-contract.json"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+passed=0
+failed=0
+
+pass() {
+  printf '  PASS: %s\n' "$1"
+  passed=$((passed + 1))
+}
+
+fail() {
+  printf '  FAIL: %s -- %s\n' "$1" "$2"
+  failed=$((failed + 1))
+}
+
+assert_file() {
+  local name="$1" path="$2"
+  if [ -f "$path" ]; then
+    pass "$name"
+  else
+    fail "$name" "missing $path"
+  fi
+}
+
+PROJECT_A="$WORK/run-a/rust-basic"
+PROJECT_B="$WORK/run-b/rust-basic"
+mkdir -p "$(dirname "$PROJECT_A")" "$(dirname "$PROJECT_B")"
+cp -R "$FIXTURE" "$PROJECT_A"
+cp -R "$FIXTURE" "$PROJECT_B"
+mkdir -p "$PROJECT_A/.signum/contracts/rust" "$PROJECT_B/.signum/contracts/rust"
+cp "$CONTRACT" "$PROJECT_A/.signum/contracts/rust/contract.json"
+cp "$CONTRACT" "$PROJECT_B/.signum/contracts/rust/contract.json"
+
+run_scanner() {
+  local project="$1"
+  (
+    cd "$project"
+    python3 "$SCANNER" \
+      --project-root "." \
+      --output ".signum/cache/codebase-index-v1.json" \
+      --style-output ".signum/cache/style-profile-v1.json" \
+      --digests-output ".signum/cache/file-digests-v1.json" \
+      --generated-at "2026-01-01T00:00:00Z"
+  )
+}
+
+run_matcher() {
+  local project="$1"
+  (
+    cd "$project"
+    python3 "$MATCHER" \
+      --project-root "." \
+      --contract ".signum/contracts/rust/contract.json" \
+      --codebase-index ".signum/cache/codebase-index-v1.json" \
+      --style-profile ".signum/cache/style-profile-v1.json" \
+      --output ".signum/contracts/rust/reuse_candidates.json" \
+      --implementation-context ".signum/contracts/rust/implementation_context.json" \
+      --max-candidates 12 \
+      --generated-at "2026-01-01T00:00:00Z"
+  )
+}
+
+run_second_digest() {
+  (
+    cd "$PROJECT_A"
+    python3 "$SCANNER" \
+      --project-root "." \
+      --output ".signum/cache/codebase-index-second.json" \
+      --style-output ".signum/cache/style-profile-second.json" \
+      --digests-output ".signum/cache/file-digests-second.json" \
+      --generated-at "2026-01-01T00:00:00Z"
+  )
+}
+
+INDEX_A="$PROJECT_A/.signum/cache/codebase-index-v1.json"
+STYLE_A="$PROJECT_A/.signum/cache/style-profile-v1.json"
+DIGEST_A="$PROJECT_A/.signum/cache/file-digests-v1.json"
+SECOND_DIGEST_A="$PROJECT_A/.signum/cache/file-digests-second.json"
+REUSE_A="$PROJECT_A/.signum/contracts/rust/reuse_candidates.json"
+CONTEXT_A="$PROJECT_A/.signum/contracts/rust/implementation_context.json"
+INDEX_B="$PROJECT_B/.signum/cache/codebase-index-v1.json"
+STYLE_B="$PROJECT_B/.signum/cache/style-profile-v1.json"
+DIGEST_B="$PROJECT_B/.signum/cache/file-digests-v1.json"
+REUSE_B="$PROJECT_B/.signum/contracts/rust/reuse_candidates.json"
+CONTEXT_B="$PROJECT_B/.signum/contracts/rust/implementation_context.json"
+
+echo "=== Rust scanner run ==="
+if run_scanner "$PROJECT_A"; then
+  pass "scanner run A exits 0"
+else
+  fail "scanner run A exits 0" "command failed"
+fi
+if run_scanner "$PROJECT_B"; then
+  pass "scanner run B exits 0"
+else
+  fail "scanner run B exits 0" "command failed"
+fi
+assert_file "rust codebase index created" "$INDEX_A"
+assert_file "rust style profile created" "$STYLE_A"
+assert_file "rust digest cache created" "$DIGEST_A"
+
+echo ""
+echo "=== Rust scanner signals ==="
+if python3 - "$INDEX_A" "$STYLE_A" "$DIGEST_A" "$WORK" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+index = json.loads(Path(sys.argv[1]).read_text())
+style = json.loads(Path(sys.argv[2]).read_text())
+digests = json.loads(Path(sys.argv[3]).read_text())
+work = sys.argv[4]
+errors = []
+
+def require(condition, message):
+    if not condition:
+        errors.append(message)
+
+def records(section):
+    value = index.get(section, [])
+    return value if isinstance(value, list) else []
+
+def find(section, **criteria):
+    for item in records(section):
+        if all(item.get(key) == value for key, value in criteria.items()):
+            return item
+    return None
+
+require(any(item.get("language") == "rust" for item in index.get("languageDetections", [])), "rust language detection missing")
+require("rust" in index.get("primaryLanguages", []), "rust primary language missing")
+
+root_manifest = find("manifests", path="Cargo.toml", kind="cargo")
+require(root_manifest is not None, "root Cargo.toml manifest missing")
+if root_manifest:
+    require(root_manifest.get("workspaceMembers") == ["crates/api", "crates/cli", "crates/shared"], "workspace members not parsed")
+shared_manifest = find("manifests", path="crates/shared/Cargo.toml", kind="cargo")
+require(shared_manifest is not None and shared_manifest.get("packageName") == "shared", "nested shared package manifest missing")
+api_manifest = find("manifests", path="crates/api/Cargo.toml", kind="cargo")
+require(api_manifest is not None and "shared" in api_manifest.get("dependencies", []), "dependency keys not parsed")
+cli_manifest = find("manifests", path="crates/cli/Cargo.toml", kind="cargo")
+require(cli_manifest is not None and cli_manifest.get("bin"), "bin hints not parsed")
+
+symbols = records("symbols")
+def symbol(name, kind=None, path="crates/shared/src/validation.rs"):
+    for item in symbols:
+        if item.get("name") == name and item.get("path") == path and (kind is None or item.get("kind") == kind):
+            return item
+    return None
+
+validate = symbol("validate_email", "function")
+require(validate is not None and validate.get("exported") is True and validate.get("visibility") == "pub", "pub function visibility/export missing")
+normalize = symbol("normalize_email", "function")
+require(normalize is not None and normalize.get("exported") is False and normalize.get("visibility") == "pub(crate)", "pub(crate) function visibility/export missing")
+require(symbol("EmailAddress", "struct") is not None, "struct symbol missing")
+require(symbol("ValidationError", "enum") is not None, "enum symbol missing")
+require(symbol("Validator", "trait") is not None, "trait symbol missing")
+require(symbol("UserId", "type") is not None, "type alias symbol missing")
+require(symbol("DEFAULT_TIMEOUT", "constant") is not None, "const symbol missing")
+require(symbol("CACHE_NAME", "static") is not None, "static symbol missing")
+method = symbol("validate", "method")
+require(method is not None and method.get("implType") == "EmailAddress", "impl method symbol missing")
+module_symbol = symbol("validation", "module", "crates/shared/src/lib.rs")
+require(module_symbol is not None and module_symbol.get("exported") is True, "pub mod symbol missing")
+inline_test_symbol = symbol("validates_email", "function")
+require(
+    inline_test_symbol is None or inline_test_symbol.get("testOnly") is True,
+    "inline cfg(test) function emitted as production symbol",
+)
+
+imports = records("imports")
+def has_import(path, imported, resolved=None, kind=None):
+    for item in imports:
+        if item.get("path") != path or item.get("imported") != imported:
+            continue
+        if resolved is not None and item.get("resolvedPath") != resolved:
+            continue
+        if kind is not None and item.get("kind") != kind:
+            continue
+        return True
+    return False
+
+require(has_import("crates/api/src/signup.rs", "shared::validation::validate_email", "crates/shared/src/validation.rs"), "api shared use import not resolved")
+require(has_import("crates/cli/src/main.rs", "shared::validation::validate_email", "crates/shared/src/validation.rs"), "cli shared use import not resolved")
+require(has_import("crates/shared/src/lib.rs", "validation", "crates/shared/src/validation.rs", "mod"), "pub mod validation not resolved")
+require(has_import("crates/shared/src/lib.rs", "validation::validate_email", "crates/shared/src/validation.rs", "pub use"), "pub use validation not extracted")
+require(has_import("tests/integration_signup.rs", "api::signup::create_signup", "crates/api/src/signup.rs"), "workspace crate integration import not resolved")
+
+modules = records("modules")
+shared_lib = find("modules", path="crates/shared/src/lib.rs")
+cli_main = find("modules", path="crates/cli/src/main.rs")
+integration = find("modules", path="tests/integration_signup.rs")
+require(shared_lib is not None and shared_lib.get("rustRole") == "library-crate-root", "src/lib.rs library boundary missing")
+require(cli_main is not None and cli_main.get("rustRole") == "binary-crate-root", "src/main.rs binary boundary missing")
+require(integration is not None and integration.get("kind") == "test", "tests/ integration test module missing")
+
+boundaries = records("moduleBoundaries")
+def has_boundary(path, kind):
+    return any(item.get("path") == path and item.get("kind") == kind for item in boundaries)
+require(has_boundary("crates/shared/src/lib.rs", "rust-library-crate-root"), "library crate boundary missing")
+require(has_boundary("crates/cli/src/main.rs", "rust-binary-crate-root"), "binary crate boundary missing")
+require(has_boundary("crates/shared", "rust-workspace-member"), "workspace member boundary missing")
+require(has_boundary("crates/shared/src/validation.rs", "rust-inline-cfg-test"), "inline cfg test boundary missing")
+require(has_boundary("crates/shared/src/validation.rs", "rust-crate-local-visibility"), "crate-local visibility boundary missing")
+
+tests = records("tests")
+validation_test = next((item for item in tests if item.get("path") == "crates/shared/src/validation.rs"), None)
+require(validation_test is not None and validation_test.get("framework") == "rust-test", "inline Rust test record missing")
+if validation_test:
+    require(validation_test.get("inlineCfgTest") is True, "inline cfg(test) flag missing")
+    require("validates_email" in validation_test.get("testFunctions", []), "inline test function missing")
+integration_test = next((item for item in tests if item.get("path") == "tests/integration_signup.rs"), None)
+require(integration_test is not None and integration_test.get("framework") == "tokio-test", "tokio integration test missing")
+if integration_test:
+    require("accepts_signup_email" in integration_test.get("testFunctions", []), "tokio test function missing")
+
+test_conventions = style.get("testConventions", [])
+require(any(item.get("language") == "rust" and item.get("value") == "inline #[cfg(test)]" for item in test_conventions), "inline Rust test convention missing")
+require(any(item.get("language") == "rust" and item.get("value") == "tests/ directory" for item in test_conventions), "Rust tests directory convention missing")
+require(any(item.get("value") == "Rust crate-local visibility" for item in style.get("boundaries", [])), "crate-local visibility style boundary missing")
+
+shared = find("sharedCandidates", path="crates/shared/src/validation.rs")
+require(shared is not None, "Rust shared validation candidate missing")
+if shared:
+    require("validate_email" in shared.get("symbols", []), "shared candidate exported symbol missing")
+    require(shared.get("usageCount", 0) >= 2, "shared candidate fan-in too low")
+    require("crates/api/src/signup.rs" in shared.get("importedBy", []), "api importer missing")
+    require("crates/cli/src/main.rs" in shared.get("importedBy", []), "cli importer missing")
+    require("crates/shared/src/validation.rs" in shared.get("pairedTests", []), "inline paired test missing")
+    reasons = set(shared.get("reasons", []))
+    require({"imported-by-local-files", "exported-symbols", "paired-test"} <= reasons, "shared candidate lacks strong reasons")
+    require(reasons != {"shared-directory-name"}, "shared candidate relies only on directory name")
+    require("normalize_email" in shared.get("crateLocalSymbols", []), "crate-local symbol risk evidence missing")
+    require(shared.get("visibilityRisks"), "visibility risk missing on shared candidate")
+
+for candidate in records("sharedCandidates"):
+    reasons = set(candidate.get("reasons", []))
+    if candidate.get("language") == "rust":
+        require(reasons != {"shared-directory-name"} and reasons != {"rust-crates-directory"}, "Rust candidate uses only weak directory prior")
+
+files = digests.get("files", {})
+for path in (
+    "Cargo.toml",
+    "crates/shared/src/validation.rs",
+    "crates/api/src/signup.rs",
+    "crates/cli/src/main.rs",
+    "tests/integration_signup.rs",
+):
+    require(path in files, f"digest missing {path}")
+    require(files.get(path, {}).get("indexed") is True, f"digest did not index {path}")
+require(work not in json.dumps(index) and work not in json.dumps(style) and work not in json.dumps(digests), "scanner artifacts leaked temp path")
+
+if errors:
+    for error in errors:
+        print(error, file=sys.stderr)
+    raise SystemExit(1)
+PY
+then
+  pass "Rust scanner language, manifest, symbol, import, test, boundary, shared, and digest signals are valid"
+else
+  fail "Rust scanner language, manifest, symbol, import, test, boundary, shared, and digest signals are valid" "Python assertion failed"
+fi
+
+echo ""
+echo "=== Rust matcher run ==="
+if run_matcher "$PROJECT_A"; then
+  pass "matcher run A exits 0"
+else
+  fail "matcher run A exits 0" "command failed"
+fi
+if run_matcher "$PROJECT_B"; then
+  pass "matcher run B exits 0"
+else
+  fail "matcher run B exits 0" "command failed"
+fi
+assert_file "rust reuse candidates created" "$REUSE_A"
+assert_file "rust implementation context created" "$CONTEXT_A"
+
+if python3 - "$REUSE_A" "$CONTEXT_A" "$WORK" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+reuse = json.loads(Path(sys.argv[1]).read_text())
+context = json.loads(Path(sys.argv[2]).read_text())
+work = sys.argv[3]
+errors = []
+
+def require(condition, message):
+    if not condition:
+        errors.append(message)
+
+candidates = reuse.get("candidates", [])
+require(reuse.get("contractId") == "rust-validation-contract", "Rust contract ID missing")
+require(reuse.get("candidateCount") == len(candidates), "candidate count mismatch")
+require("rust" in context.get("primaryLanguages", []), "Rust context language missing")
+require(context.get("moduleBoundaries"), "Rust module boundaries missing from implementation context")
+require(work not in json.dumps(reuse) and work not in json.dumps(context), "matcher artifacts leaked temp path")
+
+validation_candidates = [
+    item for item in candidates
+    if item.get("path") == "crates/shared/src/validation.rs"
+    and item.get("kind") in {"existing-helper", "shared-module"}
+]
+require(validation_candidates, "Rust validation helper candidate missing")
+helper = next((item for item in validation_candidates if item.get("symbol") == "validate_email"), None)
+require(helper is not None, "validate_email helper candidate missing")
+helper = helper or validation_candidates[0]
+why = " ".join(helper.get("whyRelevant", [])).lower()
+require(helper.get("whyRelevant"), "Rust helper whyRelevant missing")
+require(any(term in why for term in ("symbol", "imported", "paired test", "shared candidate", "validation")), "Rust helper lacks evidence")
+require(helper.get("kind") in {"existing-helper", "shared-module"}, "Rust helper kind is unexpected")
+require(any(item.get("path") == "crates/shared/src/validation.rs" for item in candidates[:3]), "Rust helper is not a top candidate")
+helper_risks = " ".join(helper.get("risks", [])).lower()
+require("crate-local" not in helper_risks and "outside its crate" not in helper_risks, "pub helper inherited crate-local visibility risk")
+
+require(
+    not any(item.get("symbol") == "validates_email" for item in candidates),
+    "inline test function surfaced as reuse candidate",
+)
+
+normalize = next((item for item in candidates if item.get("symbol") == "normalize_email"), None)
+if normalize is not None:
+    risks = " ".join(normalize.get("risks", [])).lower()
+    require("crate-local" in risks or "outside its crate" in risks, "pub(crate) helper lacks boundary risk")
+
+shared_module = next(
+    (
+        item for item in candidates
+        if item.get("path") == "crates/shared/src/validation.rs"
+        and item.get("kind") == "shared-module"
+    ),
+    None,
+)
+if shared_module is not None:
+    module_risks = " ".join(shared_module.get("risks", [])).lower()
+    require("crate-local" in module_risks or "visibility" in module_risks, "shared module lacks mixed visibility boundary context")
+
+main_candidate = next((item for item in candidates if item.get("path") == "crates/cli/src/main.rs"), None)
+if main_candidate is not None:
+    require(any("binary" in risk.lower() for risk in main_candidate.get("risks", [])), "src/main.rs candidate lacks binary boundary risk")
+
+for candidate in validation_candidates:
+    why_text = " ".join(candidate.get("whyRelevant", [])).lower()
+    require("crates directory" not in why_text, "validation candidate relies on crates directory wording")
+
+if errors:
+    for error in errors:
+        print(error, file=sys.stderr)
+    raise SystemExit(1)
+PY
+then
+  pass "Rust matcher candidates and boundary risks are valid"
+else
+  fail "Rust matcher candidates and boundary risks are valid" "Python assertion failed"
+fi
+
+echo ""
+echo "=== Fixed-time stability ==="
+if run_second_digest; then
+  pass "second same-project digest run exits 0"
+else
+  fail "second same-project digest run exits 0" "command failed"
+fi
+if cmp -s "$INDEX_A" "$INDEX_B"; then
+  pass "rust codebase index is byte-stable with fixed generatedAt"
+else
+  fail "rust codebase index is byte-stable with fixed generatedAt" "$(diff -u "$INDEX_A" "$INDEX_B" || true)"
+fi
+if cmp -s "$STYLE_A" "$STYLE_B"; then
+  pass "rust style profile is byte-stable with fixed generatedAt"
+else
+  fail "rust style profile is byte-stable with fixed generatedAt" "$(diff -u "$STYLE_A" "$STYLE_B" || true)"
+fi
+if cmp -s "$DIGEST_A" "$SECOND_DIGEST_A"; then
+  pass "rust digest cache is byte-stable with fixed generatedAt"
+else
+  fail "rust digest cache is byte-stable with fixed generatedAt" "$(diff -u "$DIGEST_A" "$SECOND_DIGEST_A" || true)"
+fi
+if cmp -s "$REUSE_A" "$REUSE_B"; then
+  pass "rust reuse candidates are byte-stable with fixed generatedAt"
+else
+  fail "rust reuse candidates are byte-stable with fixed generatedAt" "$(diff -u "$REUSE_A" "$REUSE_B" || true)"
+fi
+if cmp -s "$CONTEXT_A" "$CONTEXT_B"; then
+  pass "rust implementation context is byte-stable with fixed generatedAt"
+else
+  fail "rust implementation context is byte-stable with fixed generatedAt" "$(diff -u "$CONTEXT_A" "$CONTEXT_B" || true)"
+fi
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi
+
+echo "ok: codebase awareness Rust adapter signals and matcher candidates are deterministic"


### PR DESCRIPTION
## Summary

- Add shallow Rust lexical/symbol support to the Codebase Awareness scanner.
- Add Cargo manifest/workspace/package/dependency/bin/lib hint parsing without invoking Cargo.
- Add Rust imports/module references, approximate workspace crate resolution, crate/module boundary hints, Rust test detection, and evidence-based shared candidates.
- Add matcher language context and Rust boundary risks for crate-local visibility and binary `src/main.rs` candidates.
- Add a `rust-basic` fixture repo, Rust validation contract fixture, and deterministic Rust adapter test.
- Update root, Claude overlay, and Codex docs with narrow Rust support wording.

## Rust signals added

- `Cargo.toml` and `Cargo.lock` manifest/config detection.
- Cargo workspace members, nested package names, dependency keys, and lib/bin hints.
- Rust functions, methods, structs, enums, traits, type aliases, const/static items, and modules.
- Rust `use`, grouped `use`, `mod`, `pub mod`, and `pub use` references.
- Approximate resolution for local workspace crate imports such as `shared::validation::validate_email`.
- `src/lib.rs`, `src/main.rs`, workspace member, `tests/`, inline `#[cfg(test)]`, public API, and crate-local visibility boundary hints.
- Rust `#[test]`, `#[tokio::test]`, `#[async_std::test]`, inline tests, integration tests, and test function names.
- Rust shared candidates that require import/test/export/workspace evidence rather than relying only on `crates/`.

## Explicit non-goals

- No Cargo, `rustc`, `cargo metadata`, or `cargo test` execution.
- No C# adapter.
- No Tree-sitter, AST parser dependency, embeddings, Semgrep, CodeQL, Faiss, or network-backed scanning.
- No verdict mapping, duplicate scan schema, reuse summary schema, PACK/proofpack behavior, or true incremental per-file extraction reuse changes.
- No semantic Rust type checking or full module resolution claims.

## Validation

- `git diff --check`
- `git status --short`
- `git ls-files --others --exclude-standard`
- `python3 -m compileall -q scripts/codebase_awareness scripts/build_codebase_index.py scripts/build_reuse_candidates.py scripts/validate_reuse_decision.py scripts/audit_codebase_reuse.py scripts/evaluate_codebase_awareness_audit.py scripts/build_reuse_summary.py`
- `bash tests/test-codebase-index.sh`
- `bash tests/test-codebase-digests-cache.sh`
- `bash tests/test-codebase-rust-adapter.sh`
- `bash tests/test-reuse-candidates.sh`
- `bash tests/test-reuse-decision-validator.sh`
- `bash tests/test-codebase-reuse-audit.sh`
- `bash tests/test-codebase-reuse-summary.sh`
- `bash tests/test-codebase-awareness-execute-wiring.sh`
- `bash tests/test-codebase-awareness-audit-wiring.sh`
- `bash tests/test-codebase-awareness-verdict-mapping.sh`
- `bash tests/test-codebase-awareness-pack-wiring.sh`
- `CDPATH= bash tests/test-artifact-path-inventory.sh`
- `bash tests/test-helper-output-paths.sh`
- `CDPATH= bash tests/test-signum-command-renderer.sh`
- `CDPATH= bash tests/test-signum-fragment-parity.sh`
- `CDPATH= bash tests/test-claude-overlay-runtime-parity.sh`
- `CDPATH= bash tests/test-claude-overlay-doc-mirror.sh`
- `CDPATH= bash tests/test-claude-overlay-pack-parity.sh`
- `CDPATH= bash tests/test-signum-command-structure.sh`
- `CDPATH= bash tests/test-codex-skill-canonical-paths.sh`
- `CDPATH= bash tests/test-codex-plugin-metadata.sh`
- `bash scripts/run-deterministic-tests.sh`

Note: `tests/test-codebase-go-adapter.sh` is absent in this checkout, so the closest existing Codebase Awareness scanner/matcher coverage was run and the missing command is reported in the Signum mechanic report.