### PR TITLE
[codex] Extract Codebase Awareness scanner adapters

### DIFF
--- a/scripts/codebase_awareness/adapters/__init__.py
+++ b/scripts/codebase_awareness/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Language adapters for the shallow codebase awareness scanner."""

--- a/scripts/codebase_awareness/adapters/common.py
+++ b/scripts/codebase_awareness/adapters/common.py
@@ -1,0 +1,51 @@
+"""Shared stdlib helpers for codebase awareness scanner adapters."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def split_identifier(value: str) -> list[str]:
+    value = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", value)
+    value = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", value)
+    return [part.lower() for part in re.split(r"[^A-Za-z0-9]+", value) if part]
+
+
+def tokens_for_path(rel: str) -> list[str]:
+    return sorted(set(split_identifier(rel)))
+
+
+def is_test_path(rel: str) -> bool:
+    path = Path(rel)
+    name = path.name
+    parts = set(path.parts)
+    return (
+        "test" in parts
+        or "tests" in parts
+        or name.startswith("test_")
+        or name.endswith("Test.cs")
+        or name.endswith("Tests.cs")
+        or name.endswith("_test.go")
+        or name.endswith("_test.py")
+        or name.endswith("_test.rs")
+        or ".test." in name
+        or ".spec." in name
+    )
+
+
+def is_test_fixture_path(rel: str) -> bool:
+    return "testdata" in Path(rel).parts
+
+
+def normalize_rel_parts(value: str) -> str:
+    parts: list[str] = []
+    for part in value.split("/"):
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if parts:
+                parts.pop()
+            continue
+        parts.append(part)
+    return "/".join(parts)

--- a/scripts/codebase_awareness/adapters/csharp.py
+++ b/scripts/codebase_awareness/adapters/csharp.py
@@ -1,0 +1,1046 @@
+"""C#/.NET adapter for the shallow codebase awareness scanner."""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from scripts.codebase_awareness.adapters.common import (
+    is_test_path,
+    normalize_rel_parts,
+    split_identifier,
+    tokens_for_path,
+)
+
+TEST_PACKAGE_FRAMEWORKS = {
+    "microsoft.net.test.sdk": "dotnet-test",
+    "mstest.testframework": "mstest",
+    "nunit": "nunit",
+    "xunit": "xunit",
+}
+EXTERNAL_NAMESPACE_PREFIXES = ("Microsoft.", "Newtonsoft.", "System.")
+
+
+def manifest_kinds() -> dict[str, str]:
+    return {
+        "Directory.Build.props": "dotnet-props",
+        "Directory.Build.targets": "dotnet-targets",
+    }
+
+
+def manifest_kind_for_path(rel: str) -> str | None:
+    path = Path(rel)
+    if path.suffix == ".sln":
+        return "dotnet-solution"
+    if path.suffix == ".csproj":
+        return "dotnet-project"
+    if path.name == "Directory.Build.props" or path.suffix == ".props":
+        return "dotnet-props"
+    if path.name == "Directory.Build.targets" or path.suffix == ".targets":
+        return "dotnet-targets"
+    return None
+
+
+def language_for_manifest(kind: str) -> str | None:
+    if kind in {"dotnet-project", "dotnet-props", "dotnet-solution", "dotnet-targets"}:
+        return "csharp"
+    return None
+
+
+def line_without_comment(line: str) -> str:
+    in_string = False
+    escaped = False
+    quote = ""
+    for index, char in enumerate(line):
+        if in_string:
+            if escaped:
+                escaped = False
+                continue
+            if char == "\\":
+                escaped = True
+                continue
+            if char == quote:
+                in_string = False
+                quote = ""
+            continue
+        if char in {"\"", "'"}:
+            in_string = True
+            quote = char
+            continue
+        if char == "/" and index + 1 < len(line) and line[index + 1] == "/":
+            return line[:index]
+    return line
+
+
+def brace_delta(line: str) -> int:
+    stripped = line_without_comment(line)
+    return stripped.count("{") - stripped.count("}")
+
+
+def normalize_visibility(modifiers: str, default_visibility: str) -> str:
+    words = set(re.findall(r"\b(public|internal|private|protected)\b", modifiers))
+    if "private" in words and "protected" in words:
+        return "private protected"
+    if "protected" in words and "internal" in words:
+        return "protected internal"
+    for visibility in ("public", "internal", "private", "protected"):
+        if visibility in words:
+            return visibility
+    return default_visibility
+
+
+def visibility_exported(visibility: str) -> bool:
+    return visibility == "public"
+
+
+def visibility_risk(visibility: str) -> str | None:
+    if visibility == "internal":
+        return "C# internal symbol is assembly-local and may not be reusable across project boundaries"
+    if visibility == "protected internal":
+        return "C# protected internal symbol is constrained by assembly or inheritance boundaries"
+    if visibility == "private protected":
+        return "C# private protected symbol is constrained to derived types in the same assembly"
+    if visibility == "protected":
+        return "C# protected symbol is inheritance-scoped"
+    if visibility == "private":
+        return "C# private symbol is not reusable outside its containing type"
+    return None
+
+
+def symbol_record(
+    *,
+    rel: str,
+    line_number: int,
+    kind: str,
+    name: str,
+    visibility: str,
+    namespace: str | None,
+    container: str | None = None,
+    is_static: bool = False,
+) -> dict[str, Any]:
+    tokens = set(split_identifier(name))
+    if container:
+        tokens.update(split_identifier(container))
+    record: dict[str, Any] = {
+        "name": name,
+        "kind": kind,
+        "language": "csharp",
+        "path": rel,
+        "line": line_number,
+        "exported": visibility_exported(visibility),
+        "visibility": visibility,
+        "static": is_static,
+        "tokens": sorted(tokens),
+    }
+    if namespace:
+        record["namespace"] = namespace
+    if container:
+        record["container"] = container
+    risk = visibility_risk(visibility)
+    if risk:
+        record["visibilityRisks"] = [risk]
+    return record
+
+
+def extract_namespaces(rel: str, text: str) -> list[dict[str, Any]]:
+    namespaces: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        stripped = line_without_comment(line)
+        match = re.search(r"^\s*namespace\s+([A-Za-z_][\w.]*)\s*(?:[;{]|$)", stripped)
+        if not match:
+            continue
+        namespace = match.group(1)
+        if namespace in seen:
+            continue
+        seen.add(namespace)
+        namespaces.append(
+            symbol_record(
+                rel=rel,
+                line_number=line_number,
+                kind="namespace",
+                name=namespace,
+                visibility="public",
+                namespace=namespace,
+            )
+        )
+    return namespaces
+
+
+def extract_symbols(rel: str, text: str) -> list[dict[str, Any]]:
+    symbols = extract_namespaces(rel, text)
+    modifier_words = (
+        "public|internal|private|protected|static|sealed|abstract|partial|readonly|"
+        "ref|unsafe|new|virtual|override|async|extern|required|const"
+    )
+    modifiers = rf"(?P<mods>(?:(?:{modifier_words})\s+)*)"
+    type_pattern = re.compile(
+        rf"^\s*{modifiers}(?P<kind>record\s+struct|record\s+class|class|record|struct|interface|enum)\s+"
+        rf"(?P<name>[A-Za-z_][\w]*)\b"
+    )
+    constructor_pattern = re.compile(rf"^\s*{modifiers}(?P<name>[A-Za-z_][\w]*)\s*\(")
+    method_pattern = re.compile(
+        rf"^\s*{modifiers}(?P<return>[A-Za-z_][\w.<>,?\[\]]*(?:\s*<[^;=(){{}}]+>)?)\s+"
+        rf"(?P<name>[A-Za-z_][\w]*)\s*(?:<[^;=(){{}}]+>)?\s*\("
+    )
+    property_pattern = re.compile(
+        rf"^\s*{modifiers}(?P<type>[A-Za-z_][\w.<>,?\[\]]*)\s+"
+        rf"(?P<name>[A-Za-z_][\w]*)\s*\{{[^}}]*(?:get|set|init)\b"
+    )
+    field_pattern = re.compile(
+        rf"^\s*{modifiers}(?P<type>[A-Za-z_][\w.<>,?\[\]]*)\s+"
+        rf"(?P<name>[A-Za-z_][\w]*)\s*(?:=|;)"
+    )
+    namespace_pattern = re.compile(r"^\s*namespace\s+([A-Za-z_][\w.]*)\s*(?:[;{]|$)")
+    control_words = {"catch", "for", "foreach", "if", "lock", "switch", "using", "while"}
+    seen: set[tuple[str, str, str | None]] = {
+        ("namespace", str(symbol.get("name")), None) for symbol in symbols
+    }
+    brace_depth = 0
+    type_stack: list[tuple[int, str]] = []
+    pending_type: tuple[str, int] | None = None
+    current_namespace: str | None = None
+
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        while type_stack and brace_depth < type_stack[-1][0]:
+            type_stack.pop()
+        line = line_without_comment(raw_line)
+        stripped = line.strip()
+        if not stripped or stripped.startswith("["):
+            brace_depth += brace_delta(line)
+            continue
+
+        namespace_match = namespace_pattern.search(line)
+        if namespace_match:
+            current_namespace = namespace_match.group(1)
+
+        if pending_type and "{" in line:
+            type_stack.append((brace_depth + 1, pending_type[0]))
+            pending_type = None
+
+        type_match = type_pattern.search(line)
+        if type_match:
+            raw_kind = re.sub(r"\s+", " ", type_match.group("kind").strip())
+            kind = "record" if raw_kind.startswith("record") else raw_kind
+            name = type_match.group("name")
+            visibility = normalize_visibility(type_match.group("mods") or "", "internal")
+            key = (kind, name, type_stack[-1][1] if type_stack else None)
+            if key not in seen:
+                seen.add(key)
+                symbols.append(
+                    symbol_record(
+                        rel=rel,
+                        line_number=line_number,
+                        kind=kind,
+                        name=name,
+                        visibility=visibility,
+                        namespace=current_namespace,
+                        container=type_stack[-1][1] if type_stack else None,
+                        is_static=bool(re.search(r"\bstatic\b", type_match.group("mods") or "")),
+                    )
+                )
+            if "{" in line:
+                type_stack.append((brace_depth + 1, name))
+            elif not stripped.endswith(";"):
+                pending_type = (name, brace_depth + 1)
+            brace_depth += brace_delta(line)
+            continue
+
+        container = type_stack[-1][1] if type_stack else None
+        if container:
+            constructor_match = constructor_pattern.search(line)
+            if constructor_match and constructor_match.group("name") == container:
+                visibility = normalize_visibility(constructor_match.group("mods") or "", "private")
+                key = ("constructor", container, container)
+                if key not in seen:
+                    seen.add(key)
+                    symbols.append(
+                        symbol_record(
+                            rel=rel,
+                            line_number=line_number,
+                            kind="constructor",
+                            name=container,
+                            visibility=visibility,
+                            namespace=current_namespace,
+                            container=container,
+                            is_static=bool(re.search(r"\bstatic\b", constructor_match.group("mods") or "")),
+                        )
+                    )
+                brace_depth += brace_delta(line)
+                continue
+
+            property_match = property_pattern.search(line)
+            if property_match:
+                name = property_match.group("name")
+                visibility = normalize_visibility(property_match.group("mods") or "", "private")
+                key = ("property", name, container)
+                if key not in seen:
+                    seen.add(key)
+                    symbols.append(
+                        symbol_record(
+                            rel=rel,
+                            line_number=line_number,
+                            kind="property",
+                            name=name,
+                            visibility=visibility,
+                            namespace=current_namespace,
+                            container=container,
+                            is_static=bool(re.search(r"\bstatic\b", property_match.group("mods") or "")),
+                        )
+                    )
+                brace_depth += brace_delta(line)
+                continue
+
+            method_match = method_pattern.search(line)
+            if method_match and method_match.group("name") not in control_words:
+                name = method_match.group("name")
+                visibility = normalize_visibility(method_match.group("mods") or "", "private")
+                key = ("method", name, container)
+                if key not in seen:
+                    seen.add(key)
+                    symbols.append(
+                        symbol_record(
+                            rel=rel,
+                            line_number=line_number,
+                            kind="method",
+                            name=name,
+                            visibility=visibility,
+                            namespace=current_namespace,
+                            container=container,
+                            is_static=bool(re.search(r"\bstatic\b", method_match.group("mods") or "")),
+                        )
+                    )
+                brace_depth += brace_delta(line)
+                continue
+
+            if "(" not in line and not stripped.startswith(("return ", "throw ")):
+                field_match = field_pattern.search(line)
+                if field_match:
+                    name = field_match.group("name")
+                    mods = field_match.group("mods") or ""
+                    visibility = normalize_visibility(mods, "private")
+                    kind = "constant" if re.search(r"\bconst\b", mods) else "field"
+                    key = (kind, name, container)
+                    if key not in seen:
+                        seen.add(key)
+                        symbols.append(
+                            symbol_record(
+                                rel=rel,
+                                line_number=line_number,
+                                kind=kind,
+                                name=name,
+                                visibility=visibility,
+                                namespace=current_namespace,
+                                container=container,
+                                is_static=bool(re.search(r"\bstatic\b", mods)),
+                            )
+                        )
+
+        brace_depth += brace_delta(line)
+        while type_stack and brace_depth < type_stack[-1][0]:
+            type_stack.pop()
+    return symbols
+
+
+def extract_import_records(text: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    pattern = re.compile(
+        r"""
+        ^\s*
+        (?P<global>global\s+)?
+        using\s+
+        (?P<static>static\s+)?
+        (?:
+          (?P<alias>[A-Za-z_][\w]*)\s*=\s*
+        )?
+        (?P<imported>[A-Za-z_][\w.]*)
+        \s*;
+        """,
+        re.MULTILINE | re.VERBOSE,
+    )
+    seen: set[tuple[str, str | None, bool, bool]] = set()
+    for match in pattern.finditer(text):
+        imported = match.group("imported")
+        alias = match.group("alias")
+        is_static = bool(match.group("static"))
+        is_global = bool(match.group("global"))
+        key = (imported, alias, is_static, is_global)
+        if key in seen:
+            continue
+        seen.add(key)
+        record: dict[str, Any] = {
+            "imported": imported,
+            "kind": "using",
+            "alias": alias,
+            "static": is_static,
+            "global": is_global,
+            "tokens": sorted(set(split_identifier(imported))),
+        }
+        records.append(record)
+    return sorted(records, key=lambda item: (str(item.get("imported")), str(item.get("alias") or "")))
+
+
+def local_xml_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def parse_xml_document(text: str) -> ET.Element | None:
+    try:
+        return ET.fromstring(text)
+    except ET.ParseError:
+        return None
+
+
+def xml_children_text(root: ET.Element, name: str) -> list[str]:
+    values: list[str] = []
+    for element in root.iter():
+        if local_xml_name(element.tag) != name:
+            continue
+        text = (element.text or "").strip()
+        if text:
+            values.append(text)
+    return values
+
+
+def parse_sln_projects(text: str) -> list[dict[str, str]]:
+    projects: list[dict[str, str]] = []
+    pattern = re.compile(
+        r'^\s*Project\("\{[^"]+\}"\)\s*=\s*"(?P<name>[^"]+)",\s*"(?P<path>[^"]+)",\s*"\{[^"]+\}"',
+        re.MULTILINE,
+    )
+    for match in pattern.finditer(text):
+        project_path = match.group("path").replace("\\", "/")
+        if not project_path.endswith(".csproj"):
+            continue
+        projects.append(
+            {
+                "name": match.group("name"),
+                "path": normalize_rel_parts(project_path),
+            }
+        )
+    return sorted(projects, key=lambda item: (item["path"], item["name"]))
+
+
+def normalize_project_include(base_dir: str, include: str) -> str:
+    include = include.replace("\\", "/")
+    if not base_dir:
+        return normalize_rel_parts(include)
+    return normalize_rel_parts(f"{base_dir}/{include}")
+
+
+def parse_dotnet_project(rel: str, text: str) -> dict[str, Any]:
+    path = Path(rel)
+    base_dir = path.parent.as_posix()
+    if base_dir == ".":
+        base_dir = ""
+    root = parse_xml_document(text)
+    target_frameworks: list[str] = []
+    output_type: str | None = None
+    assembly_name: str | None = None
+    root_namespace: str | None = None
+    project_references: list[str] = []
+    package_references: list[dict[str, str]] = []
+    package_names: list[str] = []
+    is_packable_values: list[str] = []
+    explicit_test_project_values: list[str] = []
+
+    if root is not None:
+        target_frameworks.extend(xml_children_text(root, "TargetFramework"))
+        for value in xml_children_text(root, "TargetFrameworks"):
+            target_frameworks.extend(item.strip() for item in value.split(";") if item.strip())
+        output_values = xml_children_text(root, "OutputType")
+        if output_values:
+            output_type = output_values[0]
+        assembly_values = xml_children_text(root, "AssemblyName")
+        if assembly_values:
+            assembly_name = assembly_values[0]
+        root_namespace_values = xml_children_text(root, "RootNamespace")
+        if root_namespace_values:
+            root_namespace = root_namespace_values[0]
+        is_packable_values = xml_children_text(root, "IsPackable")
+        explicit_test_project_values = xml_children_text(root, "IsTestProject")
+        for element in root.iter():
+            tag = local_xml_name(element.tag)
+            if tag == "ProjectReference":
+                include = element.attrib.get("Include") or element.attrib.get("Update")
+                if include:
+                    project_references.append(normalize_project_include(base_dir, include))
+            elif tag == "PackageReference":
+                include = element.attrib.get("Include") or element.attrib.get("Update")
+                if not include:
+                    continue
+                version = element.attrib.get("Version")
+                if not version:
+                    for child in element:
+                        if local_xml_name(child.tag) == "Version" and child.text:
+                            version = child.text.strip()
+                            break
+                package_record = {"include": include}
+                if version:
+                    package_record["version"] = version
+                package_references.append(package_record)
+                package_names.append(include)
+
+    project_name = path.stem
+    lower_packages = {package.lower() for package in package_names}
+    is_test_project = (
+        project_name.endswith(".Tests")
+        or "tests" in path.parts
+        or any(TEST_PACKAGE_FRAMEWORKS.get(package) for package in lower_packages)
+        or any(value.lower() == "true" for value in explicit_test_project_values)
+    )
+    tokens = set(tokens_for_path(rel))
+    for value in [project_name, assembly_name or "", root_namespace or "", output_type or ""]:
+        tokens.update(split_identifier(value))
+    tokens.update(token for package in package_names for token in split_identifier(package))
+    manifest: dict[str, Any] = {
+        "path": rel,
+        "kind": "dotnet-project",
+        "language": "csharp",
+        "projectName": project_name,
+        "assemblyName": assembly_name or project_name,
+        "targetFrameworks": sorted(set(target_frameworks)),
+        "projectReferences": sorted(set(project_references)),
+        "packageReferences": sorted(set(package_names)),
+        "isTestProject": is_test_project,
+        "tokens": sorted(tokens),
+    }
+    if root_namespace:
+        manifest["rootNamespace"] = root_namespace
+    if output_type:
+        manifest["outputType"] = output_type
+    if package_references:
+        manifest["packageReferenceDetails"] = sorted(
+            package_references,
+            key=lambda item: (str(item.get("include")), str(item.get("version", ""))),
+        )
+    test_packages = sorted(
+        package for package in lower_packages if package in TEST_PACKAGE_FRAMEWORKS
+    )
+    if test_packages:
+        manifest["testPackageHints"] = [
+            {"package": package, "framework": TEST_PACKAGE_FRAMEWORKS[package]}
+            for package in test_packages
+        ]
+    if is_packable_values:
+        manifest["isPackable"] = is_packable_values[0]
+    return manifest
+
+
+def parse_dotnet_props_targets(rel: str, text: str, kind: str) -> dict[str, Any]:
+    root = parse_xml_document(text)
+    properties: set[str] = set()
+    item_types: set[str] = set()
+    if root is not None:
+        for element in root.iter():
+            name = local_xml_name(element.tag)
+            if name in {"Project", "PropertyGroup", "ItemGroup"}:
+                continue
+            if element.attrib:
+                item_types.add(name)
+            elif (element.text or "").strip():
+                properties.add(name)
+    tokens = set(tokens_for_path(rel))
+    tokens.update(token for value in properties | item_types for token in split_identifier(value))
+    manifest: dict[str, Any] = {
+        "path": rel,
+        "kind": kind,
+        "language": "csharp",
+        "tokens": sorted(tokens),
+    }
+    if properties:
+        manifest["properties"] = sorted(properties)
+    if item_types:
+        manifest["itemTypes"] = sorted(item_types)
+    return manifest
+
+
+def extract_manifest(rel: str, text: str, kind: str) -> dict[str, Any] | None:
+    if kind == "dotnet-solution":
+        projects = parse_sln_projects(text)
+        manifest: dict[str, Any] = {
+            "path": rel,
+            "kind": kind,
+            "language": "csharp",
+            "tokens": tokens_for_path(rel),
+        }
+        if projects:
+            manifest["projects"] = projects
+            project_tokens = {token for project in projects for token in split_identifier(" ".join(project.values()))}
+            manifest["tokens"] = sorted(set(manifest["tokens"]) | project_tokens)
+        return manifest
+    if kind == "dotnet-project":
+        return parse_dotnet_project(rel, text)
+    if kind in {"dotnet-props", "dotnet-targets"}:
+        return parse_dotnet_props_targets(rel, text, kind)
+    return None
+
+
+def build_context(manifests: list[dict[str, Any]], known_files: set[str]) -> dict[str, Any]:
+    projects: list[dict[str, Any]] = []
+    project_by_path: dict[str, dict[str, Any]] = {}
+    for manifest in manifests:
+        if manifest.get("kind") != "dotnet-project":
+            continue
+        path = str(manifest.get("path") or "")
+        if not path:
+            continue
+        root = Path(path).parent.as_posix()
+        if root == ".":
+            root = ""
+        project = {
+            "path": path,
+            "root": root,
+            "projectName": manifest.get("projectName") or Path(path).stem,
+            "assemblyName": manifest.get("assemblyName") or manifest.get("projectName") or Path(path).stem,
+            "rootNamespace": manifest.get("rootNamespace")
+            or manifest.get("assemblyName")
+            or manifest.get("projectName")
+            or Path(path).stem,
+            "projectReferences": sorted(str(item) for item in manifest.get("projectReferences", []) if isinstance(item, str)),
+            "packageReferences": sorted(str(item) for item in manifest.get("packageReferences", []) if isinstance(item, str)),
+            "isTestProject": bool(manifest.get("isTestProject")),
+            "outputType": manifest.get("outputType"),
+            "targetFrameworks": manifest.get("targetFrameworks", []),
+        }
+        projects.append(project)
+        project_by_path[path] = project
+
+    referenced_by: dict[str, list[str]] = defaultdict(list)
+    for project in projects:
+        for reference in project.get("projectReferences", []):
+            if reference in project_by_path:
+                referenced_by[reference].append(str(project.get("path")))
+
+    for project in projects:
+        path = str(project.get("path"))
+        project["referencedBy"] = sorted(set(referenced_by.get(path, [])))
+        source_files = [
+            rel
+            for rel in known_files
+            if rel.endswith(".cs")
+            and (
+                (not project.get("root") and "/" not in rel)
+                or (bool(project.get("root")) and rel.startswith(f"{project.get('root')}/"))
+            )
+        ]
+        project["sourceFiles"] = sorted(source_files)
+
+    return {
+        "projects": sorted(projects, key=lambda item: str(item.get("root") or "")),
+        "projectByPath": project_by_path,
+    }
+
+
+def project_for_path(rel: str, csharp_context: dict[str, Any]) -> dict[str, Any] | None:
+    projects = csharp_context.get("projects")
+    if not isinstance(projects, list):
+        return None
+    matches = []
+    for project in projects:
+        if not isinstance(project, dict):
+            continue
+        root = str(project.get("root") or "")
+        project_path = str(project.get("path") or "")
+        if rel == project_path or (root and rel.startswith(f"{root}/")) or (not root and "/" not in rel):
+            matches.append(project)
+    if not matches:
+        return None
+    return sorted(matches, key=lambda item: len(str(item.get("root") or "")), reverse=True)[0]
+
+
+def transitive_project_references(project: dict[str, Any], csharp_context: dict[str, Any]) -> list[dict[str, Any]]:
+    project_by_path = csharp_context.get("projectByPath")
+    if not isinstance(project_by_path, dict):
+        return []
+    found: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    pending = [str(item) for item in project.get("projectReferences", [])]
+    while pending:
+        path = pending.pop(0)
+        if path in seen:
+            continue
+        seen.add(path)
+        target = project_by_path.get(path)
+        if not isinstance(target, dict):
+            continue
+        found.append(target)
+        pending.extend(str(item) for item in target.get("projectReferences", []))
+    return found
+
+
+def namespace_matches(imported: str, project: dict[str, Any]) -> bool:
+    namespaces = [
+        str(project.get("rootNamespace") or ""),
+        str(project.get("assemblyName") or ""),
+        str(project.get("projectName") or ""),
+    ]
+    for namespace in namespaces:
+        if not namespace:
+            continue
+        if imported == namespace or imported.startswith(f"{namespace}."):
+            return True
+    return False
+
+
+def resolve_import(
+    source_rel: str,
+    imported: str,
+    csharp_context: dict[str, Any],
+) -> str | None:
+    if not imported:
+        return None
+    source_project = project_for_path(source_rel, csharp_context)
+    candidates: list[dict[str, Any]] = []
+    if source_project:
+        candidates.append(source_project)
+        candidates.extend(transitive_project_references(source_project, csharp_context))
+    else:
+        projects = csharp_context.get("projects")
+        if isinstance(projects, list):
+            candidates.extend(project for project in projects if isinstance(project, dict))
+
+    for project in candidates:
+        if not namespace_matches(imported, project):
+            continue
+        root = str(project.get("root") or "")
+        return root or "."
+
+    if imported.startswith(EXTERNAL_NAMESPACE_PREFIXES):
+        return None
+    return None
+
+
+def test_framework_for_text(rel: str, text: str) -> str | None:
+    if re.search(r"\[(?:Fact|Theory)\b", text):
+        return "xunit"
+    if re.search(r"\[(?:Test|TestCase|TestFixture)\b", text):
+        return "nunit"
+    if re.search(r"\[(?:TestMethod|TestClass)\b", text):
+        return "mstest"
+    if is_test_path(rel):
+        return "dotnet-test"
+    return None
+
+
+def test_info(
+    rel: str,
+    text: str,
+    language: str | None,
+    project: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if language != "csharp" or Path(rel).suffix != ".cs":
+        return {"hasTests": False, "framework": None, "testFunctions": []}
+    package_frameworks: set[str] = set()
+    if project:
+        for package in project.get("packageReferences", []):
+            framework = TEST_PACKAGE_FRAMEWORKS.get(str(package).lower())
+            if framework:
+                package_frameworks.add(framework)
+
+    attr_frameworks: set[str] = set()
+    test_functions: list[str] = []
+    pending_attr: str | None = None
+    attr_pattern = re.compile(r"\[(?P<attr>Fact|Theory|Test|TestCase|TestFixture|TestMethod|TestClass)\b")
+    method_pattern = re.compile(
+        r"^\s*(?:(?:public|internal|private|protected|static|async|virtual|override|sealed|new)\s+)*"
+        r"(?:[A-Za-z_][\w.<>,?\[\]]+\s+)?(?P<name>[A-Za-z_][\w]*)\s*\("
+    )
+    for line in text.splitlines():
+        attr_match = attr_pattern.search(line)
+        if attr_match:
+            attr = attr_match.group("attr")
+            if attr in {"Fact", "Theory"}:
+                attr_frameworks.add("xunit")
+                pending_attr = attr
+            elif attr in {"Test", "TestCase", "TestFixture"}:
+                attr_frameworks.add("nunit")
+                if attr != "TestFixture":
+                    pending_attr = attr
+            elif attr in {"TestMethod", "TestClass"}:
+                attr_frameworks.add("mstest")
+                if attr == "TestMethod":
+                    pending_attr = attr
+            continue
+        if pending_attr:
+            method_match = method_pattern.search(line)
+            if method_match:
+                test_functions.append(method_match.group("name"))
+                pending_attr = None
+                continue
+            if line.strip() and not line.strip().startswith("["):
+                pending_attr = None
+
+    frameworks = attr_frameworks | package_frameworks
+    framework_order = ("xunit", "nunit", "mstest", "dotnet-test")
+    framework = next((item for item in framework_order if item in frameworks), None)
+    if framework is None and (project and project.get("isTestProject")):
+        framework = "dotnet-test"
+    has_tests = bool(test_functions or frameworks or is_test_path(rel) or (project and project.get("isTestProject")))
+    return {
+        "hasTests": has_tests,
+        "framework": framework,
+        "testFunctions": sorted(set(test_functions)),
+    }
+
+
+def module_fields(
+    rel: str,
+    text: str,
+    csharp_context: dict[str, Any],
+    manifest: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    hints: list[dict[str, Any]] = []
+    project = project_for_path(rel, csharp_context)
+    if project and Path(rel).suffix == ".cs":
+        for key in ("projectName", "assemblyName", "rootNamespace", "outputType"):
+            value = project.get(key)
+            if value:
+                fields[key] = value
+        if project.get("root"):
+            fields["projectRoot"] = project.get("root")
+        if project.get("path"):
+            fields["projectPath"] = project.get("path")
+        if project.get("targetFrameworks"):
+            fields["targetFrameworks"] = project.get("targetFrameworks")
+        if project.get("isTestProject"):
+            fields["testProject"] = True
+
+    if manifest and manifest.get("kind") == "dotnet-solution":
+        hints.append({"kind": "dotnet-solution", "value": "C# solution boundary", "weak": False})
+    if manifest and manifest.get("kind") == "dotnet-project":
+        hints.append({"kind": "dotnet-project", "value": "C# project/assembly boundary", "weak": False})
+        if manifest.get("isTestProject"):
+            hints.append({"kind": "dotnet-test-project", "value": "C# test project boundary", "weak": False})
+            fields["testProject"] = True
+        if str(manifest.get("outputType") or "").lower() == "exe":
+            hints.append(
+                {
+                    "kind": "dotnet-executable-project",
+                    "value": "C# executable project boundary",
+                    "weak": False,
+                    "risk": "Executable C# project is not a generic helper module",
+                }
+            )
+            fields["executableBoundary"] = True
+        for reference in manifest.get("projectReferences", []):
+            if isinstance(reference, str):
+                hints.append(
+                    {
+                        "kind": "dotnet-project-reference",
+                        "value": "C# project reference dependency edge",
+                        "path": reference,
+                        "sourceProject": rel,
+                        "weak": False,
+                    }
+                )
+    if manifest and manifest.get("kind") in {"dotnet-props", "dotnet-targets"}:
+        hints.append({"kind": manifest.get("kind"), "value": "MSBuild props/targets manifest", "weak": False})
+
+    if hints:
+        fields["boundaryHints"] = hints
+        fields["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in hints if isinstance(hint, dict))
+    return fields
+
+
+def build_project_modules(
+    modules: list[dict[str, Any]],
+    symbols: list[dict[str, Any]],
+    tests: list[dict[str, Any]],
+    importers_by_target: dict[str, list[str]],
+    csharp_context: dict[str, Any],
+) -> list[dict[str, Any]]:
+    projects = csharp_context.get("projects")
+    if not isinstance(projects, list):
+        return []
+    modules_by_path = {str(module.get("path")): module for module in modules}
+    symbols_by_project: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    files_by_project: dict[str, list[str]] = defaultdict(list)
+    tests_by_project: dict[str, list[str]] = defaultdict(list)
+
+    for module in modules:
+        if module.get("language") != "csharp" or Path(str(module.get("path") or "")).suffix != ".cs":
+            continue
+        path = str(module.get("path"))
+        project_path = str(module.get("projectPath") or "")
+        if not project_path:
+            project = project_for_path(path, csharp_context)
+            project_path = str(project.get("path") or "") if project else ""
+        if not project_path:
+            continue
+        files_by_project[project_path].append(path)
+        if module.get("kind") == "test" or module.get("testProject"):
+            tests_by_project[project_path].append(path)
+    for symbol in symbols:
+        if symbol.get("language") != "csharp":
+            continue
+        path = str(symbol.get("path") or "")
+        module = modules_by_path.get(path)
+        project_path = str(module.get("projectPath") or "") if module else ""
+        if not project_path:
+            project = project_for_path(path, csharp_context)
+            project_path = str(project.get("path") or "") if project else ""
+        if project_path:
+            symbols_by_project[project_path].append(symbol)
+
+    project_modules: list[dict[str, Any]] = []
+    for project in projects:
+        if not isinstance(project, dict):
+            continue
+        project_path = str(project.get("path") or "")
+        root = str(project.get("root") or ".")
+        source_files = sorted(files_by_project.get(project_path, []))
+        test_files = sorted(tests_by_project.get(project_path, []))
+        project_symbols = symbols_by_project.get(project_path, [])
+        public_symbols = sorted(
+            {
+                str(symbol.get("name"))
+                for symbol in project_symbols
+                if symbol.get("exported") and str(symbol.get("kind")) != "namespace" and isinstance(symbol.get("name"), str)
+            }
+        )
+        internal_symbols = sorted(
+            {
+                str(symbol.get("name"))
+                for symbol in project_symbols
+                if str(symbol.get("visibility") or "") == "internal" and isinstance(symbol.get("name"), str)
+            }
+        )
+        imported_by = sorted(set(importers_by_target.get(root, [])))
+        referenced_by = sorted(set(str(item) for item in project.get("referencedBy", []) if item))
+        paired_test_paths = sorted(
+            {
+                str(test.get("path"))
+                for test in tests
+                if isinstance(test.get("path"), str)
+                and (
+                    str(test.get("path")) in imported_by
+                    or set(tokens_for_path(str(test.get("path")))) & set(split_identifier(str(project.get("projectName") or "")))
+                    or set(tokens_for_path(str(test.get("path")))) & {token for symbol in public_symbols for token in split_identifier(symbol)}
+                )
+            }
+        )
+        tokens = set(tokens_for_path(root))
+        for value in (
+            str(project.get("projectName") or ""),
+            str(project.get("assemblyName") or ""),
+            str(project.get("rootNamespace") or ""),
+        ):
+            tokens.update(split_identifier(value))
+        for symbol_name in public_symbols:
+            tokens.update(split_identifier(symbol_name))
+        boundary_hints: list[dict[str, Any]] = [
+            {"kind": "dotnet-project", "value": "C# project/assembly boundary", "weak": False}
+        ]
+        if referenced_by:
+            boundary_hints.append({"kind": "dotnet-project-referenced", "value": "C# project referenced by local projects", "weak": False})
+        if project.get("isTestProject"):
+            boundary_hints.append({"kind": "dotnet-test-project", "value": "C# test project boundary", "weak": False})
+        if str(project.get("outputType") or "").lower() == "exe":
+            boundary_hints.append(
+                {
+                    "kind": "dotnet-executable-project",
+                    "value": "C# executable project boundary",
+                    "weak": False,
+                    "risk": "Executable C# project is not a generic helper module",
+                }
+            )
+        if public_symbols:
+            boundary_hints.append({"kind": "dotnet-public-api", "value": "C# public API candidate", "weak": False})
+        if internal_symbols:
+            boundary_hints.append(
+                {
+                    "kind": "dotnet-internal-api",
+                    "value": "C# internal API is assembly-local",
+                    "weak": False,
+                    "risk": "internal symbols are assembly-local and may not be reusable across projects",
+                }
+            )
+        module: dict[str, Any] = {
+            "path": root,
+            "name": str(project.get("projectName") or Path(root).name or "."),
+            "directory": Path(root).parent.as_posix() if root not in {"", "."} and Path(root).parent.as_posix() != "." else "",
+            "language": "csharp",
+            "kind": "project",
+            "projectPath": project_path,
+            "projectName": project.get("projectName"),
+            "assemblyName": project.get("assemblyName"),
+            "rootNamespace": project.get("rootNamespace"),
+            "targetFrameworks": project.get("targetFrameworks", []),
+            "files": source_files,
+            "sourceFiles": [path for path in source_files if path not in test_files],
+            "testFiles": test_files,
+            "tokens": sorted(tokens),
+            "lineCount": sum(int(modules_by_path.get(path, {}).get("lineCount", 0)) for path in source_files),
+            "symbols": public_symbols,
+            "exportedSymbolCount": len(public_symbols),
+            "internalSymbols": internal_symbols,
+            "boundaryHints": boundary_hints,
+            "boundaryKinds": sorted(str(hint.get("kind")) for hint in boundary_hints),
+        }
+        if project.get("packageReferences"):
+            module["packageReferences"] = project.get("packageReferences")
+        if project.get("projectReferences"):
+            module["projectReferenceTargets"] = project.get("projectReferences")
+        if referenced_by:
+            module["projectReferences"] = referenced_by
+            module["projectReferenceCount"] = len(referenced_by)
+        if imported_by:
+            module["importedBy"] = imported_by
+            module["importCount"] = len(imported_by)
+        if paired_test_paths:
+            module["pairedTests"] = paired_test_paths
+        if project.get("isTestProject"):
+            module["isTestProject"] = True
+        if str(project.get("outputType") or "").lower() == "exe":
+            module["executableBoundary"] = True
+        if public_symbols:
+            module["publicAPICandidate"] = True
+        if internal_symbols:
+            module["internalAssemblyLocal"] = True
+        project_modules.append(module)
+    return project_modules
+
+
+def update_module_boundaries(
+    modules: list[dict[str, Any]],
+    symbols_by_path: dict[str, list[dict[str, Any]]],
+) -> None:
+    for module in modules:
+        if module.get("language") != "csharp":
+            continue
+        path = str(module.get("path") or "")
+        if not path:
+            continue
+        hints = list(module.get("boundaryHints", []))
+        exported = sorted(
+            str(symbol.get("name"))
+            for symbol in symbols_by_path.get(path, [])
+            if symbol.get("exported") and isinstance(symbol.get("name"), str)
+        )
+        internal = sorted(
+            str(symbol.get("name"))
+            for symbol in symbols_by_path.get(path, [])
+            if str(symbol.get("visibility") or "") == "internal" and isinstance(symbol.get("name"), str)
+        )
+        if exported:
+            hints.append({"kind": "dotnet-public-api", "value": "C# public API candidate", "weak": False})
+            module["publicAPICandidate"] = True
+        if internal:
+            hints.append(
+                {
+                    "kind": "dotnet-internal-api",
+                    "value": "C# internal API is assembly-local",
+                    "weak": False,
+                    "risk": "internal symbols are assembly-local and may not be reusable across projects",
+                }
+            )
+            module["internalSymbols"] = internal
+            module["internalAssemblyLocal"] = True
+        if hints:
+            module["boundaryHints"] = hints
+            module["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in hints if isinstance(hint, dict))

--- a/scripts/codebase_awareness/adapters/go.py
+++ b/scripts/codebase_awareness/adapters/go.py
@@ -1,0 +1,468 @@
+"""Go adapter for the shallow codebase awareness scanner."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+from scripts.codebase_awareness.adapters.common import (
+    is_test_fixture_path,
+    normalize_rel_parts,
+    split_identifier,
+    tokens_for_path,
+)
+
+GO_TEST_FUNCTION_RE = re.compile(r"^\s*func\s+((?:Test|Benchmark|Fuzz)[A-Za-z0-9_]*)\s*\(", re.MULTILINE)
+
+
+def manifest_kinds() -> dict[str, str]:
+    return {
+        "go.mod": "go",
+        "go.work": "go-work",
+    }
+
+
+def language_for_manifest(kind: str) -> str | None:
+    if kind in {"go", "go-work"}:
+        return "go"
+    return None
+
+
+def is_test_path(rel: str) -> bool:
+    return Path(rel).name.endswith("_test.go")
+
+
+def is_exported_identifier(name: str) -> bool:
+    return bool(name) and "A" <= name[0] <= "Z"
+
+
+def extract_package_name(text: str) -> str | None:
+    match = re.search(r"^\s*package\s+([A-Za-z_][A-Za-z0-9_]*)\b", text, flags=re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def normalize_receiver(receiver: str) -> str | None:
+    receiver = receiver.strip()
+    if not receiver:
+        return None
+    parts = receiver.split()
+    raw_type = parts[-1] if parts else receiver
+    raw_type = raw_type.lstrip("*")
+    raw_type = raw_type.split(".")[-1]
+    raw_type = raw_type.split("[", 1)[0]
+    raw_type = re.sub(r"[^A-Za-z0-9_]", "", raw_type)
+    return raw_type or None
+
+
+def symbol_entry(
+    *,
+    name: str,
+    kind: str,
+    rel: str,
+    line_number: int,
+    receiver: str | None = None,
+) -> dict[str, Any]:
+    tokens = set(split_identifier(name))
+    if receiver:
+        tokens.update(split_identifier(receiver))
+    return {
+        "name": name,
+        "kind": kind,
+        "language": "go",
+        "path": rel,
+        "line": line_number,
+        "exported": is_exported_identifier(name),
+        "tokens": sorted(tokens),
+        "receiver": receiver,
+    }
+
+
+def extract_symbols(rel: str, text: str) -> list[dict[str, Any]]:
+    symbols: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str | None]] = set()
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        func_match = re.search(
+            r"^\s*func\s+(?:\((?P<receiver>[^)]*)\)\s*)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+            line,
+        )
+        if func_match:
+            receiver = normalize_receiver(func_match.group("receiver") or "")
+            name = func_match.group("name")
+            kind = "method" if receiver else "function"
+            key = (kind, name, receiver)
+            if key not in seen:
+                seen.add(key)
+                symbols.append(
+                    symbol_entry(
+                        name=name,
+                        kind=kind,
+                        rel=rel,
+                        line_number=line_number,
+                        receiver=receiver,
+                    )
+                )
+            continue
+
+        type_match = re.search(r"^\s*type\s+([A-Za-z_][A-Za-z0-9_]*)\b", line)
+        if type_match:
+            name = type_match.group(1)
+            key = ("type", name, None)
+            if key not in seen:
+                seen.add(key)
+                symbols.append(symbol_entry(name=name, kind="type", rel=rel, line_number=line_number))
+            continue
+
+        value_match = re.search(r"^\s*(const|var)\s+([A-Za-z_][A-Za-z0-9_]*)\b", line)
+        if value_match:
+            kind = "constant" if value_match.group(1) == "const" else "variable"
+            name = value_match.group(2)
+            key = (kind, name, None)
+            if key not in seen:
+                seen.add(key)
+                symbols.append(symbol_entry(name=name, kind=kind, rel=rel, line_number=line_number))
+            continue
+
+        grouped_value_match = re.search(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:=|[A-Za-z_\*])", line)
+        if grouped_value_match and symbols:
+            previous_kind = symbols[-1].get("kind")
+            if previous_kind in {"constant", "variable"}:
+                name = grouped_value_match.group(1)
+                key = (str(previous_kind), name, None)
+                if key not in seen:
+                    seen.add(key)
+                    symbols.append(
+                        symbol_entry(
+                            name=name,
+                            kind=str(previous_kind),
+                            rel=rel,
+                            line_number=line_number,
+                        )
+                    )
+    return symbols
+
+
+def strip_line_comment(line: str) -> str:
+    in_string = False
+    escaped = False
+    quote = ""
+    for index, char in enumerate(line):
+        if in_string:
+            if escaped:
+                escaped = False
+                continue
+            if char == "\\":
+                escaped = True
+                continue
+            if char == quote:
+                in_string = False
+                quote = ""
+            continue
+        if char in {"\"", "`"}:
+            in_string = True
+            quote = char
+            continue
+        if char == "/" and index + 1 < len(line) and line[index + 1] == "/":
+            return line[:index]
+    return line
+
+
+def parse_import_line(line: str) -> dict[str, Any] | None:
+    line = strip_line_comment(line).strip().rstrip(";")
+    if not line or line == ")":
+        return None
+    match = re.match(
+        r"^(?:(?P<alias>\.|\_|[A-Za-z_][A-Za-z0-9_]*)\s+)?(?P<quote>\"[^\"]+\"|`[^`]+`)$",
+        line,
+    )
+    if not match:
+        return None
+    alias = match.group("alias")
+    imported = match.group("quote")[1:-1]
+    if alias == "_":
+        import_kind = "blank"
+    elif alias == ".":
+        import_kind = "dot"
+    elif alias:
+        import_kind = "aliased"
+    else:
+        import_kind = "package"
+    return {
+        "imported": imported,
+        "alias": alias,
+        "importKind": import_kind,
+        "tokens": sorted(set(split_identifier(imported))),
+    }
+
+
+def extract_import_records(text: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    in_block = False
+    for line in text.splitlines():
+        stripped = strip_line_comment(line).strip()
+        if not in_block:
+            single = re.match(r"^import\s+(?!\()(.*)$", stripped)
+            if single:
+                record = parse_import_line(single.group(1))
+                if record:
+                    records.append(record)
+                continue
+            if re.match(r"^import\s*\($", stripped):
+                in_block = True
+                continue
+        else:
+            if stripped.startswith(")"):
+                in_block = False
+                continue
+            record = parse_import_line(stripped)
+            if record:
+                records.append(record)
+    unique: dict[tuple[str, str | None], dict[str, Any]] = {}
+    for record in records:
+        unique[(str(record.get("imported")), record.get("alias"))] = record
+    return [unique[key] for key in sorted(unique)]
+
+
+def parse_mod_module_path(text: str) -> str | None:
+    match = re.search(r"^\s*module\s+([^\s]+)", text, flags=re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def parse_work_uses(text: str) -> list[str]:
+    uses: list[str] = []
+    in_block = False
+    for line in text.splitlines():
+        stripped = strip_line_comment(line).strip()
+        if not stripped:
+            continue
+        if in_block:
+            if stripped.startswith(")"):
+                in_block = False
+                continue
+            value = stripped.strip("\"`")
+            if value:
+                uses.append(value)
+            continue
+        match = re.match(r"^use\s+(.+)$", stripped)
+        if not match:
+            continue
+        rest = match.group(1).strip()
+        if rest.startswith("("):
+            in_block = True
+            rest = rest[1:].strip()
+            if not rest:
+                continue
+        if rest and rest != ")":
+            uses.append(rest.strip("\"`"))
+    return sorted(set(uses))
+
+
+def extract_manifest(rel: str, text: str, kind: str) -> dict[str, Any] | None:
+    if kind not in {"go", "go-work"}:
+        return None
+    manifest: dict[str, Any] = {
+        "path": rel,
+        "kind": kind,
+        "language": "go",
+        "tokens": tokens_for_path(rel),
+    }
+    path = Path(rel)
+    if path.name == "go.mod":
+        module_path = parse_mod_module_path(text)
+        if module_path:
+            manifest["modulePath"] = module_path
+            manifest["tokens"] = sorted(set(manifest["tokens"]) | set(split_identifier(module_path)))
+    if path.name == "go.work":
+        workspace_uses = parse_work_uses(text)
+        if workspace_uses:
+            manifest["workspaceUses"] = workspace_uses
+            use_tokens = {token for use in workspace_uses for token in split_identifier(use)}
+            manifest["tokens"] = sorted(set(manifest["tokens"]) | use_tokens)
+    return manifest
+
+
+def collect_modules(indexed_files: list[Any]) -> list[tuple[str, str]]:
+    modules: list[tuple[str, str]] = []
+    for scanned_file in indexed_files:
+        if Path(scanned_file.rel).name != "go.mod":
+            continue
+        module_path = parse_mod_module_path(scanned_file.text)
+        if not module_path:
+            continue
+        directory = Path(scanned_file.rel).parent.as_posix()
+        modules.append(("" if directory == "." else directory, module_path))
+    return sorted(modules, key=lambda item: (-len(item[1]), item[0], item[1]))
+
+
+def resolve_import(
+    spec: str,
+    go_modules: list[tuple[str, str]],
+    go_package_dirs: set[str],
+) -> str | None:
+    for module_dir, module_path in go_modules:
+        if spec == module_path:
+            candidate = module_dir
+        elif spec.startswith(f"{module_path}/"):
+            suffix = spec[len(module_path) + 1 :]
+            candidate = normalize_rel_parts(f"{module_dir}/{suffix}" if module_dir else suffix)
+        else:
+            continue
+        if candidate in go_package_dirs:
+            return candidate or "."
+    return None
+
+
+def test_info(rel: str, text: str, language: str | None) -> dict[str, Any]:
+    if language != "go":
+        return {"hasTests": False, "framework": None, "testFunctions": []}
+    test_functions = sorted(set(GO_TEST_FUNCTION_RE.findall(text)))
+    return {
+        "hasTests": is_test_path(rel) or bool(test_functions),
+        "framework": "go-test" if is_test_path(rel) else None,
+        "testFunctions": test_functions,
+    }
+
+
+def boundary_hints_for_path(rel: str) -> list[dict[str, Any]]:
+    path = Path(rel)
+    parts = path.parts
+    hints: list[dict[str, Any]] = []
+    if "internal" in parts:
+        index = parts.index("internal")
+        allowed_root = "/".join(parts[:index]) or "."
+        hints.append(
+            {
+                "kind": "go-internal",
+                "value": "internal package boundary",
+                "allowedRoot": allowed_root,
+                "weak": False,
+            }
+        )
+    if parts and parts[0] == "cmd":
+        hints.append(
+            {
+                "kind": "go-cmd",
+                "value": "executable entrypoint convention",
+                "weak": False,
+            }
+        )
+    if parts and parts[0] == "pkg":
+        hints.append(
+            {
+                "kind": "go-pkg",
+                "value": "reusable package directory convention",
+                "weak": True,
+            }
+        )
+    if "testdata" in parts:
+        hints.append(
+            {
+                "kind": "go-testdata",
+                "value": "test fixture data convention",
+                "weak": False,
+            }
+        )
+    if path.name.endswith("_test.go"):
+        hints.append(
+            {
+                "kind": "go-test-file",
+                "value": "*_test.go test convention",
+                "weak": False,
+            }
+        )
+    return hints
+
+
+def build_package_modules(
+    modules: list[dict[str, Any]],
+    symbols: list[dict[str, Any]],
+    tests: list[dict[str, Any]],
+    importers_by_target: dict[str, list[str]],
+) -> list[dict[str, Any]]:
+    files_by_dir: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for module in modules:
+        path = str(module.get("path") or "")
+        if module.get("language") != "go" or not path.endswith(".go"):
+            continue
+        if is_test_fixture_path(path):
+            continue
+        directory = str(module.get("directory") or "")
+        files_by_dir[directory].append(module)
+
+    symbols_by_dir: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for symbol in symbols:
+        if symbol.get("language") != "go":
+            continue
+        path = str(symbol.get("path") or "")
+        if is_test_path(path):
+            continue
+        symbols_by_dir[Path(path).parent.as_posix() if Path(path).parent.as_posix() != "." else ""].append(symbol)
+
+    go_package_modules: list[dict[str, Any]] = []
+    for directory, package_files in sorted(files_by_dir.items()):
+        source_files = sorted(
+            str(item.get("path"))
+            for item in package_files
+            if str(item.get("path") or "").endswith(".go") and not is_test_path(str(item.get("path") or ""))
+        )
+        test_files = sorted(
+            str(item.get("path"))
+            for item in package_files
+            if is_test_path(str(item.get("path") or ""))
+        )
+        if not source_files and not test_files:
+            continue
+        package_counts = Counter(
+            str(item.get("package"))
+            for item in package_files
+            if isinstance(item.get("package"), str) and item.get("package")
+        )
+        package_name = ""
+        if package_counts:
+            package_name = sorted(package_counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
+        package_symbols = [
+            str(symbol.get("name"))
+            for symbol in symbols_by_dir.get(directory, [])
+            if symbol.get("exported") and isinstance(symbol.get("name"), str)
+        ]
+        tokens = set(tokens_for_path(directory or package_name or "."))
+        if package_name:
+            tokens.update(split_identifier(package_name))
+        for symbol_name in package_symbols:
+            tokens.update(split_identifier(symbol_name))
+        imported_by = sorted(set(importers_by_target.get(directory, [])))
+        boundary_hints = boundary_hints_for_path(directory)
+        module: dict[str, Any] = {
+            "path": directory or ".",
+            "name": package_name or Path(directory).name or ".",
+            "directory": Path(directory).parent.as_posix() if directory and Path(directory).parent.as_posix() != "." else "",
+            "language": "go",
+            "kind": "package",
+            "package": package_name or None,
+            "files": sorted(source_files + test_files),
+            "sourceFiles": source_files,
+            "testFiles": test_files,
+            "tokens": sorted(tokens),
+            "lineCount": sum(int(item.get("lineCount", 0)) for item in package_files),
+            "symbols": sorted(set(package_symbols)),
+            "exportedSymbolCount": len(set(package_symbols)),
+        }
+        if imported_by:
+            module["importedBy"] = imported_by
+            module["importCount"] = len(imported_by)
+        if test_files:
+            module["pairedTests"] = test_files
+        if boundary_hints:
+            module["boundaryHints"] = boundary_hints
+            module["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in boundary_hints)
+        if any(hint.get("kind") == "go-internal" for hint in boundary_hints):
+            module["internalBoundary"] = True
+        if any(hint.get("kind") == "go-cmd" for hint in boundary_hints):
+            module["entrypointBoundary"] = True
+        if any(hint.get("kind") == "go-pkg" for hint in boundary_hints):
+            module["weakReusablePackageConvention"] = True
+        if package_symbols and source_files:
+            module["publicAPICandidate"] = True
+        go_package_modules.append(module)
+    return go_package_modules

--- a/scripts/codebase_awareness/adapters/rust.py
+++ b/scripts/codebase_awareness/adapters/rust.py
@@ -1,0 +1,732 @@
+"""Rust adapter for the shallow codebase awareness scanner."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from scripts.codebase_awareness.adapters.common import (
+    is_test_path,
+    normalize_rel_parts,
+    split_identifier,
+    tokens_for_path,
+)
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
+    tomllib = None
+
+
+def manifest_kinds() -> dict[str, str]:
+    return {
+        "Cargo.lock": "cargo-lock",
+        "Cargo.toml": "cargo",
+    }
+
+
+def language_for_manifest(kind: str) -> str | None:
+    if kind in {"cargo", "cargo-lock"}:
+        return "toml"
+    return None
+
+
+def parse_toml_document(text: str) -> dict[str, Any]:
+    if tomllib is not None:
+        try:
+            data = tomllib.loads(text)
+        except tomllib.TOMLDecodeError:
+            data = {}
+        if isinstance(data, dict):
+            return data
+    return parse_toml_fallback(text)
+
+
+def parse_toml_fallback(text: str) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    section: list[str] = []
+    array_section: tuple[list[str], dict[str, Any]] | None = None
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("[[") and line.endswith("]]"):
+            section = [part.strip() for part in line[2:-2].split(".") if part.strip()]
+            container = data
+            for part in section[:-1]:
+                child = container.setdefault(part, {})
+                if not isinstance(child, dict):
+                    child = {}
+                    container[part] = child
+                container = child
+            entries = container.setdefault(section[-1], [])
+            if not isinstance(entries, list):
+                entries = []
+                container[section[-1]] = entries
+            item: dict[str, Any] = {}
+            entries.append(item)
+            array_section = (section, item)
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = [part.strip() for part in line[1:-1].split(".") if part.strip()]
+            array_section = None
+            continue
+        if "=" not in line:
+            continue
+        key, value = [part.strip() for part in line.split("=", 1)]
+        parsed: Any
+        if value.startswith('"') and value.endswith('"'):
+            parsed = value[1:-1]
+        elif value.startswith("[") and value.endswith("]"):
+            parsed = [
+                item.strip().strip('"').strip("'")
+                for item in value[1:-1].split(",")
+                if item.strip()
+            ]
+        else:
+            parsed = value.strip('"').strip("'")
+
+        if array_section is not None and array_section[0] == section:
+            array_section[1][key] = parsed
+            continue
+        container = data
+        for part in section:
+            child = container.setdefault(part, {})
+            if not isinstance(child, dict):
+                child = {}
+                container[part] = child
+            container = child
+        container[key] = parsed
+    return data
+
+
+def normalize_visibility(raw: str | None) -> str:
+    if not raw:
+        return "private"
+    compact = re.sub(r"\s+", " ", raw.strip())
+    compact = compact.replace("pub (", "pub(")
+    compact = re.sub(r"\(\s+", "(", compact)
+    compact = re.sub(r"\s+\)", ")", compact)
+    return compact
+
+
+def visibility_exported(visibility: str) -> bool:
+    return visibility == "pub"
+
+
+def line_without_comment(line: str) -> str:
+    return line.split("//", 1)[0]
+
+
+def brace_delta(line: str) -> int:
+    stripped = line_without_comment(line)
+    return stripped.count("{") - stripped.count("}")
+
+
+def impl_type(line: str) -> str | None:
+    pattern = re.compile(
+        r"""
+        ^\s*impl
+        (?:\s*<[^>{}]*>)?
+        \s+
+        (?:
+          [A-Za-z_][\w:<>]*
+          \s+for\s+
+        )?
+        (?P<type>[A-Za-z_][\w:]*)
+        (?:\s*<[^>{}]*>)?
+        (?:\s+where\b.*)?
+        \s*\{
+        """,
+        re.VERBOSE,
+    )
+    match = pattern.search(line)
+    if not match:
+        return None
+    return match.group("type").split("::")[-1]
+
+
+def symbol_record(
+    *,
+    rel: str,
+    line_number: int,
+    kind: str,
+    name: str,
+    visibility: str,
+    impl_type_name: str | None = None,
+    test_only: bool = False,
+) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "name": name,
+        "kind": kind,
+        "language": "rust",
+        "path": rel,
+        "line": line_number,
+        "exported": visibility_exported(visibility),
+        "visibility": visibility,
+        "tokens": sorted(set(split_identifier(name))),
+    }
+    if impl_type_name:
+        record["implType"] = impl_type_name
+        record["tokens"] = sorted(set(record["tokens"]) | set(split_identifier(impl_type_name)))
+    if test_only:
+        record["testOnly"] = True
+    return record
+
+
+def extract_symbols(rel: str, text: str) -> list[dict[str, Any]]:
+    vis = r"(?P<vis>pub(?:\s*\([^)]*\))?)?"
+    fn_pattern = re.compile(
+        rf"^\s*{vis}\s*(?:(?:async|unsafe|const)\s+)*fn\s+(?P<name>[A-Za-z_][\w]*)\b"
+    )
+    type_pattern = re.compile(
+        rf"^\s*{vis}\s*(?P<kind>struct|enum|trait|type)\s+(?P<name>[A-Za-z_][\w]*)\b"
+    )
+    const_pattern = re.compile(
+        rf"^\s*{vis}\s*(?P<kind>const|static)\s+(?P<name>[A-Za-z_][\w]*)\b"
+    )
+    mod_pattern = re.compile(
+        rf"^\s*{vis}\s*mod\s+(?P<name>[A-Za-z_][\w]*)\s*(?:;|\{{)"
+    )
+    cfg_test_re = re.compile(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]")
+    test_attr_re = re.compile(r"#\s*\[\s*(?:(?:tokio|async_std)::)?test\s*\]")
+    symbols: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    brace_depth = 0
+    impl_stack: list[tuple[int, str]] = []
+    test_module_stack: list[int] = []
+    pending_cfg_test = False
+    pending_test_attr = False
+
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        while impl_stack and brace_depth < impl_stack[-1][0]:
+            impl_stack.pop()
+        while test_module_stack and brace_depth < test_module_stack[-1]:
+            test_module_stack.pop()
+
+        if cfg_test_re.search(line):
+            pending_cfg_test = True
+            brace_depth += brace_delta(line)
+            continue
+
+        if test_attr_re.search(line):
+            pending_test_attr = True
+            brace_depth += brace_delta(line)
+            continue
+
+        cfg_test_item = pending_cfg_test
+        pending_cfg_test = False
+        test_mod_line = bool(cfg_test_item and re.search(r"^\s*(?:pub\s+)?mod\s+[A-Za-z_][\w]*\s*\{", line))
+        if test_mod_line:
+            test_module_stack.append(brace_depth + 1)
+        test_attr_item = pending_test_attr
+        pending_test_attr = False
+        in_test_module = bool(test_module_stack) or cfg_test_item or test_attr_item
+
+        current_impl_type = impl_type(line)
+        if current_impl_type and not in_test_module:
+            impl_stack.append((brace_depth + 1, current_impl_type))
+        active_impl = impl_stack[-1][1] if impl_stack and brace_depth >= impl_stack[-1][0] else None
+
+        if not in_test_module:
+            for pattern, default_kind in (
+                (fn_pattern, "function"),
+                (type_pattern, None),
+                (const_pattern, None),
+                (mod_pattern, "module"),
+            ):
+                match = pattern.search(line)
+                if not match:
+                    continue
+                name = match.group("name")
+                visibility = normalize_visibility(match.groupdict().get("vis"))
+                kind = default_kind or match.group("kind")
+                if kind == "fn":
+                    kind = "function"
+                if kind == "const":
+                    kind = "constant"
+                if kind == "static":
+                    kind = "static"
+                if kind == "function" and active_impl:
+                    kind = "method"
+                key = (kind, name, active_impl or "")
+                if key in seen:
+                    continue
+                seen.add(key)
+                symbols.append(
+                    symbol_record(
+                        rel=rel,
+                        line_number=line_number,
+                        kind=kind,
+                        name=name,
+                        visibility=visibility,
+                        impl_type_name=active_impl if kind == "method" else None,
+                    )
+                )
+                break
+
+        brace_depth += brace_delta(line)
+        while impl_stack and brace_depth < impl_stack[-1][0]:
+            impl_stack.pop()
+        while test_module_stack and brace_depth < test_module_stack[-1]:
+            test_module_stack.pop()
+    return symbols
+
+
+def split_top_level_commas(value: str) -> list[str]:
+    items: list[str] = []
+    depth = 0
+    start = 0
+    for index, char in enumerate(value):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth = max(0, depth - 1)
+        elif char == "," and depth == 0:
+            item = value[start:index].strip()
+            if item:
+                items.append(item)
+            start = index + 1
+    item = value[start:].strip()
+    if item:
+        items.append(item)
+    return items
+
+
+def find_matching_brace(value: str, start: int) -> int | None:
+    depth = 0
+    for index in range(start, len(value)):
+        char = value[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def clean_use_spec(spec: str) -> str:
+    spec = re.sub(r"\s+as\s+[A-Za-z_][\w]*$", "", spec.strip())
+    spec = spec.strip(":")
+    spec = re.sub(r"\s+", "", spec)
+    return spec
+
+
+def expand_use_tree(value: str) -> list[str]:
+    value = value.strip()
+    brace_index = value.find("{")
+    if brace_index == -1:
+        cleaned = clean_use_spec(value)
+        return [cleaned] if cleaned else []
+    end = find_matching_brace(value, brace_index)
+    if end is None:
+        cleaned = clean_use_spec(value)
+        return [cleaned] if cleaned else []
+
+    prefix = value[:brace_index]
+    suffix = value[end + 1 :]
+    inner = value[brace_index + 1 : end]
+    expanded: list[str] = []
+    for item in split_top_level_commas(inner):
+        for child in expand_use_tree(item):
+            if child == "self":
+                combined = prefix.rstrip(":")
+            elif prefix.endswith("::"):
+                combined = f"{prefix}{child}"
+            elif prefix:
+                combined = f"{prefix}::{child}"
+            else:
+                combined = child
+            combined = clean_use_spec(f"{combined}{suffix}")
+            if combined:
+                expanded.append(combined)
+    return sorted(set(expanded))
+
+
+def extract_import_records(text: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    use_pattern = re.compile(r"^\s*(?P<vis>pub(?:\s*\([^)]*\))?)?\s*use\s+(?P<body>[^;]+);")
+    mod_pattern = re.compile(r"^\s*(?P<vis>pub(?:\s*\([^)]*\))?)?\s*mod\s+(?P<name>[A-Za-z_][\w]*)\s*(?:;|\{)")
+    seen: set[tuple[str, str, int]] = set()
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        use_match = use_pattern.search(line)
+        if use_match:
+            visibility = normalize_visibility(use_match.group("vis"))
+            kind = "pub use" if visibility == "pub" else "use"
+            for spec in expand_use_tree(use_match.group("body")):
+                key = (kind, spec, line_number)
+                if key in seen:
+                    continue
+                seen.add(key)
+                records.append(
+                    {
+                        "imported": spec,
+                        "kind": kind,
+                        "visibility": visibility,
+                        "exported": visibility == "pub",
+                        "tokens": sorted(set(split_identifier(spec))),
+                        "line": line_number,
+                    }
+                )
+            continue
+
+        mod_match = mod_pattern.search(line)
+        if mod_match:
+            visibility = normalize_visibility(mod_match.group("vis"))
+            name = mod_match.group("name")
+            key = ("mod", name, line_number)
+            if key in seen:
+                continue
+            seen.add(key)
+            records.append(
+                {
+                    "imported": name,
+                    "kind": "mod",
+                    "visibility": visibility,
+                    "exported": visibility == "pub",
+                    "tokens": sorted(set(split_identifier(name))),
+                    "line": line_number,
+                }
+            )
+    return sorted(records, key=lambda item: (int(item.get("line", 0)), str(item.get("imported"))))
+
+
+def extract_manifest(rel: str, text: str, kind: str) -> dict[str, Any] | None:
+    if kind not in {"cargo", "cargo-lock"}:
+        return None
+    path = Path(rel)
+    manifest: dict[str, Any] = {
+        "path": rel,
+        "kind": kind,
+        "language": "toml",
+        "tokens": tokens_for_path(rel),
+    }
+    if path.name == "Cargo.toml":
+        data = parse_toml_document(text)
+        package = data.get("package") if isinstance(data, dict) else None
+        workspace = data.get("workspace") if isinstance(data, dict) else None
+        if isinstance(package, dict):
+            name = package.get("name")
+            if isinstance(name, str) and name:
+                manifest["packageName"] = name
+        if isinstance(workspace, dict):
+            members = workspace.get("members")
+            if isinstance(members, list):
+                manifest["workspaceMembers"] = sorted(str(member) for member in members if isinstance(member, str))
+        dependency_sections = {
+            "dependencies": "dependencies",
+            "dev-dependencies": "devDependencies",
+            "build-dependencies": "buildDependencies",
+        }
+        for source_key, output_key in dependency_sections.items():
+            section = data.get(source_key) if isinstance(data, dict) else None
+            if isinstance(section, dict):
+                manifest[output_key] = sorted(str(key) for key in section)
+        lib = data.get("lib") if isinstance(data, dict) else None
+        if isinstance(lib, dict):
+            hint = {str(key): str(value) for key, value in sorted(lib.items()) if isinstance(value, (str, int, bool))}
+            manifest["lib"] = hint or True
+        bins = data.get("bin") if isinstance(data, dict) else None
+        if isinstance(bins, list):
+            bin_targets = []
+            for item in bins:
+                if isinstance(item, dict):
+                    name = item.get("name")
+                    path_value = item.get("path")
+                    target = {}
+                    if isinstance(name, str):
+                        target["name"] = name
+                    if isinstance(path_value, str):
+                        target["path"] = path_value
+                    if target:
+                        bin_targets.append(target)
+            if bin_targets:
+                manifest["bin"] = sorted(bin_targets, key=lambda item: (str(item.get("name", "")), str(item.get("path", ""))))
+        token_values = [str(manifest.get("packageName", ""))]
+        token_values.extend(str(item) for item in manifest.get("workspaceMembers", []))
+        token_values.extend(str(item) for item in manifest.get("dependencies", []))
+        manifest["tokens"] = sorted(set(manifest["tokens"]) | set(split_identifier(" ".join(token_values))))
+    if path.name == "Cargo.lock":
+        packages = sorted(set(re.findall(r'^\s*name\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)))
+        if packages:
+            manifest["packages"] = packages[:50]
+            manifest["tokens"] = sorted(set(manifest["tokens"]) | set(split_identifier(" ".join(packages[:50]))))
+    return manifest
+
+
+def crate_name_for_package(package_name: str) -> str:
+    return package_name.replace("-", "_")
+
+
+def build_context(manifests: list[dict[str, Any]], known_files: set[str]) -> dict[str, Any]:
+    workspace_members: set[str] = set()
+    for manifest in manifests:
+        if manifest.get("kind") != "cargo":
+            continue
+        base = Path(str(manifest.get("path") or "")).parent
+        base_rel = "" if base.as_posix() == "." else base.as_posix()
+        for member in manifest.get("workspaceMembers", []):
+            if not isinstance(member, str) or not member:
+                continue
+            member_path = normalize_rel_parts(f"{base_rel}/{member}" if base_rel else member)
+            workspace_members.add(member_path)
+
+    crates: list[dict[str, Any]] = []
+    for manifest in manifests:
+        if manifest.get("kind") != "cargo":
+            continue
+        path = str(manifest.get("path") or "")
+        root = Path(path).parent.as_posix()
+        if root == ".":
+            root = ""
+        package_name = manifest.get("packageName")
+        if not isinstance(package_name, str):
+            package_name = Path(root).name if root else ""
+        if not package_name and root not in workspace_members:
+            continue
+        crate = {
+            "root": root,
+            "manifestPath": path,
+            "packageName": package_name,
+            "crateName": crate_name_for_package(package_name) if package_name else "",
+            "workspaceMember": root in workspace_members,
+        }
+        crates.append(crate)
+
+    crate_by_name: dict[str, dict[str, Any]] = {}
+    for crate in crates:
+        for key in (crate.get("crateName"), crate.get("packageName")):
+            if isinstance(key, str) and key:
+                crate_by_name[key] = crate
+
+    return {
+        "crates": sorted(crates, key=lambda item: str(item.get("root") or "")),
+        "crateByName": crate_by_name,
+        "workspaceMembers": sorted(workspace_members),
+        "knownFiles": sorted(known_files),
+    }
+
+
+def src_root(crate: dict[str, Any] | None) -> str:
+    if not crate:
+        return "src"
+    root = str(crate.get("root") or "")
+    return f"{root}/src" if root else "src"
+
+
+def crate_for_path(rel: str, rust_context: dict[str, Any]) -> dict[str, Any] | None:
+    crates = rust_context.get("crates")
+    if not isinstance(crates, list):
+        return None
+    matches = []
+    for crate in crates:
+        if not isinstance(crate, dict):
+            continue
+        root = str(crate.get("root") or "")
+        if not root or rel == root or rel.startswith(f"{root}/"):
+            matches.append(crate)
+    if not matches:
+        return None
+    return sorted(matches, key=lambda item: len(str(item.get("root") or "")), reverse=True)[0]
+
+
+def module_path_candidates(base_dir: str, module_parts: list[str]) -> list[str]:
+    candidates: list[str] = []
+    for count in range(len(module_parts), -1, -1):
+        parts = module_parts[:count]
+        if not parts:
+            candidates.extend(
+                [
+                    f"{base_dir}/lib.rs",
+                    f"{base_dir}/main.rs",
+                    f"{base_dir}/mod.rs",
+                ]
+            )
+            continue
+        module_path = "/".join(parts)
+        candidates.extend(
+            [
+                f"{base_dir}/{module_path}.rs",
+                f"{base_dir}/{module_path}/mod.rs",
+                f"{base_dir}/{module_path}/lib.rs",
+            ]
+        )
+    return [normalize_rel_parts(candidate) for candidate in candidates]
+
+
+def resolve_import(
+    source_rel: str,
+    imported: str,
+    known_files: set[str],
+    rust_context: dict[str, Any],
+) -> str | None:
+    if not imported:
+        return None
+    parts = [part for part in imported.split("::") if part and part not in {"*"}]
+    if not parts:
+        return None
+    crate = crate_for_path(source_rel, rust_context)
+    crate_by_name = rust_context.get("crateByName")
+    if not isinstance(crate_by_name, dict):
+        crate_by_name = {}
+
+    first = parts[0]
+    rest = parts[1:]
+    if first == "crate":
+        base = src_root(crate)
+        module_parts = rest
+    elif first == "self":
+        base = Path(source_rel).parent.as_posix()
+        module_parts = rest
+    elif first == "super":
+        base = Path(source_rel).parent.parent.as_posix()
+        module_parts = rest
+    elif first in crate_by_name:
+        target = crate_by_name[first]
+        base = src_root(target if isinstance(target, dict) else None)
+        module_parts = rest
+    elif crate:
+        base = src_root(crate)
+        module_parts = parts
+    else:
+        return None
+
+    for candidate in module_path_candidates(base, module_parts):
+        if candidate in known_files:
+            return candidate
+    return None
+
+
+def test_info(rel: str, text: str, language: str | None) -> dict[str, Any]:
+    if language != "rust":
+        return {"hasTests": False, "testFunctions": [], "hasCfgTest": False}
+    has_cfg_test = bool(re.search(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]", text))
+    test_functions: list[str] = []
+    pending_test = False
+    for line in text.splitlines():
+        if re.search(r"#\s*\[\s*(?:test|tokio::test|async_std::test)\s*\]", line):
+            pending_test = True
+            continue
+        if pending_test:
+            match = re.search(r"^\s*(?:async\s+)?fn\s+([A-Za-z_][\w]*)\b", line)
+            if match:
+                test_functions.append(match.group(1))
+                pending_test = False
+                continue
+            if line.strip() and not line.strip().startswith("#"):
+                pending_test = False
+    has_tests = has_cfg_test or bool(test_functions) or is_test_path(rel)
+    return {
+        "hasTests": has_tests,
+        "testFunctions": sorted(set(test_functions)),
+        "hasCfgTest": has_cfg_test,
+    }
+
+
+def test_framework(text: str) -> str:
+    if "#[tokio::test]" in text:
+        return "tokio-test"
+    if "#[async_std::test]" in text:
+        return "async-std-test"
+    return "rust-test"
+
+
+def module_role(rel: str, crate: dict[str, Any] | None) -> str | None:
+    if not crate:
+        if rel.startswith("crates/"):
+            return "crates-directory"
+        if Path(rel).parts and "tests" in Path(rel).parts:
+            return "integration-test"
+        return None
+    root = src_root(crate)
+    if rel == f"{root}/lib.rs":
+        return "library-crate-root"
+    if rel == f"{root}/main.rs":
+        return "binary-crate-root"
+    if Path(rel).parts and "tests" in Path(rel).parts:
+        return "integration-test"
+    if Path(rel).name == "mod.rs":
+        return "module-root"
+    return None
+
+
+def module_fields(rel: str, text: str, rust_context: dict[str, Any]) -> dict[str, Any]:
+    crate = crate_for_path(rel, rust_context)
+    fields: dict[str, Any] = {}
+    if crate:
+        if crate.get("root"):
+            fields["crateRoot"] = crate.get("root")
+        if crate.get("crateName"):
+            fields["crateName"] = crate.get("crateName")
+        if crate.get("packageName"):
+            fields["packageName"] = crate.get("packageName")
+        if crate.get("workspaceMember"):
+            fields["workspaceMember"] = True
+    role = module_role(rel, crate)
+    hints: list[dict[str, Any]] = []
+    if role == "library-crate-root":
+        hints.append({"kind": "rust-library-crate-root", "value": "Rust library crate root", "weak": False})
+    elif role == "binary-crate-root":
+        hints.append({"kind": "rust-binary-crate-root", "value": "Rust binary crate root", "weak": False})
+    elif role == "integration-test":
+        hints.append({"kind": "rust-integration-test", "value": "Rust integration test", "weak": False})
+    elif role == "crates-directory":
+        hints.append({"kind": "rust-crates-directory", "value": "crates/ directory convention", "weak": True})
+    if crate and crate.get("workspaceMember") and crate.get("root"):
+        hints.append(
+            {
+                "kind": "rust-workspace-member",
+                "value": "Cargo workspace member",
+                "weak": False,
+                "path": crate.get("root"),
+            }
+        )
+    if re.search(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]", text):
+        fields["hasInlineCfgTest"] = True
+        hints.append({"kind": "rust-inline-cfg-test", "value": "inline #[cfg(test)] tests", "weak": False})
+    if hints:
+        fields["boundaryHints"] = hints
+        fields["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in hints)
+    if role:
+        fields["rustRole"] = role
+    return fields
+
+
+def update_module_boundaries(
+    modules: list[dict[str, Any]],
+    symbols_by_path: dict[str, list[dict[str, Any]]],
+) -> None:
+    for module in modules:
+        if module.get("language") != "rust":
+            continue
+        path = str(module.get("path") or "")
+        if not path:
+            continue
+        hints = list(module.get("boundaryHints", []))
+        exported = sorted(
+            str(symbol.get("name"))
+            for symbol in symbols_by_path.get(path, [])
+            if symbol.get("exported") and isinstance(symbol.get("name"), str)
+        )
+        if exported:
+            hints.append({"kind": "rust-public-api", "value": "Rust public API candidate", "weak": False})
+        crate_local = sorted(
+            str(symbol.get("name"))
+            for symbol in symbols_by_path.get(path, [])
+            if str(symbol.get("visibility") or "").startswith("pub(") and isinstance(symbol.get("name"), str)
+        )
+        if crate_local:
+            hints.append(
+                {
+                    "kind": "rust-crate-local-visibility",
+                    "value": "Rust crate-local visibility",
+                    "weak": False,
+                    "risk": "pub(crate)/pub(super) visibility may not be reusable outside the crate",
+                }
+            )
+            module["crateLocalSymbols"] = crate_local
+        if hints:
+            module["boundaryHints"] = hints
+            module["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in hints if isinstance(hint, dict))

--- a/scripts/codebase_awareness/build_index.py
+++ b/scripts/codebase_awareness/build_index.py
@@ -14,17 +14,20 @@ import json
 import os
 import re
 import sys
-import xml.etree.ElementTree as ET
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-try:
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
-    tomllib = None
+from scripts.codebase_awareness.adapters import csharp, go, rust
+from scripts.codebase_awareness.adapters.common import (
+    is_test_fixture_path,
+    is_test_path,
+    normalize_rel_parts,
+    split_identifier,
+    tokens_for_path,
+)
 
 DEFAULT_MAX_FILES = 10_000
 DEFAULT_MAX_BYTES = 50_000_000
@@ -97,11 +100,9 @@ LANGUAGE_BY_SUFFIX = {
 }
 
 SOURCE_LANGUAGES = {"csharp", "go", "javascript", "python", "rust", "shell", "typescript"}
+LANGUAGE_ADAPTERS = (go, rust, csharp)
+
 MANIFEST_NAMES = {
-    "Cargo.lock": "cargo-lock",
-    "Cargo.toml": "cargo",
-    "go.mod": "go",
-    "go.work": "go-work",
     "package-lock.json": "npm",
     "package.json": "npm",
     "pnpm-lock.yaml": "npm",
@@ -113,14 +114,6 @@ MANIFEST_NAMES = {
 }
 SHARED_DIR_HINTS = {"common", "lib", "shared", "utils"}
 VALIDATION_TOKENS = {"assert", "check", "parse", "schema", "valid", "validate", "validation", "validator"}
-GO_TEST_FUNCTION_RE = re.compile(r"^\s*func\s+((?:Test|Benchmark|Fuzz)[A-Za-z0-9_]*)\s*\(", re.MULTILINE)
-CSHARP_TEST_PACKAGE_FRAMEWORKS = {
-    "microsoft.net.test.sdk": "dotnet-test",
-    "mstest.testframework": "mstest",
-    "nunit": "nunit",
-    "xunit": "xunit",
-}
-CSHARP_EXTERNAL_NAMESPACE_PREFIXES = ("Microsoft.", "Newtonsoft.", "System.")
 
 
 @dataclass(frozen=True)
@@ -220,16 +213,17 @@ def iter_candidate_files(root: Path) -> list[Path]:
 
 def manifest_kind_for_path(rel: str) -> str | None:
     path = Path(rel)
+    for adapter in LANGUAGE_ADAPTERS:
+        adapter_manifest_kind = getattr(adapter, "manifest_kind_for_path", None)
+        if callable(adapter_manifest_kind):
+            kind = adapter_manifest_kind(rel)
+            if kind:
+                return kind
+        kinds = adapter.manifest_kinds()
+        if path.name in kinds:
+            return kinds[path.name]
     if path.name in MANIFEST_NAMES:
         return MANIFEST_NAMES[path.name]
-    if path.suffix == ".sln":
-        return "dotnet-solution"
-    if path.suffix == ".csproj":
-        return "dotnet-project"
-    if path.name == "Directory.Build.props" or path.suffix == ".props":
-        return "dotnet-props"
-    if path.name == "Directory.Build.targets" or path.suffix == ".targets":
-        return "dotnet-targets"
     return None
 
 
@@ -237,15 +231,11 @@ def language_for_path(rel: str) -> str | None:
     path = Path(rel)
     manifest_kind = manifest_kind_for_path(rel)
     if manifest_kind:
+        for adapter in LANGUAGE_ADAPTERS:
+            language = adapter.language_for_manifest(manifest_kind)
+            if language:
+                return language
         return {
-            "cargo": "toml",
-            "cargo-lock": "toml",
-            "dotnet-project": "csharp",
-            "dotnet-props": "csharp",
-            "dotnet-solution": "csharp",
-            "dotnet-targets": "csharp",
-            "go": "go",
-            "go-work": "go",
             "npm": "json" if path.suffix == ".json" else "yaml",
             "python": "toml" if path.suffix == ".toml" else "python",
         }.get(manifest_kind)
@@ -412,42 +402,6 @@ def build_scan(
     )
 
 
-def split_identifier(value: str) -> list[str]:
-    value = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", value)
-    value = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", value)
-    return [part.lower() for part in re.split(r"[^A-Za-z0-9]+", value) if part]
-
-
-def tokens_for_path(rel: str) -> list[str]:
-    return sorted(set(split_identifier(rel)))
-
-
-def is_test_path(rel: str) -> bool:
-    path = Path(rel)
-    name = path.name
-    parts = set(path.parts)
-    return (
-        "test" in parts
-        or "tests" in parts
-        or name.startswith("test_")
-        or name.endswith("Test.cs")
-        or name.endswith("Tests.cs")
-        or name.endswith("_test.go")
-        or name.endswith("_test.py")
-        or name.endswith("_test.rs")
-        or ".test." in name
-        or ".spec." in name
-    )
-
-
-def is_go_test_path(rel: str) -> bool:
-    return Path(rel).name.endswith("_test.go")
-
-
-def is_test_fixture_path(rel: str) -> bool:
-    return "testdata" in Path(rel).parts
-
-
 def module_kind(rel: str) -> str:
     if manifest_kind_for_path(rel):
         return "manifest"
@@ -458,659 +412,13 @@ def module_kind(rel: str) -> str:
     return "support"
 
 
-def is_exported_go_identifier(name: str) -> bool:
-    return bool(name) and "A" <= name[0] <= "Z"
-
-
-def extract_go_package_name(text: str) -> str | None:
-    match = re.search(r"^\s*package\s+([A-Za-z_][A-Za-z0-9_]*)\b", text, flags=re.MULTILINE)
-    return match.group(1) if match else None
-
-
-def normalize_go_receiver(receiver: str) -> str | None:
-    receiver = receiver.strip()
-    if not receiver:
-        return None
-    parts = receiver.split()
-    raw_type = parts[-1] if parts else receiver
-    raw_type = raw_type.lstrip("*")
-    raw_type = raw_type.split(".")[-1]
-    raw_type = raw_type.split("[", 1)[0]
-    raw_type = re.sub(r"[^A-Za-z0-9_]", "", raw_type)
-    return raw_type or None
-
-
-def go_symbol_entry(
-    *,
-    name: str,
-    kind: str,
-    rel: str,
-    line_number: int,
-    receiver: str | None = None,
-) -> dict[str, Any]:
-    tokens = set(split_identifier(name))
-    if receiver:
-        tokens.update(split_identifier(receiver))
-    return {
-        "name": name,
-        "kind": kind,
-        "language": "go",
-        "path": rel,
-        "line": line_number,
-        "exported": is_exported_go_identifier(name),
-        "tokens": sorted(tokens),
-        "receiver": receiver,
-    }
-
-
-def extract_go_symbols(rel: str, text: str) -> list[dict[str, Any]]:
-    symbols: list[dict[str, Any]] = []
-    seen: set[tuple[str, str, str | None]] = set()
-    for line_number, line in enumerate(text.splitlines(), start=1):
-        func_match = re.search(
-            r"^\s*func\s+(?:\((?P<receiver>[^)]*)\)\s*)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
-            line,
-        )
-        if func_match:
-            receiver = normalize_go_receiver(func_match.group("receiver") or "")
-            name = func_match.group("name")
-            kind = "method" if receiver else "function"
-            key = (kind, name, receiver)
-            if key not in seen:
-                seen.add(key)
-                symbols.append(
-                    go_symbol_entry(
-                        name=name,
-                        kind=kind,
-                        rel=rel,
-                        line_number=line_number,
-                        receiver=receiver,
-                    )
-                )
-            continue
-
-        type_match = re.search(r"^\s*type\s+([A-Za-z_][A-Za-z0-9_]*)\b", line)
-        if type_match:
-            name = type_match.group(1)
-            key = ("type", name, None)
-            if key not in seen:
-                seen.add(key)
-                symbols.append(go_symbol_entry(name=name, kind="type", rel=rel, line_number=line_number))
-            continue
-
-        value_match = re.search(r"^\s*(const|var)\s+([A-Za-z_][A-Za-z0-9_]*)\b", line)
-        if value_match:
-            kind = "constant" if value_match.group(1) == "const" else "variable"
-            name = value_match.group(2)
-            key = (kind, name, None)
-            if key not in seen:
-                seen.add(key)
-                symbols.append(go_symbol_entry(name=name, kind=kind, rel=rel, line_number=line_number))
-            continue
-
-        grouped_value_match = re.search(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:=|[A-Za-z_\*])", line)
-        if grouped_value_match and symbols:
-            previous_kind = symbols[-1].get("kind")
-            if previous_kind in {"constant", "variable"}:
-                name = grouped_value_match.group(1)
-                key = (str(previous_kind), name, None)
-                if key not in seen:
-                    seen.add(key)
-                    symbols.append(
-                        go_symbol_entry(
-                            name=name,
-                            kind=str(previous_kind),
-                            rel=rel,
-                            line_number=line_number,
-                        )
-                    )
-    return symbols
-
-
-def parse_toml_document(text: str) -> dict[str, Any]:
-    if tomllib is not None:
-        try:
-            data = tomllib.loads(text)
-        except tomllib.TOMLDecodeError:
-            data = {}
-        if isinstance(data, dict):
-            return data
-    return parse_toml_fallback(text)
-
-
-def parse_toml_fallback(text: str) -> dict[str, Any]:
-    data: dict[str, Any] = {}
-    section: list[str] = []
-    array_section: tuple[list[str], dict[str, Any]] | None = None
-    for raw_line in text.splitlines():
-        line = raw_line.split("#", 1)[0].strip()
-        if not line:
-            continue
-        if line.startswith("[[") and line.endswith("]]"):
-            section = [part.strip() for part in line[2:-2].split(".") if part.strip()]
-            container = data
-            for part in section[:-1]:
-                child = container.setdefault(part, {})
-                if not isinstance(child, dict):
-                    child = {}
-                    container[part] = child
-                container = child
-            entries = container.setdefault(section[-1], [])
-            if not isinstance(entries, list):
-                entries = []
-                container[section[-1]] = entries
-            item: dict[str, Any] = {}
-            entries.append(item)
-            array_section = (section, item)
-            continue
-        if line.startswith("[") and line.endswith("]"):
-            section = [part.strip() for part in line[1:-1].split(".") if part.strip()]
-            array_section = None
-            continue
-        if "=" not in line:
-            continue
-        key, value = [part.strip() for part in line.split("=", 1)]
-        parsed: Any
-        if value.startswith('"') and value.endswith('"'):
-            parsed = value[1:-1]
-        elif value.startswith("[") and value.endswith("]"):
-            parsed = [
-                item.strip().strip('"').strip("'")
-                for item in value[1:-1].split(",")
-                if item.strip()
-            ]
-        else:
-            parsed = value.strip('"').strip("'")
-
-        if array_section is not None and array_section[0] == section:
-            array_section[1][key] = parsed
-            continue
-        container = data
-        for part in section:
-            child = container.setdefault(part, {})
-            if not isinstance(child, dict):
-                child = {}
-                container[part] = child
-            container = child
-        container[key] = parsed
-    return data
-
-
-def normalize_rust_visibility(raw: str | None) -> str:
-    if not raw:
-        return "private"
-    compact = re.sub(r"\s+", " ", raw.strip())
-    compact = compact.replace("pub (", "pub(")
-    compact = re.sub(r"\(\s+", "(", compact)
-    compact = re.sub(r"\s+\)", ")", compact)
-    return compact
-
-
-def rust_visibility_exported(visibility: str) -> bool:
-    return visibility == "pub"
-
-
-def rust_line_without_comment(line: str) -> str:
-    return line.split("//", 1)[0]
-
-
-def rust_brace_delta(line: str) -> int:
-    stripped = rust_line_without_comment(line)
-    return stripped.count("{") - stripped.count("}")
-
-
-def rust_impl_type(line: str) -> str | None:
-    pattern = re.compile(
-        r"""
-        ^\s*impl
-        (?:\s*<[^>{}]*>)?
-        \s+
-        (?:
-          [A-Za-z_][\w:<>]*
-          \s+for\s+
-        )?
-        (?P<type>[A-Za-z_][\w:]*)
-        (?:\s*<[^>{}]*>)?
-        (?:\s+where\b.*)?
-        \s*\{
-        """,
-        re.VERBOSE,
-    )
-    match = pattern.search(line)
-    if not match:
-        return None
-    return match.group("type").split("::")[-1]
-
-
-def rust_symbol_record(
-    *,
-    rel: str,
-    line_number: int,
-    kind: str,
-    name: str,
-    visibility: str,
-    impl_type: str | None = None,
-    test_only: bool = False,
-) -> dict[str, Any]:
-    record: dict[str, Any] = {
-        "name": name,
-        "kind": kind,
-        "language": "rust",
-        "path": rel,
-        "line": line_number,
-        "exported": rust_visibility_exported(visibility),
-        "visibility": visibility,
-        "tokens": sorted(set(split_identifier(name))),
-    }
-    if impl_type:
-        record["implType"] = impl_type
-        record["tokens"] = sorted(set(record["tokens"]) | set(split_identifier(impl_type)))
-    if test_only:
-        record["testOnly"] = True
-    return record
-
-
-def extract_rust_symbols(rel: str, text: str) -> list[dict[str, Any]]:
-    vis = r"(?P<vis>pub(?:\s*\([^)]*\))?)?"
-    fn_pattern = re.compile(
-        rf"^\s*{vis}\s*(?:(?:async|unsafe|const)\s+)*fn\s+(?P<name>[A-Za-z_][\w]*)\b"
-    )
-    type_pattern = re.compile(
-        rf"^\s*{vis}\s*(?P<kind>struct|enum|trait|type)\s+(?P<name>[A-Za-z_][\w]*)\b"
-    )
-    const_pattern = re.compile(
-        rf"^\s*{vis}\s*(?P<kind>const|static)\s+(?P<name>[A-Za-z_][\w]*)\b"
-    )
-    mod_pattern = re.compile(
-        rf"^\s*{vis}\s*mod\s+(?P<name>[A-Za-z_][\w]*)\s*(?:;|\{{)"
-    )
-    cfg_test_re = re.compile(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]")
-    test_attr_re = re.compile(r"#\s*\[\s*(?:(?:tokio|async_std)::)?test\s*\]")
-    symbols: list[dict[str, Any]] = []
-    seen: set[tuple[str, str, str]] = set()
-    brace_depth = 0
-    impl_stack: list[tuple[int, str]] = []
-    test_module_stack: list[int] = []
-    pending_cfg_test = False
-    pending_test_attr = False
-
-    for line_number, line in enumerate(text.splitlines(), start=1):
-        while impl_stack and brace_depth < impl_stack[-1][0]:
-            impl_stack.pop()
-        while test_module_stack and brace_depth < test_module_stack[-1]:
-            test_module_stack.pop()
-
-        if cfg_test_re.search(line):
-            pending_cfg_test = True
-            brace_depth += rust_brace_delta(line)
-            continue
-
-        if test_attr_re.search(line):
-            pending_test_attr = True
-            brace_depth += rust_brace_delta(line)
-            continue
-
-        cfg_test_item = pending_cfg_test
-        pending_cfg_test = False
-        test_mod_line = bool(cfg_test_item and re.search(r"^\s*(?:pub\s+)?mod\s+[A-Za-z_][\w]*\s*\{", line))
-        if test_mod_line:
-            test_module_stack.append(brace_depth + 1)
-        test_attr_item = pending_test_attr
-        pending_test_attr = False
-        in_test_module = bool(test_module_stack) or cfg_test_item or test_attr_item
-
-        impl_type = rust_impl_type(line)
-        if impl_type and not in_test_module:
-            impl_stack.append((brace_depth + 1, impl_type))
-        active_impl = impl_stack[-1][1] if impl_stack and brace_depth >= impl_stack[-1][0] else None
-
-        if not in_test_module:
-            for pattern, default_kind in (
-                (fn_pattern, "function"),
-                (type_pattern, None),
-                (const_pattern, None),
-                (mod_pattern, "module"),
-            ):
-                match = pattern.search(line)
-                if not match:
-                    continue
-                name = match.group("name")
-                visibility = normalize_rust_visibility(match.groupdict().get("vis"))
-                kind = default_kind or match.group("kind")
-                if kind == "fn":
-                    kind = "function"
-                if kind == "const":
-                    kind = "constant"
-                if kind == "static":
-                    kind = "static"
-                if kind == "function" and active_impl:
-                    kind = "method"
-                key = (kind, name, active_impl or "")
-                if key in seen:
-                    continue
-                seen.add(key)
-                symbols.append(
-                    rust_symbol_record(
-                        rel=rel,
-                        line_number=line_number,
-                        kind=kind,
-                        name=name,
-                        visibility=visibility,
-                        impl_type=active_impl if kind == "method" else None,
-                    )
-                )
-                break
-
-        brace_depth += rust_brace_delta(line)
-        while impl_stack and brace_depth < impl_stack[-1][0]:
-            impl_stack.pop()
-        while test_module_stack and brace_depth < test_module_stack[-1]:
-            test_module_stack.pop()
-    return symbols
-
-
-def csharp_line_without_comment(line: str) -> str:
-    in_string = False
-    escaped = False
-    quote = ""
-    for index, char in enumerate(line):
-        if in_string:
-            if escaped:
-                escaped = False
-                continue
-            if char == "\\":
-                escaped = True
-                continue
-            if char == quote:
-                in_string = False
-                quote = ""
-            continue
-        if char in {"\"", "'"}:
-            in_string = True
-            quote = char
-            continue
-        if char == "/" and index + 1 < len(line) and line[index + 1] == "/":
-            return line[:index]
-    return line
-
-
-def csharp_brace_delta(line: str) -> int:
-    stripped = csharp_line_without_comment(line)
-    return stripped.count("{") - stripped.count("}")
-
-
-def normalize_csharp_visibility(modifiers: str, default_visibility: str) -> str:
-    words = set(re.findall(r"\b(public|internal|private|protected)\b", modifiers))
-    if "private" in words and "protected" in words:
-        return "private protected"
-    if "protected" in words and "internal" in words:
-        return "protected internal"
-    for visibility in ("public", "internal", "private", "protected"):
-        if visibility in words:
-            return visibility
-    return default_visibility
-
-
-def csharp_visibility_exported(visibility: str) -> bool:
-    return visibility == "public"
-
-
-def csharp_visibility_risk(visibility: str) -> str | None:
-    if visibility == "internal":
-        return "C# internal symbol is assembly-local and may not be reusable across project boundaries"
-    if visibility == "protected internal":
-        return "C# protected internal symbol is constrained by assembly or inheritance boundaries"
-    if visibility == "private protected":
-        return "C# private protected symbol is constrained to derived types in the same assembly"
-    if visibility == "protected":
-        return "C# protected symbol is inheritance-scoped"
-    if visibility == "private":
-        return "C# private symbol is not reusable outside its containing type"
-    return None
-
-
-def csharp_symbol_record(
-    *,
-    rel: str,
-    line_number: int,
-    kind: str,
-    name: str,
-    visibility: str,
-    namespace: str | None,
-    container: str | None = None,
-    is_static: bool = False,
-) -> dict[str, Any]:
-    tokens = set(split_identifier(name))
-    if container:
-        tokens.update(split_identifier(container))
-    record: dict[str, Any] = {
-        "name": name,
-        "kind": kind,
-        "language": "csharp",
-        "path": rel,
-        "line": line_number,
-        "exported": csharp_visibility_exported(visibility),
-        "visibility": visibility,
-        "static": is_static,
-        "tokens": sorted(tokens),
-    }
-    if namespace:
-        record["namespace"] = namespace
-    if container:
-        record["container"] = container
-    risk = csharp_visibility_risk(visibility)
-    if risk:
-        record["visibilityRisks"] = [risk]
-    return record
-
-
-def extract_csharp_namespaces(rel: str, text: str) -> list[dict[str, Any]]:
-    namespaces: list[dict[str, Any]] = []
-    seen: set[str] = set()
-    for line_number, line in enumerate(text.splitlines(), start=1):
-        stripped = csharp_line_without_comment(line)
-        match = re.search(r"^\s*namespace\s+([A-Za-z_][\w.]*)\s*(?:[;{]|$)", stripped)
-        if not match:
-            continue
-        namespace = match.group(1)
-        if namespace in seen:
-            continue
-        seen.add(namespace)
-        namespaces.append(
-            csharp_symbol_record(
-                rel=rel,
-                line_number=line_number,
-                kind="namespace",
-                name=namespace,
-                visibility="public",
-                namespace=namespace,
-            )
-        )
-    return namespaces
-
-
-def extract_csharp_symbols(rel: str, text: str) -> list[dict[str, Any]]:
-    symbols = extract_csharp_namespaces(rel, text)
-    modifier_words = (
-        "public|internal|private|protected|static|sealed|abstract|partial|readonly|"
-        "ref|unsafe|new|virtual|override|async|extern|required|const"
-    )
-    modifiers = rf"(?P<mods>(?:(?:{modifier_words})\s+)*)"
-    type_pattern = re.compile(
-        rf"^\s*{modifiers}(?P<kind>record\s+struct|record\s+class|class|record|struct|interface|enum)\s+"
-        rf"(?P<name>[A-Za-z_][\w]*)\b"
-    )
-    constructor_pattern = re.compile(rf"^\s*{modifiers}(?P<name>[A-Za-z_][\w]*)\s*\(")
-    method_pattern = re.compile(
-        rf"^\s*{modifiers}(?P<return>[A-Za-z_][\w.<>,?\[\]]*(?:\s*<[^;=(){{}}]+>)?)\s+"
-        rf"(?P<name>[A-Za-z_][\w]*)\s*(?:<[^;=(){{}}]+>)?\s*\("
-    )
-    property_pattern = re.compile(
-        rf"^\s*{modifiers}(?P<type>[A-Za-z_][\w.<>,?\[\]]*)\s+"
-        rf"(?P<name>[A-Za-z_][\w]*)\s*\{{[^}}]*(?:get|set|init)\b"
-    )
-    field_pattern = re.compile(
-        rf"^\s*{modifiers}(?P<type>[A-Za-z_][\w.<>,?\[\]]*)\s+"
-        rf"(?P<name>[A-Za-z_][\w]*)\s*(?:=|;)"
-    )
-    namespace_pattern = re.compile(r"^\s*namespace\s+([A-Za-z_][\w.]*)\s*(?:[;{]|$)")
-    control_words = {"catch", "for", "foreach", "if", "lock", "switch", "using", "while"}
-    seen: set[tuple[str, str, str | None]] = {
-        ("namespace", str(symbol.get("name")), None) for symbol in symbols
-    }
-    brace_depth = 0
-    type_stack: list[tuple[int, str]] = []
-    pending_type: tuple[str, int] | None = None
-    current_namespace: str | None = None
-
-    for line_number, raw_line in enumerate(text.splitlines(), start=1):
-        while type_stack and brace_depth < type_stack[-1][0]:
-            type_stack.pop()
-        line = csharp_line_without_comment(raw_line)
-        stripped = line.strip()
-        if not stripped or stripped.startswith("["):
-            brace_depth += csharp_brace_delta(line)
-            continue
-
-        namespace_match = namespace_pattern.search(line)
-        if namespace_match:
-            current_namespace = namespace_match.group(1)
-
-        if pending_type and "{" in line:
-            type_stack.append((brace_depth + 1, pending_type[0]))
-            pending_type = None
-
-        type_match = type_pattern.search(line)
-        if type_match:
-            raw_kind = re.sub(r"\s+", " ", type_match.group("kind").strip())
-            kind = "record" if raw_kind.startswith("record") else raw_kind
-            name = type_match.group("name")
-            visibility = normalize_csharp_visibility(type_match.group("mods") or "", "internal")
-            key = (kind, name, type_stack[-1][1] if type_stack else None)
-            if key not in seen:
-                seen.add(key)
-                symbols.append(
-                    csharp_symbol_record(
-                        rel=rel,
-                        line_number=line_number,
-                        kind=kind,
-                        name=name,
-                        visibility=visibility,
-                        namespace=current_namespace,
-                        container=type_stack[-1][1] if type_stack else None,
-                        is_static=bool(re.search(r"\bstatic\b", type_match.group("mods") or "")),
-                    )
-                )
-            if "{" in line:
-                type_stack.append((brace_depth + 1, name))
-            elif not stripped.endswith(";"):
-                pending_type = (name, brace_depth + 1)
-            brace_depth += csharp_brace_delta(line)
-            continue
-
-        container = type_stack[-1][1] if type_stack else None
-        if container:
-            constructor_match = constructor_pattern.search(line)
-            if constructor_match and constructor_match.group("name") == container:
-                visibility = normalize_csharp_visibility(constructor_match.group("mods") or "", "private")
-                key = ("constructor", container, container)
-                if key not in seen:
-                    seen.add(key)
-                    symbols.append(
-                        csharp_symbol_record(
-                            rel=rel,
-                            line_number=line_number,
-                            kind="constructor",
-                            name=container,
-                            visibility=visibility,
-                            namespace=current_namespace,
-                            container=container,
-                            is_static=bool(re.search(r"\bstatic\b", constructor_match.group("mods") or "")),
-                        )
-                    )
-                brace_depth += csharp_brace_delta(line)
-                continue
-
-            property_match = property_pattern.search(line)
-            if property_match:
-                name = property_match.group("name")
-                visibility = normalize_csharp_visibility(property_match.group("mods") or "", "private")
-                key = ("property", name, container)
-                if key not in seen:
-                    seen.add(key)
-                    symbols.append(
-                        csharp_symbol_record(
-                            rel=rel,
-                            line_number=line_number,
-                            kind="property",
-                            name=name,
-                            visibility=visibility,
-                            namespace=current_namespace,
-                            container=container,
-                            is_static=bool(re.search(r"\bstatic\b", property_match.group("mods") or "")),
-                        )
-                    )
-                brace_depth += csharp_brace_delta(line)
-                continue
-
-            method_match = method_pattern.search(line)
-            if method_match and method_match.group("name") not in control_words:
-                name = method_match.group("name")
-                visibility = normalize_csharp_visibility(method_match.group("mods") or "", "private")
-                key = ("method", name, container)
-                if key not in seen:
-                    seen.add(key)
-                    symbols.append(
-                        csharp_symbol_record(
-                            rel=rel,
-                            line_number=line_number,
-                            kind="method",
-                            name=name,
-                            visibility=visibility,
-                            namespace=current_namespace,
-                            container=container,
-                            is_static=bool(re.search(r"\bstatic\b", method_match.group("mods") or "")),
-                        )
-                    )
-                brace_depth += csharp_brace_delta(line)
-                continue
-
-            if "(" not in line and not stripped.startswith(("return ", "throw ")):
-                field_match = field_pattern.search(line)
-                if field_match:
-                    name = field_match.group("name")
-                    mods = field_match.group("mods") or ""
-                    visibility = normalize_csharp_visibility(mods, "private")
-                    kind = "constant" if re.search(r"\bconst\b", mods) else "field"
-                    key = (kind, name, container)
-                    if key not in seen:
-                        seen.add(key)
-                        symbols.append(
-                            csharp_symbol_record(
-                                rel=rel,
-                                line_number=line_number,
-                                kind=kind,
-                                name=name,
-                                visibility=visibility,
-                                namespace=current_namespace,
-                                container=container,
-                                is_static=bool(re.search(r"\bstatic\b", mods)),
-                            )
-                        )
-
-        brace_depth += csharp_brace_delta(line)
-        while type_stack and brace_depth < type_stack[-1][0]:
-            type_stack.pop()
-    return symbols
-
-
 def extract_symbols(rel: str, language: str | None, text: str) -> list[dict[str, Any]]:
     if language == "csharp" and Path(rel).suffix == ".cs":
-        return extract_csharp_symbols(rel, text)
+        return csharp.extract_symbols(rel, text)
     if language == "go":
-        return extract_go_symbols(rel, text)
+        return go.extract_symbols(rel, text)
     if language == "rust":
-        return extract_rust_symbols(rel, text)
+        return rust.extract_symbols(rel, text)
 
     patterns: list[tuple[str, str, str]] = []
     if language in {"javascript", "typescript"}:
@@ -1183,251 +491,13 @@ def extract_import_specs(language: str | None, text: str) -> list[str]:
     return sorted(set(specs))
 
 
-def strip_go_line_comment(line: str) -> str:
-    in_string = False
-    escaped = False
-    quote = ""
-    for index, char in enumerate(line):
-        if in_string:
-            if escaped:
-                escaped = False
-                continue
-            if char == "\\":
-                escaped = True
-                continue
-            if char == quote:
-                in_string = False
-                quote = ""
-            continue
-        if char in {"\"", "`"}:
-            in_string = True
-            quote = char
-            continue
-        if char == "/" and index + 1 < len(line) and line[index + 1] == "/":
-            return line[:index]
-    return line
-
-
-def parse_go_import_line(line: str) -> dict[str, Any] | None:
-    line = strip_go_line_comment(line).strip().rstrip(";")
-    if not line or line == ")":
-        return None
-    match = re.match(
-        r"^(?:(?P<alias>\.|\_|[A-Za-z_][A-Za-z0-9_]*)\s+)?(?P<quote>\"[^\"]+\"|`[^`]+`)$",
-        line,
-    )
-    if not match:
-        return None
-    alias = match.group("alias")
-    imported = match.group("quote")[1:-1]
-    if alias == "_":
-        import_kind = "blank"
-    elif alias == ".":
-        import_kind = "dot"
-    elif alias:
-        import_kind = "aliased"
-    else:
-        import_kind = "package"
-    return {
-        "imported": imported,
-        "alias": alias,
-        "importKind": import_kind,
-        "tokens": sorted(set(split_identifier(imported))),
-    }
-
-
-def extract_go_import_records(text: str) -> list[dict[str, Any]]:
-    records: list[dict[str, Any]] = []
-    in_block = False
-    for line in text.splitlines():
-        stripped = strip_go_line_comment(line).strip()
-        if not in_block:
-            single = re.match(r"^import\s+(?!\()(.*)$", stripped)
-            if single:
-                record = parse_go_import_line(single.group(1))
-                if record:
-                    records.append(record)
-                continue
-            if re.match(r"^import\s*\($", stripped):
-                in_block = True
-                continue
-        else:
-            if stripped.startswith(")"):
-                in_block = False
-                continue
-            record = parse_go_import_line(stripped)
-            if record:
-                records.append(record)
-    unique: dict[tuple[str, str | None], dict[str, Any]] = {}
-    for record in records:
-        unique[(str(record.get("imported")), record.get("alias"))] = record
-    return [unique[key] for key in sorted(unique)]
-
-
-def split_top_level_commas(value: str) -> list[str]:
-    items: list[str] = []
-    depth = 0
-    start = 0
-    for index, char in enumerate(value):
-        if char == "{":
-            depth += 1
-        elif char == "}":
-            depth = max(0, depth - 1)
-        elif char == "," and depth == 0:
-            item = value[start:index].strip()
-            if item:
-                items.append(item)
-            start = index + 1
-    item = value[start:].strip()
-    if item:
-        items.append(item)
-    return items
-
-
-def find_matching_brace(value: str, start: int) -> int | None:
-    depth = 0
-    for index in range(start, len(value)):
-        char = value[index]
-        if char == "{":
-            depth += 1
-        elif char == "}":
-            depth -= 1
-            if depth == 0:
-                return index
-    return None
-
-
-def clean_rust_use_spec(spec: str) -> str:
-    spec = re.sub(r"\s+as\s+[A-Za-z_][\w]*$", "", spec.strip())
-    spec = spec.strip(":")
-    spec = re.sub(r"\s+", "", spec)
-    return spec
-
-
-def expand_rust_use_tree(value: str) -> list[str]:
-    value = value.strip()
-    brace_index = value.find("{")
-    if brace_index == -1:
-        cleaned = clean_rust_use_spec(value)
-        return [cleaned] if cleaned else []
-    end = find_matching_brace(value, brace_index)
-    if end is None:
-        cleaned = clean_rust_use_spec(value)
-        return [cleaned] if cleaned else []
-
-    prefix = value[:brace_index]
-    suffix = value[end + 1 :]
-    inner = value[brace_index + 1 : end]
-    expanded: list[str] = []
-    for item in split_top_level_commas(inner):
-        for child in expand_rust_use_tree(item):
-            if child == "self":
-                combined = prefix.rstrip(":")
-            elif prefix.endswith("::"):
-                combined = f"{prefix}{child}"
-            elif prefix:
-                combined = f"{prefix}::{child}"
-            else:
-                combined = child
-            combined = clean_rust_use_spec(f"{combined}{suffix}")
-            if combined:
-                expanded.append(combined)
-    return sorted(set(expanded))
-
-
-def extract_rust_import_records(text: str) -> list[dict[str, Any]]:
-    records: list[dict[str, Any]] = []
-    use_pattern = re.compile(r"^\s*(?P<vis>pub(?:\s*\([^)]*\))?)?\s*use\s+(?P<body>[^;]+);")
-    mod_pattern = re.compile(r"^\s*(?P<vis>pub(?:\s*\([^)]*\))?)?\s*mod\s+(?P<name>[A-Za-z_][\w]*)\s*(?:;|\{)")
-    seen: set[tuple[str, str, int]] = set()
-    for line_number, line in enumerate(text.splitlines(), start=1):
-        use_match = use_pattern.search(line)
-        if use_match:
-            visibility = normalize_rust_visibility(use_match.group("vis"))
-            kind = "pub use" if visibility == "pub" else "use"
-            for spec in expand_rust_use_tree(use_match.group("body")):
-                key = (kind, spec, line_number)
-                if key in seen:
-                    continue
-                seen.add(key)
-                records.append(
-                    {
-                        "imported": spec,
-                        "kind": kind,
-                        "visibility": visibility,
-                        "exported": visibility == "pub",
-                        "tokens": sorted(set(split_identifier(spec))),
-                        "line": line_number,
-                    }
-                )
-            continue
-
-        mod_match = mod_pattern.search(line)
-        if mod_match:
-            visibility = normalize_rust_visibility(mod_match.group("vis"))
-            name = mod_match.group("name")
-            key = ("mod", name, line_number)
-            if key in seen:
-                continue
-            seen.add(key)
-            records.append(
-                {
-                    "imported": name,
-                    "kind": "mod",
-                    "visibility": visibility,
-                    "exported": visibility == "pub",
-                    "tokens": sorted(set(split_identifier(name))),
-                    "line": line_number,
-                }
-            )
-    return sorted(records, key=lambda item: (int(item.get("line", 0)), str(item.get("imported"))))
-
-
-def extract_csharp_import_records(text: str) -> list[dict[str, Any]]:
-    records: list[dict[str, Any]] = []
-    pattern = re.compile(
-        r"""
-        ^\s*
-        (?P<global>global\s+)?
-        using\s+
-        (?P<static>static\s+)?
-        (?:
-          (?P<alias>[A-Za-z_][\w]*)\s*=\s*
-        )?
-        (?P<imported>[A-Za-z_][\w.]*)
-        \s*;
-        """,
-        re.MULTILINE | re.VERBOSE,
-    )
-    seen: set[tuple[str, str | None, bool, bool]] = set()
-    for match in pattern.finditer(text):
-        imported = match.group("imported")
-        alias = match.group("alias")
-        is_static = bool(match.group("static"))
-        is_global = bool(match.group("global"))
-        key = (imported, alias, is_static, is_global)
-        if key in seen:
-            continue
-        seen.add(key)
-        record: dict[str, Any] = {
-            "imported": imported,
-            "kind": "using",
-            "alias": alias,
-            "static": is_static,
-            "global": is_global,
-            "tokens": sorted(set(split_identifier(imported))),
-        }
-        records.append(record)
-    return sorted(records, key=lambda item: (str(item.get("imported")), str(item.get("alias") or "")))
-
-
 def extract_import_records(language: str | None, text: str) -> list[dict[str, Any]]:
     if language == "csharp":
-        return extract_csharp_import_records(text)
+        return csharp.extract_import_records(text)
     if language == "go":
-        return extract_go_import_records(text)
+        return go.extract_import_records(text)
     if language == "rust":
-        return extract_rust_import_records(text)
+        return rust.extract_import_records(text)
     return [
         {
             "imported": spec,
@@ -1437,347 +507,37 @@ def extract_import_records(language: str | None, text: str) -> list[dict[str, An
     ]
 
 
-def normalize_rel_parts(value: str) -> str:
-    parts: list[str] = []
-    for part in value.split("/"):
-        if part in {"", "."}:
-            continue
-        if part == "..":
-            if parts:
-                parts.pop()
-            continue
-        parts.append(part)
-    return "/".join(parts)
-
-
-def parse_go_mod_module_path(text: str) -> str | None:
-    match = re.search(r"^\s*module\s+([^\s]+)", text, flags=re.MULTILINE)
-    return match.group(1) if match else None
-
-
-def parse_go_work_uses(text: str) -> list[str]:
-    uses: list[str] = []
-    in_block = False
-    for line in text.splitlines():
-        stripped = strip_go_line_comment(line).strip()
-        if not stripped:
-            continue
-        if in_block:
-            if stripped.startswith(")"):
-                in_block = False
-                continue
-            value = stripped.strip("\"`")
-            if value:
-                uses.append(value)
-            continue
-        match = re.match(r"^use\s+(.+)$", stripped)
-        if not match:
-            continue
-        rest = match.group(1).strip()
-        if rest.startswith("("):
-            in_block = True
-            rest = rest[1:].strip()
-            if not rest:
-                continue
-        if rest and rest != ")":
-            uses.append(rest.strip("\"`"))
-    return sorted(set(uses))
-
-
-def local_xml_name(tag: str) -> str:
-    return tag.rsplit("}", 1)[-1]
-
-
-def parse_xml_document(text: str) -> ET.Element | None:
-    try:
-        return ET.fromstring(text)
-    except ET.ParseError:
-        return None
-
-
-def xml_children_text(root: ET.Element, name: str) -> list[str]:
-    values: list[str] = []
-    for element in root.iter():
-        if local_xml_name(element.tag) != name:
-            continue
-        text = (element.text or "").strip()
-        if text:
-            values.append(text)
-    return values
-
-
-def parse_sln_projects(text: str) -> list[dict[str, str]]:
-    projects: list[dict[str, str]] = []
-    pattern = re.compile(
-        r'^\s*Project\("\{[^"]+\}"\)\s*=\s*"(?P<name>[^"]+)",\s*"(?P<path>[^"]+)",\s*"\{[^"]+\}"',
-        re.MULTILINE,
-    )
-    for match in pattern.finditer(text):
-        project_path = match.group("path").replace("\\", "/")
-        if not project_path.endswith(".csproj"):
-            continue
-        projects.append(
-            {
-                "name": match.group("name"),
-                "path": normalize_rel_parts(project_path),
-            }
-        )
-    return sorted(projects, key=lambda item: (item["path"], item["name"]))
-
-
-def normalize_msbuild_include(base_dir: str, include: str) -> str:
-    include = include.replace("\\", "/")
-    if not base_dir:
-        return normalize_rel_parts(include)
-    return normalize_rel_parts(f"{base_dir}/{include}")
-
-
-def parse_dotnet_project(rel: str, text: str) -> dict[str, Any]:
+def extract_manifest(rel: str, text: str) -> dict[str, Any] | None:
     path = Path(rel)
-    base_dir = path.parent.as_posix()
-    if base_dir == ".":
-        base_dir = ""
-    root = parse_xml_document(text)
-    target_frameworks: list[str] = []
-    output_type: str | None = None
-    assembly_name: str | None = None
-    root_namespace: str | None = None
-    project_references: list[str] = []
-    package_references: list[dict[str, str]] = []
-    package_names: list[str] = []
-    is_packable_values: list[str] = []
-    explicit_test_project_values: list[str] = []
-
-    if root is not None:
-        target_frameworks.extend(xml_children_text(root, "TargetFramework"))
-        for value in xml_children_text(root, "TargetFrameworks"):
-            target_frameworks.extend(item.strip() for item in value.split(";") if item.strip())
-        output_values = xml_children_text(root, "OutputType")
-        if output_values:
-            output_type = output_values[0]
-        assembly_values = xml_children_text(root, "AssemblyName")
-        if assembly_values:
-            assembly_name = assembly_values[0]
-        root_namespace_values = xml_children_text(root, "RootNamespace")
-        if root_namespace_values:
-            root_namespace = root_namespace_values[0]
-        is_packable_values = xml_children_text(root, "IsPackable")
-        explicit_test_project_values = xml_children_text(root, "IsTestProject")
-        for element in root.iter():
-            tag = local_xml_name(element.tag)
-            if tag == "ProjectReference":
-                include = element.attrib.get("Include") or element.attrib.get("Update")
-                if include:
-                    project_references.append(normalize_msbuild_include(base_dir, include))
-            elif tag == "PackageReference":
-                include = element.attrib.get("Include") or element.attrib.get("Update")
-                if not include:
-                    continue
-                version = element.attrib.get("Version")
-                if not version:
-                    for child in element:
-                        if local_xml_name(child.tag) == "Version" and child.text:
-                            version = child.text.strip()
-                            break
-                package_record = {"include": include}
-                if version:
-                    package_record["version"] = version
-                package_references.append(package_record)
-                package_names.append(include)
-
-    project_name = path.stem
-    lower_packages = {package.lower() for package in package_names}
-    is_test_project = (
-        project_name.endswith(".Tests")
-        or "tests" in path.parts
-        or any(CSHARP_TEST_PACKAGE_FRAMEWORKS.get(package) for package in lower_packages)
-        or any(value.lower() == "true" for value in explicit_test_project_values)
-    )
-    tokens = set(tokens_for_path(rel))
-    for value in [project_name, assembly_name or "", root_namespace or "", output_type or ""]:
-        tokens.update(split_identifier(value))
-    tokens.update(token for package in package_names for token in split_identifier(package))
+    manifest_kind = manifest_kind_for_path(rel)
+    if not manifest_kind:
+        return None
+    for adapter in LANGUAGE_ADAPTERS:
+        manifest = adapter.extract_manifest(rel, text, manifest_kind)
+        if manifest:
+            return manifest
     manifest: dict[str, Any] = {
         "path": rel,
-        "kind": "dotnet-project",
-        "language": "csharp",
-        "projectName": project_name,
-        "assemblyName": assembly_name or project_name,
-        "targetFrameworks": sorted(set(target_frameworks)),
-        "projectReferences": sorted(set(project_references)),
-        "packageReferences": sorted(set(package_names)),
-        "isTestProject": is_test_project,
-        "tokens": sorted(tokens),
+        "kind": manifest_kind,
+        "language": language_for_path(rel),
+        "tokens": tokens_for_path(rel),
     }
-    if root_namespace:
-        manifest["rootNamespace"] = root_namespace
-    if output_type:
-        manifest["outputType"] = output_type
-    if package_references:
-        manifest["packageReferenceDetails"] = sorted(
-            package_references,
-            key=lambda item: (str(item.get("include")), str(item.get("version", ""))),
-        )
-    test_packages = sorted(
-        package for package in lower_packages if package in CSHARP_TEST_PACKAGE_FRAMEWORKS
-    )
-    if test_packages:
-        manifest["testPackageHints"] = [
-            {"package": package, "framework": CSHARP_TEST_PACKAGE_FRAMEWORKS[package]}
-            for package in test_packages
-        ]
-    if is_packable_values:
-        manifest["isPackable"] = is_packable_values[0]
+    if path.name == "package.json":
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            data = {}
+        if isinstance(data, dict):
+            scripts = data.get("scripts")
+            deps = data.get("dependencies")
+            dev_deps = data.get("devDependencies")
+            if isinstance(scripts, dict):
+                manifest["scripts"] = sorted(str(key) for key in scripts)
+            if isinstance(deps, dict):
+                manifest["dependencies"] = sorted(str(key) for key in deps)
+            if isinstance(dev_deps, dict):
+                manifest["devDependencies"] = sorted(str(key) for key in dev_deps)
     return manifest
-
-
-def parse_dotnet_props_targets(rel: str, text: str, kind: str) -> dict[str, Any]:
-    root = parse_xml_document(text)
-    properties: set[str] = set()
-    item_types: set[str] = set()
-    if root is not None:
-        for element in root.iter():
-            name = local_xml_name(element.tag)
-            if name in {"Project", "PropertyGroup", "ItemGroup"}:
-                continue
-            if element.attrib:
-                item_types.add(name)
-            elif (element.text or "").strip():
-                properties.add(name)
-    tokens = set(tokens_for_path(rel))
-    tokens.update(token for value in properties | item_types for token in split_identifier(value))
-    manifest: dict[str, Any] = {
-        "path": rel,
-        "kind": kind,
-        "language": "csharp",
-        "tokens": sorted(tokens),
-    }
-    if properties:
-        manifest["properties"] = sorted(properties)
-    if item_types:
-        manifest["itemTypes"] = sorted(item_types)
-    return manifest
-
-
-def collect_go_modules(indexed_files: list[ScanFile]) -> list[tuple[str, str]]:
-    modules: list[tuple[str, str]] = []
-    for scanned_file in indexed_files:
-        if Path(scanned_file.rel).name != "go.mod":
-            continue
-        module_path = parse_go_mod_module_path(scanned_file.text)
-        if not module_path:
-            continue
-        directory = Path(scanned_file.rel).parent.as_posix()
-        modules.append(("" if directory == "." else directory, module_path))
-    return sorted(modules, key=lambda item: (-len(item[1]), item[0], item[1]))
-
-
-def resolve_go_import(
-    spec: str,
-    go_modules: list[tuple[str, str]],
-    go_package_dirs: set[str],
-) -> str | None:
-    for module_dir, module_path in go_modules:
-        if spec == module_path:
-            candidate = module_dir
-        elif spec.startswith(f"{module_path}/"):
-            suffix = spec[len(module_path) + 1 :]
-            candidate = normalize_rel_parts(f"{module_dir}/{suffix}" if module_dir else suffix)
-        else:
-            continue
-        if candidate in go_package_dirs:
-            return candidate or "."
-    return None
-
-
-def rust_src_root(crate: dict[str, Any] | None) -> str:
-    if not crate:
-        return "src"
-    root = str(crate.get("root") or "")
-    return f"{root}/src" if root else "src"
-
-
-def rust_crate_for_path(rel: str, rust_context: dict[str, Any]) -> dict[str, Any] | None:
-    crates = rust_context.get("crates")
-    if not isinstance(crates, list):
-        return None
-    matches = []
-    for crate in crates:
-        if not isinstance(crate, dict):
-            continue
-        root = str(crate.get("root") or "")
-        if not root or rel == root or rel.startswith(f"{root}/"):
-            matches.append(crate)
-    if not matches:
-        return None
-    return sorted(matches, key=lambda item: len(str(item.get("root") or "")), reverse=True)[0]
-
-
-def rust_module_path_candidates(base_dir: str, module_parts: list[str]) -> list[str]:
-    candidates: list[str] = []
-    for count in range(len(module_parts), -1, -1):
-        parts = module_parts[:count]
-        if not parts:
-            candidates.extend(
-                [
-                    f"{base_dir}/lib.rs",
-                    f"{base_dir}/main.rs",
-                    f"{base_dir}/mod.rs",
-                ]
-            )
-            continue
-        module_path = "/".join(parts)
-        candidates.extend(
-            [
-                f"{base_dir}/{module_path}.rs",
-                f"{base_dir}/{module_path}/mod.rs",
-                f"{base_dir}/{module_path}/lib.rs",
-            ]
-        )
-    return [normalize_rel_parts(candidate) for candidate in candidates]
-
-
-def resolve_rust_import(
-    source_rel: str,
-    imported: str,
-    known_files: set[str],
-    rust_context: dict[str, Any],
-) -> str | None:
-    if not imported:
-        return None
-    parts = [part for part in imported.split("::") if part and part not in {"*"}]
-    if not parts:
-        return None
-    crate = rust_crate_for_path(source_rel, rust_context)
-    crate_by_name = rust_context.get("crateByName")
-    if not isinstance(crate_by_name, dict):
-        crate_by_name = {}
-
-    first = parts[0]
-    rest = parts[1:]
-    if first == "crate":
-        base = rust_src_root(crate)
-        module_parts = rest
-    elif first == "self":
-        base = Path(source_rel).parent.as_posix()
-        module_parts = rest
-    elif first == "super":
-        base = Path(source_rel).parent.parent.as_posix()
-        module_parts = rest
-    elif first in crate_by_name:
-        target = crate_by_name[first]
-        base = rust_src_root(target if isinstance(target, dict) else None)
-        module_parts = rest
-    elif crate:
-        base = rust_src_root(crate)
-        module_parts = parts
-    else:
-        return None
-
-    for candidate in rust_module_path_candidates(base, module_parts):
-        if candidate in known_files:
-            return candidate
-    return None
 
 
 def resolve_import(
@@ -1793,13 +553,13 @@ def resolve_import(
 ) -> str | None:
     if language == "csharp":
         if isinstance(csharp_context, dict):
-            return resolve_csharp_import(source_rel, spec, csharp_context)
+            return csharp.resolve_import(source_rel, spec, csharp_context)
         return None
     if language == "go":
-        return resolve_go_import(spec, go_modules, go_package_dirs)
+        return go.resolve_import(spec, go_modules, go_package_dirs)
     if language == "rust":
         if isinstance(rust_context, dict):
-            return resolve_rust_import(source_rel, spec, known_files, rust_context)
+            return rust.resolve_import(source_rel, spec, known_files, rust_context)
         return None
     if not spec.startswith("."):
         return None
@@ -1833,16 +593,8 @@ def resolve_import(
 
 def test_framework_for_path(rel: str, text: str, language: str | None) -> str | None:
     if language == "csharp":
-        if re.search(r"\[(?:Fact|Theory)\b", text):
-            return "xunit"
-        if re.search(r"\[(?:Test|TestCase|TestFixture)\b", text):
-            return "nunit"
-        if re.search(r"\[(?:TestMethod|TestClass)\b", text):
-            return "mstest"
-        if is_test_path(rel):
-            return "dotnet-test"
-        return None
-    if language == "go" and is_go_test_path(rel):
+        return csharp.test_framework_for_text(rel, text)
+    if language == "go" and go.is_test_path(rel):
         return "go-test"
     if language in {"javascript", "typescript"}:
         if re.search(r"\bdescribe\s*\(|\bit\s*\(|\btest\s*\(", text):
@@ -1855,99 +607,8 @@ def test_framework_for_path(rel: str, text: str, language: str | None) -> str | 
     if language == "shell":
         return "shell"
     if language == "rust":
-        if "#[tokio::test]" in text:
-            return "tokio-test"
-        if "#[async_std::test]" in text:
-            return "async-std-test"
-        return "rust-test"
+        return rust.test_framework(text)
     return None
-
-
-def csharp_test_info(
-    rel: str,
-    text: str,
-    language: str | None,
-    project: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    if language != "csharp" or Path(rel).suffix != ".cs":
-        return {"hasTests": False, "framework": None, "testFunctions": []}
-    package_frameworks: set[str] = set()
-    if project:
-        for package in project.get("packageReferences", []):
-            framework = CSHARP_TEST_PACKAGE_FRAMEWORKS.get(str(package).lower())
-            if framework:
-                package_frameworks.add(framework)
-
-    attr_frameworks: set[str] = set()
-    test_functions: list[str] = []
-    pending_attr: str | None = None
-    attr_pattern = re.compile(r"\[(?P<attr>Fact|Theory|Test|TestCase|TestFixture|TestMethod|TestClass)\b")
-    method_pattern = re.compile(
-        r"^\s*(?:(?:public|internal|private|protected|static|async|virtual|override|sealed|new)\s+)*"
-        r"(?:[A-Za-z_][\w.<>,?\[\]]+\s+)?(?P<name>[A-Za-z_][\w]*)\s*\("
-    )
-    for line in text.splitlines():
-        attr_match = attr_pattern.search(line)
-        if attr_match:
-            attr = attr_match.group("attr")
-            if attr in {"Fact", "Theory"}:
-                attr_frameworks.add("xunit")
-                pending_attr = attr
-            elif attr in {"Test", "TestCase", "TestFixture"}:
-                attr_frameworks.add("nunit")
-                if attr != "TestFixture":
-                    pending_attr = attr
-            elif attr in {"TestMethod", "TestClass"}:
-                attr_frameworks.add("mstest")
-                if attr == "TestMethod":
-                    pending_attr = attr
-            continue
-        if pending_attr:
-            method_match = method_pattern.search(line)
-            if method_match:
-                test_functions.append(method_match.group("name"))
-                pending_attr = None
-                continue
-            if line.strip() and not line.strip().startswith("["):
-                pending_attr = None
-
-    frameworks = attr_frameworks | package_frameworks
-    framework_order = ("xunit", "nunit", "mstest", "dotnet-test")
-    framework = next((item for item in framework_order if item in frameworks), None)
-    if framework is None and (project and project.get("isTestProject")):
-        framework = "dotnet-test"
-    has_tests = bool(test_functions or frameworks or is_test_path(rel) or (project and project.get("isTestProject")))
-    return {
-        "hasTests": has_tests,
-        "framework": framework,
-        "testFunctions": sorted(set(test_functions)),
-    }
-
-
-def rust_test_info(rel: str, text: str, language: str | None) -> dict[str, Any]:
-    if language != "rust":
-        return {"hasTests": False, "testFunctions": [], "hasCfgTest": False}
-    has_cfg_test = bool(re.search(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]", text))
-    test_functions: list[str] = []
-    pending_test = False
-    for line in text.splitlines():
-        if re.search(r"#\s*\[\s*(?:test|tokio::test|async_std::test)\s*\]", line):
-            pending_test = True
-            continue
-        if pending_test:
-            match = re.search(r"^\s*(?:async\s+)?fn\s+([A-Za-z_][\w]*)\b", line)
-            if match:
-                test_functions.append(match.group(1))
-                pending_test = False
-                continue
-            if line.strip() and not line.strip().startswith("#"):
-                pending_test = False
-    has_tests = has_cfg_test or bool(test_functions) or is_test_path(rel)
-    return {
-        "hasTests": has_tests,
-        "testFunctions": sorted(set(test_functions)),
-        "hasCfgTest": has_cfg_test,
-    }
 
 
 def paired_tests_for(rel: str, tests: list[dict[str, Any]]) -> list[str]:
@@ -1970,467 +631,6 @@ def paired_tests_for(rel: str, tests: list[dict[str, Any]]) -> list[str]:
         if stem and stem in tokens_for_path(test_path):
             pairs.append(test_path)
     return sorted(set(pairs))
-
-
-def go_boundary_hints_for_path(rel: str) -> list[dict[str, Any]]:
-    path = Path(rel)
-    parts = path.parts
-    hints: list[dict[str, Any]] = []
-    if "internal" in parts:
-        index = parts.index("internal")
-        allowed_root = "/".join(parts[:index]) or "."
-        hints.append(
-            {
-                "kind": "go-internal",
-                "value": "internal package boundary",
-                "allowedRoot": allowed_root,
-                "weak": False,
-            }
-        )
-    if parts and parts[0] == "cmd":
-        hints.append(
-            {
-                "kind": "go-cmd",
-                "value": "executable entrypoint convention",
-                "weak": False,
-            }
-        )
-    if parts and parts[0] == "pkg":
-        hints.append(
-            {
-                "kind": "go-pkg",
-                "value": "reusable package directory convention",
-                "weak": True,
-            }
-        )
-    if "testdata" in parts:
-        hints.append(
-            {
-                "kind": "go-testdata",
-                "value": "test fixture data convention",
-                "weak": False,
-            }
-        )
-    if path.name.endswith("_test.go"):
-        hints.append(
-            {
-                "kind": "go-test-file",
-                "value": "*_test.go test convention",
-                "weak": False,
-            }
-        )
-    return hints
-
-
-def extract_manifest(rel: str, text: str) -> dict[str, Any] | None:
-    path = Path(rel)
-    manifest_kind = manifest_kind_for_path(rel)
-    if not manifest_kind:
-        return None
-    manifest: dict[str, Any] = {
-        "path": rel,
-        "kind": manifest_kind,
-        "language": language_for_path(rel),
-        "tokens": tokens_for_path(rel),
-    }
-    if manifest_kind == "dotnet-solution":
-        projects = parse_sln_projects(text)
-        manifest["language"] = "csharp"
-        if projects:
-            manifest["projects"] = projects
-            project_tokens = {token for project in projects for token in split_identifier(" ".join(project.values()))}
-            manifest["tokens"] = sorted(set(manifest["tokens"]) | project_tokens)
-        return manifest
-    if manifest_kind == "dotnet-project":
-        return parse_dotnet_project(rel, text)
-    if manifest_kind in {"dotnet-props", "dotnet-targets"}:
-        return parse_dotnet_props_targets(rel, text, manifest_kind)
-    if path.name == "go.mod":
-        module_path = parse_go_mod_module_path(text)
-        if module_path:
-            manifest["modulePath"] = module_path
-            manifest["tokens"] = sorted(set(manifest["tokens"]) | set(split_identifier(module_path)))
-    if path.name == "go.work":
-        workspace_uses = parse_go_work_uses(text)
-        if workspace_uses:
-            manifest["workspaceUses"] = workspace_uses
-            use_tokens = {token for use in workspace_uses for token in split_identifier(use)}
-            manifest["tokens"] = sorted(set(manifest["tokens"]) | use_tokens)
-    if path.name == "Cargo.toml":
-        data = parse_toml_document(text)
-        package = data.get("package") if isinstance(data, dict) else None
-        workspace = data.get("workspace") if isinstance(data, dict) else None
-        if isinstance(package, dict):
-            name = package.get("name")
-            if isinstance(name, str) and name:
-                manifest["packageName"] = name
-        if isinstance(workspace, dict):
-            members = workspace.get("members")
-            if isinstance(members, list):
-                manifest["workspaceMembers"] = sorted(str(member) for member in members if isinstance(member, str))
-        dependency_sections = {
-            "dependencies": "dependencies",
-            "dev-dependencies": "devDependencies",
-            "build-dependencies": "buildDependencies",
-        }
-        for source_key, output_key in dependency_sections.items():
-            section = data.get(source_key) if isinstance(data, dict) else None
-            if isinstance(section, dict):
-                manifest[output_key] = sorted(str(key) for key in section)
-        lib = data.get("lib") if isinstance(data, dict) else None
-        if isinstance(lib, dict):
-            hint = {str(key): str(value) for key, value in sorted(lib.items()) if isinstance(value, (str, int, bool))}
-            manifest["lib"] = hint or True
-        bins = data.get("bin") if isinstance(data, dict) else None
-        if isinstance(bins, list):
-            bin_targets = []
-            for item in bins:
-                if isinstance(item, dict):
-                    name = item.get("name")
-                    path_value = item.get("path")
-                    target = {}
-                    if isinstance(name, str):
-                        target["name"] = name
-                    if isinstance(path_value, str):
-                        target["path"] = path_value
-                    if target:
-                        bin_targets.append(target)
-            if bin_targets:
-                manifest["bin"] = sorted(bin_targets, key=lambda item: (str(item.get("name", "")), str(item.get("path", ""))))
-        token_values = [str(manifest.get("packageName", ""))]
-        token_values.extend(str(item) for item in manifest.get("workspaceMembers", []))
-        token_values.extend(str(item) for item in manifest.get("dependencies", []))
-        manifest["tokens"] = sorted(set(manifest["tokens"]) | set(split_identifier(" ".join(token_values))))
-    if path.name == "Cargo.lock":
-        packages = sorted(set(re.findall(r'^\s*name\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)))
-        if packages:
-            manifest["packages"] = packages[:50]
-            manifest["tokens"] = sorted(set(manifest["tokens"]) | set(split_identifier(" ".join(packages[:50]))))
-    if path.name == "package.json":
-        try:
-            data = json.loads(text)
-        except json.JSONDecodeError:
-            data = {}
-        if isinstance(data, dict):
-            scripts = data.get("scripts")
-            deps = data.get("dependencies")
-            dev_deps = data.get("devDependencies")
-            if isinstance(scripts, dict):
-                manifest["scripts"] = sorted(str(key) for key in scripts)
-            if isinstance(deps, dict):
-                manifest["dependencies"] = sorted(str(key) for key in deps)
-            if isinstance(dev_deps, dict):
-                manifest["devDependencies"] = sorted(str(key) for key in dev_deps)
-    return manifest
-
-
-def rust_crate_name_for_package(package_name: str) -> str:
-    return package_name.replace("-", "_")
-
-
-def build_rust_context(manifests: list[dict[str, Any]], known_files: set[str]) -> dict[str, Any]:
-    workspace_members: set[str] = set()
-    for manifest in manifests:
-        if manifest.get("kind") != "cargo":
-            continue
-        base = Path(str(manifest.get("path") or "")).parent
-        base_rel = "" if base.as_posix() == "." else base.as_posix()
-        for member in manifest.get("workspaceMembers", []):
-            if not isinstance(member, str) or not member:
-                continue
-            member_path = normalize_rel_parts(f"{base_rel}/{member}" if base_rel else member)
-            workspace_members.add(member_path)
-
-    crates: list[dict[str, Any]] = []
-    for manifest in manifests:
-        if manifest.get("kind") != "cargo":
-            continue
-        path = str(manifest.get("path") or "")
-        root = Path(path).parent.as_posix()
-        if root == ".":
-            root = ""
-        package_name = manifest.get("packageName")
-        if not isinstance(package_name, str):
-            package_name = Path(root).name if root else ""
-        if not package_name and root not in workspace_members:
-            continue
-        crate = {
-            "root": root,
-            "manifestPath": path,
-            "packageName": package_name,
-            "crateName": rust_crate_name_for_package(package_name) if package_name else "",
-            "workspaceMember": root in workspace_members,
-        }
-        crates.append(crate)
-
-    crate_by_name: dict[str, dict[str, Any]] = {}
-    for crate in crates:
-        for key in (crate.get("crateName"), crate.get("packageName")):
-            if isinstance(key, str) and key:
-                crate_by_name[key] = crate
-
-    return {
-        "crates": sorted(crates, key=lambda item: str(item.get("root") or "")),
-        "crateByName": crate_by_name,
-        "workspaceMembers": sorted(workspace_members),
-        "knownFiles": sorted(known_files),
-    }
-
-
-def build_csharp_context(manifests: list[dict[str, Any]], known_files: set[str]) -> dict[str, Any]:
-    projects: list[dict[str, Any]] = []
-    project_by_path: dict[str, dict[str, Any]] = {}
-    for manifest in manifests:
-        if manifest.get("kind") != "dotnet-project":
-            continue
-        path = str(manifest.get("path") or "")
-        if not path:
-            continue
-        root = Path(path).parent.as_posix()
-        if root == ".":
-            root = ""
-        project = {
-            "path": path,
-            "root": root,
-            "projectName": manifest.get("projectName") or Path(path).stem,
-            "assemblyName": manifest.get("assemblyName") or manifest.get("projectName") or Path(path).stem,
-            "rootNamespace": manifest.get("rootNamespace")
-            or manifest.get("assemblyName")
-            or manifest.get("projectName")
-            or Path(path).stem,
-            "projectReferences": sorted(str(item) for item in manifest.get("projectReferences", []) if isinstance(item, str)),
-            "packageReferences": sorted(str(item) for item in manifest.get("packageReferences", []) if isinstance(item, str)),
-            "isTestProject": bool(manifest.get("isTestProject")),
-            "outputType": manifest.get("outputType"),
-            "targetFrameworks": manifest.get("targetFrameworks", []),
-        }
-        projects.append(project)
-        project_by_path[path] = project
-
-    referenced_by: dict[str, list[str]] = defaultdict(list)
-    for project in projects:
-        for reference in project.get("projectReferences", []):
-            if reference in project_by_path:
-                referenced_by[reference].append(str(project.get("path")))
-
-    for project in projects:
-        path = str(project.get("path"))
-        project["referencedBy"] = sorted(set(referenced_by.get(path, [])))
-        source_files = [
-            rel
-            for rel in known_files
-            if rel.endswith(".cs")
-            and (
-                (not project.get("root") and "/" not in rel)
-                or (bool(project.get("root")) and rel.startswith(f"{project.get('root')}/"))
-            )
-        ]
-        project["sourceFiles"] = sorted(source_files)
-
-    return {
-        "projects": sorted(projects, key=lambda item: str(item.get("root") or "")),
-        "projectByPath": project_by_path,
-    }
-
-
-def csharp_project_for_path(rel: str, csharp_context: dict[str, Any]) -> dict[str, Any] | None:
-    projects = csharp_context.get("projects")
-    if not isinstance(projects, list):
-        return None
-    matches = []
-    for project in projects:
-        if not isinstance(project, dict):
-            continue
-        root = str(project.get("root") or "")
-        project_path = str(project.get("path") or "")
-        if rel == project_path or (root and rel.startswith(f"{root}/")) or (not root and "/" not in rel):
-            matches.append(project)
-    if not matches:
-        return None
-    return sorted(matches, key=lambda item: len(str(item.get("root") or "")), reverse=True)[0]
-
-
-def csharp_transitive_project_references(project: dict[str, Any], csharp_context: dict[str, Any]) -> list[dict[str, Any]]:
-    project_by_path = csharp_context.get("projectByPath")
-    if not isinstance(project_by_path, dict):
-        return []
-    found: list[dict[str, Any]] = []
-    seen: set[str] = set()
-    pending = [str(item) for item in project.get("projectReferences", [])]
-    while pending:
-        path = pending.pop(0)
-        if path in seen:
-            continue
-        seen.add(path)
-        target = project_by_path.get(path)
-        if not isinstance(target, dict):
-            continue
-        found.append(target)
-        pending.extend(str(item) for item in target.get("projectReferences", []))
-    return found
-
-
-def csharp_namespace_matches(imported: str, project: dict[str, Any]) -> bool:
-    namespaces = [
-        str(project.get("rootNamespace") or ""),
-        str(project.get("assemblyName") or ""),
-        str(project.get("projectName") or ""),
-    ]
-    for namespace in namespaces:
-        if not namespace:
-            continue
-        if imported == namespace or imported.startswith(f"{namespace}."):
-            return True
-    return False
-
-
-def resolve_csharp_import(
-    source_rel: str,
-    imported: str,
-    csharp_context: dict[str, Any],
-) -> str | None:
-    if not imported:
-        return None
-    source_project = csharp_project_for_path(source_rel, csharp_context)
-    candidates: list[dict[str, Any]] = []
-    if source_project:
-        candidates.append(source_project)
-        candidates.extend(csharp_transitive_project_references(source_project, csharp_context))
-    else:
-        projects = csharp_context.get("projects")
-        if isinstance(projects, list):
-            candidates.extend(project for project in projects if isinstance(project, dict))
-
-    for project in candidates:
-        if not csharp_namespace_matches(imported, project):
-            continue
-        root = str(project.get("root") or "")
-        return root or "."
-
-    if imported.startswith(CSHARP_EXTERNAL_NAMESPACE_PREFIXES):
-        return None
-    return None
-
-
-def rust_module_role(rel: str, crate: dict[str, Any] | None) -> str | None:
-    if not crate:
-        if rel.startswith("crates/"):
-            return "crates-directory"
-        if Path(rel).parts and "tests" in Path(rel).parts:
-            return "integration-test"
-        return None
-    src_root = rust_src_root(crate)
-    if rel == f"{src_root}/lib.rs":
-        return "library-crate-root"
-    if rel == f"{src_root}/main.rs":
-        return "binary-crate-root"
-    if Path(rel).parts and "tests" in Path(rel).parts:
-        return "integration-test"
-    if Path(rel).name == "mod.rs":
-        return "module-root"
-    return None
-
-
-def rust_module_fields(rel: str, text: str, rust_context: dict[str, Any]) -> dict[str, Any]:
-    crate = rust_crate_for_path(rel, rust_context)
-    fields: dict[str, Any] = {}
-    if crate:
-        if crate.get("root"):
-            fields["crateRoot"] = crate.get("root")
-        if crate.get("crateName"):
-            fields["crateName"] = crate.get("crateName")
-        if crate.get("packageName"):
-            fields["packageName"] = crate.get("packageName")
-        if crate.get("workspaceMember"):
-            fields["workspaceMember"] = True
-    role = rust_module_role(rel, crate)
-    hints: list[dict[str, Any]] = []
-    if role == "library-crate-root":
-        hints.append({"kind": "rust-library-crate-root", "value": "Rust library crate root", "weak": False})
-    elif role == "binary-crate-root":
-        hints.append({"kind": "rust-binary-crate-root", "value": "Rust binary crate root", "weak": False})
-    elif role == "integration-test":
-        hints.append({"kind": "rust-integration-test", "value": "Rust integration test", "weak": False})
-    elif role == "crates-directory":
-        hints.append({"kind": "rust-crates-directory", "value": "crates/ directory convention", "weak": True})
-    if crate and crate.get("workspaceMember") and crate.get("root"):
-        hints.append(
-            {
-                "kind": "rust-workspace-member",
-                "value": "Cargo workspace member",
-                "weak": False,
-                "path": crate.get("root"),
-            }
-        )
-    if re.search(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]", text):
-        fields["hasInlineCfgTest"] = True
-        hints.append({"kind": "rust-inline-cfg-test", "value": "inline #[cfg(test)] tests", "weak": False})
-    if hints:
-        fields["boundaryHints"] = hints
-        fields["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in hints)
-    if role:
-        fields["rustRole"] = role
-    return fields
-
-
-def csharp_module_fields(
-    rel: str,
-    text: str,
-    csharp_context: dict[str, Any],
-    manifest: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    fields: dict[str, Any] = {}
-    hints: list[dict[str, Any]] = []
-    project = csharp_project_for_path(rel, csharp_context)
-    if project and Path(rel).suffix == ".cs":
-        for key in ("projectName", "assemblyName", "rootNamespace", "outputType"):
-            value = project.get(key)
-            if value:
-                fields[key] = value
-        if project.get("root"):
-            fields["projectRoot"] = project.get("root")
-        if project.get("path"):
-            fields["projectPath"] = project.get("path")
-        if project.get("targetFrameworks"):
-            fields["targetFrameworks"] = project.get("targetFrameworks")
-        if project.get("isTestProject"):
-            fields["testProject"] = True
-
-    if manifest and manifest.get("kind") == "dotnet-solution":
-        hints.append({"kind": "dotnet-solution", "value": "C# solution boundary", "weak": False})
-    if manifest and manifest.get("kind") == "dotnet-project":
-        hints.append({"kind": "dotnet-project", "value": "C# project/assembly boundary", "weak": False})
-        if manifest.get("isTestProject"):
-            hints.append({"kind": "dotnet-test-project", "value": "C# test project boundary", "weak": False})
-            fields["testProject"] = True
-        if str(manifest.get("outputType") or "").lower() == "exe":
-            hints.append(
-                {
-                    "kind": "dotnet-executable-project",
-                    "value": "C# executable project boundary",
-                    "weak": False,
-                    "risk": "Executable C# project is not a generic helper module",
-                }
-            )
-            fields["executableBoundary"] = True
-        for reference in manifest.get("projectReferences", []):
-            if isinstance(reference, str):
-                hints.append(
-                    {
-                        "kind": "dotnet-project-reference",
-                        "value": "C# project reference dependency edge",
-                        "path": reference,
-                        "sourceProject": rel,
-                        "weak": False,
-                    }
-                )
-    if manifest and manifest.get("kind") in {"dotnet-props", "dotnet-targets"}:
-        hints.append({"kind": manifest.get("kind"), "value": "MSBuild props/targets manifest", "weak": False})
-
-    if hints:
-        fields["boundaryHints"] = hints
-        fields["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in hints if isinstance(hint, dict))
-    return fields
 
 
 def convention_entry(name: str, value: str, language: str | None, evidence: list[str]) -> dict[str, Any]:
@@ -2504,9 +704,9 @@ def build_style_profile(
             logging.append(convention_entry("logging", "runtime logging call", language, [rel]))
         if re.search(r"\b(process\.env|os\.environ|getenv)\b", text):
             config.append(convention_entry("config", "environment variable access", language, [rel]))
-        if language == "go" and is_go_test_path(rel):
+        if language == "go" and go.is_test_path(rel):
             go_conventions.append(convention_entry("go-test-command", "go test", "go", [rel]))
-            package_name = extract_go_package_name(text)
+            package_name = go.extract_package_name(text)
             if package_name and not package_name.endswith("_test"):
                 go_conventions.append(convention_entry("go-test-scope", "package-local tests", "go", [rel]))
         if language == "csharp" and Path(rel).suffix == ".cs":
@@ -2651,259 +851,6 @@ def compact_conventions(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     ]
 
 
-def build_go_package_modules(
-    modules: list[dict[str, Any]],
-    symbols: list[dict[str, Any]],
-    tests: list[dict[str, Any]],
-    importers_by_target: dict[str, list[str]],
-) -> list[dict[str, Any]]:
-    files_by_dir: dict[str, list[dict[str, Any]]] = defaultdict(list)
-    for module in modules:
-        path = str(module.get("path") or "")
-        if module.get("language") != "go" or not path.endswith(".go"):
-            continue
-        if is_test_fixture_path(path):
-            continue
-        directory = str(module.get("directory") or "")
-        files_by_dir[directory].append(module)
-
-    symbols_by_dir: dict[str, list[dict[str, Any]]] = defaultdict(list)
-    for symbol in symbols:
-        if symbol.get("language") != "go":
-            continue
-        path = str(symbol.get("path") or "")
-        if is_go_test_path(path):
-            continue
-        symbols_by_dir[Path(path).parent.as_posix() if Path(path).parent.as_posix() != "." else ""].append(symbol)
-
-    go_package_modules: list[dict[str, Any]] = []
-    for directory, package_files in sorted(files_by_dir.items()):
-        source_files = sorted(
-            str(item.get("path"))
-            for item in package_files
-            if str(item.get("path") or "").endswith(".go") and not is_go_test_path(str(item.get("path") or ""))
-        )
-        test_files = sorted(
-            str(item.get("path"))
-            for item in package_files
-            if is_go_test_path(str(item.get("path") or ""))
-        )
-        if not source_files and not test_files:
-            continue
-        package_counts = Counter(
-            str(item.get("package"))
-            for item in package_files
-            if isinstance(item.get("package"), str) and item.get("package")
-        )
-        package_name = ""
-        if package_counts:
-            package_name = sorted(package_counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
-        package_symbols = [
-            str(symbol.get("name"))
-            for symbol in symbols_by_dir.get(directory, [])
-            if symbol.get("exported") and isinstance(symbol.get("name"), str)
-        ]
-        tokens = set(tokens_for_path(directory or package_name or "."))
-        if package_name:
-            tokens.update(split_identifier(package_name))
-        for symbol_name in package_symbols:
-            tokens.update(split_identifier(symbol_name))
-        imported_by = sorted(set(importers_by_target.get(directory, [])))
-        boundary_hints = go_boundary_hints_for_path(directory)
-        module: dict[str, Any] = {
-            "path": directory or ".",
-            "name": package_name or Path(directory).name or ".",
-            "directory": Path(directory).parent.as_posix() if directory and Path(directory).parent.as_posix() != "." else "",
-            "language": "go",
-            "kind": "package",
-            "package": package_name or None,
-            "files": sorted(source_files + test_files),
-            "sourceFiles": source_files,
-            "testFiles": test_files,
-            "tokens": sorted(tokens),
-            "lineCount": sum(int(item.get("lineCount", 0)) for item in package_files),
-            "symbols": sorted(set(package_symbols)),
-            "exportedSymbolCount": len(set(package_symbols)),
-        }
-        if imported_by:
-            module["importedBy"] = imported_by
-            module["importCount"] = len(imported_by)
-        if test_files:
-            module["pairedTests"] = test_files
-        if boundary_hints:
-            module["boundaryHints"] = boundary_hints
-            module["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in boundary_hints)
-        if any(hint.get("kind") == "go-internal" for hint in boundary_hints):
-            module["internalBoundary"] = True
-        if any(hint.get("kind") == "go-cmd" for hint in boundary_hints):
-            module["entrypointBoundary"] = True
-        if any(hint.get("kind") == "go-pkg" for hint in boundary_hints):
-            module["weakReusablePackageConvention"] = True
-        if package_symbols and source_files:
-            module["publicAPICandidate"] = True
-        go_package_modules.append(module)
-    return go_package_modules
-
-
-def build_csharp_project_modules(
-    modules: list[dict[str, Any]],
-    symbols: list[dict[str, Any]],
-    tests: list[dict[str, Any]],
-    importers_by_target: dict[str, list[str]],
-    csharp_context: dict[str, Any],
-) -> list[dict[str, Any]]:
-    projects = csharp_context.get("projects")
-    if not isinstance(projects, list):
-        return []
-    modules_by_path = {str(module.get("path")): module for module in modules}
-    symbols_by_project: dict[str, list[dict[str, Any]]] = defaultdict(list)
-    files_by_project: dict[str, list[str]] = defaultdict(list)
-    tests_by_project: dict[str, list[str]] = defaultdict(list)
-
-    for module in modules:
-        if module.get("language") != "csharp" or Path(str(module.get("path") or "")).suffix != ".cs":
-            continue
-        path = str(module.get("path"))
-        project_path = str(module.get("projectPath") or "")
-        if not project_path:
-            project = csharp_project_for_path(path, csharp_context)
-            project_path = str(project.get("path") or "") if project else ""
-        if not project_path:
-            continue
-        files_by_project[project_path].append(path)
-        if module.get("kind") == "test" or module.get("testProject"):
-            tests_by_project[project_path].append(path)
-    for symbol in symbols:
-        if symbol.get("language") != "csharp":
-            continue
-        path = str(symbol.get("path") or "")
-        module = modules_by_path.get(path)
-        project_path = str(module.get("projectPath") or "") if module else ""
-        if not project_path:
-            project = csharp_project_for_path(path, csharp_context)
-            project_path = str(project.get("path") or "") if project else ""
-        if project_path:
-            symbols_by_project[project_path].append(symbol)
-
-    project_modules: list[dict[str, Any]] = []
-    for project in projects:
-        if not isinstance(project, dict):
-            continue
-        project_path = str(project.get("path") or "")
-        root = str(project.get("root") or ".")
-        source_files = sorted(files_by_project.get(project_path, []))
-        test_files = sorted(tests_by_project.get(project_path, []))
-        project_symbols = symbols_by_project.get(project_path, [])
-        public_symbols = sorted(
-            {
-                str(symbol.get("name"))
-                for symbol in project_symbols
-                if symbol.get("exported") and str(symbol.get("kind")) != "namespace" and isinstance(symbol.get("name"), str)
-            }
-        )
-        internal_symbols = sorted(
-            {
-                str(symbol.get("name"))
-                for symbol in project_symbols
-                if str(symbol.get("visibility") or "") == "internal" and isinstance(symbol.get("name"), str)
-            }
-        )
-        imported_by = sorted(set(importers_by_target.get(root, [])))
-        referenced_by = sorted(set(str(item) for item in project.get("referencedBy", []) if item))
-        paired_test_paths = sorted(
-            {
-                str(test.get("path"))
-                for test in tests
-                if isinstance(test.get("path"), str)
-                and (
-                    str(test.get("path")) in imported_by
-                    or set(tokens_for_path(str(test.get("path")))) & set(split_identifier(str(project.get("projectName") or "")))
-                    or set(tokens_for_path(str(test.get("path")))) & {token for symbol in public_symbols for token in split_identifier(symbol)}
-                )
-            }
-        )
-        tokens = set(tokens_for_path(root))
-        for value in (
-            str(project.get("projectName") or ""),
-            str(project.get("assemblyName") or ""),
-            str(project.get("rootNamespace") or ""),
-        ):
-            tokens.update(split_identifier(value))
-        for symbol_name in public_symbols:
-            tokens.update(split_identifier(symbol_name))
-        boundary_hints: list[dict[str, Any]] = [
-            {"kind": "dotnet-project", "value": "C# project/assembly boundary", "weak": False}
-        ]
-        if referenced_by:
-            boundary_hints.append({"kind": "dotnet-project-referenced", "value": "C# project referenced by local projects", "weak": False})
-        if project.get("isTestProject"):
-            boundary_hints.append({"kind": "dotnet-test-project", "value": "C# test project boundary", "weak": False})
-        if str(project.get("outputType") or "").lower() == "exe":
-            boundary_hints.append(
-                {
-                    "kind": "dotnet-executable-project",
-                    "value": "C# executable project boundary",
-                    "weak": False,
-                    "risk": "Executable C# project is not a generic helper module",
-                }
-            )
-        if public_symbols:
-            boundary_hints.append({"kind": "dotnet-public-api", "value": "C# public API candidate", "weak": False})
-        if internal_symbols:
-            boundary_hints.append(
-                {
-                    "kind": "dotnet-internal-api",
-                    "value": "C# internal API is assembly-local",
-                    "weak": False,
-                    "risk": "internal symbols are assembly-local and may not be reusable across projects",
-                }
-            )
-        module: dict[str, Any] = {
-            "path": root,
-            "name": str(project.get("projectName") or Path(root).name or "."),
-            "directory": Path(root).parent.as_posix() if root not in {"", "."} and Path(root).parent.as_posix() != "." else "",
-            "language": "csharp",
-            "kind": "project",
-            "projectPath": project_path,
-            "projectName": project.get("projectName"),
-            "assemblyName": project.get("assemblyName"),
-            "rootNamespace": project.get("rootNamespace"),
-            "targetFrameworks": project.get("targetFrameworks", []),
-            "files": source_files,
-            "sourceFiles": [path for path in source_files if path not in test_files],
-            "testFiles": test_files,
-            "tokens": sorted(tokens),
-            "lineCount": sum(int(modules_by_path.get(path, {}).get("lineCount", 0)) for path in source_files),
-            "symbols": public_symbols,
-            "exportedSymbolCount": len(public_symbols),
-            "internalSymbols": internal_symbols,
-            "boundaryHints": boundary_hints,
-            "boundaryKinds": sorted(str(hint.get("kind")) for hint in boundary_hints),
-        }
-        if project.get("packageReferences"):
-            module["packageReferences"] = project.get("packageReferences")
-        if project.get("projectReferences"):
-            module["projectReferenceTargets"] = project.get("projectReferences")
-        if referenced_by:
-            module["projectReferences"] = referenced_by
-            module["projectReferenceCount"] = len(referenced_by)
-        if imported_by:
-            module["importedBy"] = imported_by
-            module["importCount"] = len(imported_by)
-        if paired_test_paths:
-            module["pairedTests"] = paired_test_paths
-        if project.get("isTestProject"):
-            module["isTestProject"] = True
-        if str(project.get("outputType") or "").lower() == "exe":
-            module["executableBoundary"] = True
-        if public_symbols:
-            module["publicAPICandidate"] = True
-        if internal_symbols:
-            module["internalAssemblyLocal"] = True
-        project_modules.append(module)
-    return project_modules
-
-
 def collect_module_boundaries(modules: list[dict[str, Any]]) -> list[dict[str, Any]]:
     boundaries: list[dict[str, Any]] = []
     for module in modules:
@@ -2937,7 +884,7 @@ def build_index(
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
     indexed_files = [file for file in scan.files if file.indexed]
     known_files = {file.rel for file in indexed_files}
-    go_modules = collect_go_modules(indexed_files)
+    go_modules = go.collect_modules(indexed_files)
     go_package_dirs = {
         Path(file.rel).parent.as_posix() if Path(file.rel).parent.as_posix() != "." else ""
         for file in indexed_files
@@ -2954,8 +901,8 @@ def build_index(
         if manifest:
             manifest_by_path[scanned_file.rel] = manifest
     manifests: list[dict[str, Any]] = list(manifest_by_path.values())
-    rust_context = build_rust_context(manifests, known_files)
-    csharp_context = build_csharp_context(manifests, known_files)
+    rust_context = rust.build_context(manifests, known_files)
+    csharp_context = csharp.build_context(manifests, known_files)
     csharp_project_by_path = csharp_context.get("projectByPath")
     if isinstance(csharp_project_by_path, dict):
         for manifest in manifests:
@@ -2973,11 +920,11 @@ def build_index(
         if text:
             file_text[rel] = text
         kind = module_kind(rel)
-        csharp_project = csharp_project_for_path(rel, csharp_context) if language == "csharp" else None
+        csharp_project = csharp.project_for_path(rel, csharp_context) if language == "csharp" else None
         if language == "csharp" and Path(rel).suffix == ".cs" and csharp_project and csharp_project.get("isTestProject"):
             kind = "test"
-        package_name = extract_go_package_name(text) if language == "go" else None
-        boundary_hints = go_boundary_hints_for_path(rel) if language == "go" or is_test_fixture_path(rel) else []
+        package_name = go.extract_package_name(text) if language == "go" else None
+        boundary_hints = go.boundary_hints_for_path(rel) if language == "go" or is_test_fixture_path(rel) else []
         module = {
             "path": rel,
             "name": Path(rel).stem,
@@ -2995,9 +942,9 @@ def build_index(
             module["boundaryHints"] = boundary_hints
             module["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in boundary_hints)
         if language == "rust":
-            module.update(rust_module_fields(rel, text, rust_context))
+            module.update(rust.module_fields(rel, text, rust_context))
         if language == "csharp":
-            module.update(csharp_module_fields(rel, text, csharp_context, manifest_by_path.get(rel)))
+            module.update(csharp.module_fields(rel, text, csharp_context, manifest_by_path.get(rel)))
         if is_test_fixture_path(rel):
             module["testFixture"] = True
         modules.append(module)
@@ -3028,9 +975,10 @@ def build_index(
                 if key in import_record:
                     item[key] = import_record.get(key)
             imports.append(item)
-        rust_tests = rust_test_info(rel, text, language)
-        csharp_tests = csharp_test_info(rel, text, language, csharp_project)
-        if kind == "test" or rust_tests.get("hasTests") or csharp_tests.get("hasTests"):
+        go_tests = go.test_info(rel, text, language)
+        rust_tests = rust.test_info(rel, text, language)
+        csharp_tests = csharp.test_info(rel, text, language, csharp_project)
+        if kind == "test" or go_tests.get("hasTests") or rust_tests.get("hasTests") or csharp_tests.get("hasTests"):
             test_entry = {
                 "path": rel,
                 "language": language,
@@ -3041,9 +989,8 @@ def build_index(
                 if package_name:
                     test_entry["package"] = package_name
                     test_entry["targetPackage"] = package_name[: -len("_test")] if package_name.endswith("_test") else package_name
-                test_functions = sorted(set(GO_TEST_FUNCTION_RE.findall(text)))
-                if test_functions:
-                    test_entry["testFunctions"] = test_functions
+                if go_tests.get("testFunctions"):
+                    test_entry["testFunctions"] = go_tests["testFunctions"]
             if rust_tests.get("testFunctions"):
                 test_entry["testFunctions"] = rust_tests["testFunctions"]
             if rust_tests.get("hasCfgTest"):
@@ -3072,80 +1019,15 @@ def build_index(
         if paired_tests and (path not in tests_by_path or tests_by_path.get(path, {}).get("inlineCfgTest")):
             module["pairedTests"] = paired_tests
 
-    modules.extend(build_go_package_modules(modules, symbols, tests, importers_by_target))
-    modules.extend(build_csharp_project_modules(modules, symbols, tests, importers_by_target, csharp_context))
+    modules.extend(go.build_package_modules(modules, symbols, tests, importers_by_target))
+    modules.extend(csharp.build_project_modules(modules, symbols, tests, importers_by_target, csharp_context))
 
     symbols_by_path: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for symbol in symbols:
         symbols_by_path[str(symbol.get("path"))].append(symbol)
 
-    for module in modules:
-        if module.get("language") != "rust":
-            continue
-        path = str(module.get("path") or "")
-        if not path:
-            continue
-        hints = list(module.get("boundaryHints", []))
-        exported = sorted(
-            str(symbol.get("name"))
-            for symbol in symbols_by_path.get(path, [])
-            if symbol.get("exported") and isinstance(symbol.get("name"), str)
-        )
-        if exported:
-            hints.append({"kind": "rust-public-api", "value": "Rust public API candidate", "weak": False})
-        crate_local = sorted(
-            str(symbol.get("name"))
-            for symbol in symbols_by_path.get(path, [])
-            if str(symbol.get("visibility") or "").startswith("pub(") and isinstance(symbol.get("name"), str)
-        )
-        if crate_local:
-            hints.append(
-                {
-                    "kind": "rust-crate-local-visibility",
-                    "value": "Rust crate-local visibility",
-                    "weak": False,
-                    "risk": "pub(crate)/pub(super) visibility may not be reusable outside the crate",
-                }
-            )
-            module["crateLocalSymbols"] = crate_local
-        if hints:
-            module["boundaryHints"] = hints
-            module["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in hints if isinstance(hint, dict))
-
-    for module in modules:
-        if module.get("language") != "csharp":
-            continue
-        path = str(module.get("path") or "")
-        if not path:
-            continue
-        hints = list(module.get("boundaryHints", []))
-        exported = sorted(
-            str(symbol.get("name"))
-            for symbol in symbols_by_path.get(path, [])
-            if symbol.get("exported") and isinstance(symbol.get("name"), str)
-        )
-        internal = sorted(
-            str(symbol.get("name"))
-            for symbol in symbols_by_path.get(path, [])
-            if str(symbol.get("visibility") or "") == "internal" and isinstance(symbol.get("name"), str)
-        )
-        if exported:
-            hints.append({"kind": "dotnet-public-api", "value": "C# public API candidate", "weak": False})
-            module["publicAPICandidate"] = True
-        if internal:
-            hints.append(
-                {
-                    "kind": "dotnet-internal-api",
-                    "value": "C# internal API is assembly-local",
-                    "weak": False,
-                    "risk": "internal symbols are assembly-local and may not be reusable across projects",
-                }
-            )
-            module["internalSymbols"] = internal
-            module["internalAssemblyLocal"] = True
-        if hints:
-            module["boundaryHints"] = hints
-            module["boundaryKinds"] = sorted(str(hint.get("kind")) for hint in hints if isinstance(hint, dict))
+    rust.update_module_boundaries(modules, symbols_by_path)
+    csharp.update_module_boundaries(modules, symbols_by_path)
 
     shared_candidates: list[dict[str, Any]] = []
     for module in modules:

--- a/tests/test-codebase-adapter-layout.sh
+++ b/tests/test-codebase-adapter-layout.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+ADAPTER_DIR="$ROOT_DIR/scripts/codebase_awareness/adapters"
+BUILD_INDEX="$ROOT_DIR/scripts/codebase_awareness/build_index.py"
+
+passed=0
+failed=0
+
+pass() {
+  printf '  PASS: %s\n' "$1"
+  passed=$((passed + 1))
+}
+
+fail() {
+  printf '  FAIL: %s -- %s\n' "$1" "$2"
+  failed=$((failed + 1))
+}
+
+assert_file() {
+  local name="$1" path="$2"
+  if [ -f "$path" ]; then
+    pass "$name"
+  else
+    fail "$name" "missing $path"
+  fi
+}
+
+echo "=== Adapter module layout ==="
+assert_file "adapter package exists" "$ADAPTER_DIR/__init__.py"
+assert_file "common adapter helpers exist" "$ADAPTER_DIR/common.py"
+assert_file "Go adapter exists" "$ADAPTER_DIR/go.py"
+assert_file "Rust adapter exists" "$ADAPTER_DIR/rust.py"
+assert_file "C# adapter exists" "$ADAPTER_DIR/csharp.py"
+
+if rg -q 'from scripts\.codebase_awareness\.adapters import csharp, go, rust' "$BUILD_INDEX"; then
+  pass "build_index imports language adapters"
+else
+  fail "build_index imports language adapters" "adapter import missing"
+fi
+
+if python3 - "$ADAPTER_DIR" <<'PY'
+import ast
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+allowed_roots = {
+    "__future__",
+    "collections",
+    "pathlib",
+    "re",
+    "scripts",
+    "tomllib",
+    "typing",
+    "xml",
+}
+errors = []
+for path in sorted(root.glob("*.py")):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root_name = alias.name.split(".", 1)[0]
+                if root_name not in allowed_roots:
+                    errors.append(f"{path.name}: import {alias.name}")
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            root_name = module.split(".", 1)[0]
+            if root_name and root_name not in allowed_roots:
+                errors.append(f"{path.name}: from {module} import ...")
+if errors:
+    print("\n".join(errors))
+    raise SystemExit(1)
+PY
+then
+  pass "adapters use only stdlib and local scanner helpers"
+else
+  fail "adapters use only stdlib and local scanner helpers" "unexpected import found"
+fi
+
+if rg -n 'subprocess|os\.system|os\.popen|Popen|check_call|check_output|execv|spawn' "$ADAPTER_DIR"; then
+  fail "adapters do not invoke external commands" "process execution API found"
+else
+  pass "adapters do not invoke external commands"
+fi
+
+if rg -n 'go list|cargo metadata|msbuild|nuget|roslyn' "$ADAPTER_DIR"; then
+  fail "adapters avoid banned external tooling strings" "banned tooling string found"
+else
+  pass "adapters avoid banned external tooling strings"
+fi
+
+echo ""
+echo "=== Existing language coverage hooks ==="
+for test_file in \
+  "$ROOT_DIR/tests/test-codebase-go-adapter.sh" \
+  "$ROOT_DIR/tests/test-codebase-rust-adapter.sh" \
+  "$ROOT_DIR/tests/test-codebase-csharp-adapter.sh"
+do
+  if rg -q 'sharedCandidates|moduleBoundaries|symbols|imports|tests' "$test_file" && rg -q 'SCANNER=' "$test_file"; then
+    pass "$(basename "$test_file") exercises scanner output"
+  else
+    fail "$(basename "$test_file") exercises scanner output" "expected output assertions missing"
+  fi
+done
+
+echo ""
+echo "=== Scanner compile ==="
+if python3 -m compileall -q "$ROOT_DIR/scripts/codebase_awareness" "$ROOT_DIR/scripts/build_codebase_index.py"; then
+  pass "scanner and adapters compile"
+else
+  fail "scanner and adapters compile" "compileall failed"
+fi
+
+echo ""
+printf 'Passed: %s\n' "$passed"
+printf 'Failed: %s\n' "$failed"
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi
+
+echo "ok: codebase awareness adapter module layout is stdlib-only and wired into build_index"

--- a/tests/test-codebase-adapter-layout.sh
+++ b/tests/test-codebase-adapter-layout.sh
@@ -34,7 +34,7 @@ assert_file "Go adapter exists" "$ADAPTER_DIR/go.py"
 assert_file "Rust adapter exists" "$ADAPTER_DIR/rust.py"
 assert_file "C# adapter exists" "$ADAPTER_DIR/csharp.py"
 
-if rg -q 'from scripts\.codebase_awareness\.adapters import csharp, go, rust' "$BUILD_INDEX"; then
+if grep -Eq 'from scripts\.codebase_awareness\.adapters import csharp, go, rust' "$BUILD_INDEX"; then
   pass "build_index imports language adapters"
 else
   fail "build_index imports language adapters" "adapter import missing"
@@ -80,16 +80,48 @@ else
   fail "adapters use only stdlib and local scanner helpers" "unexpected import found"
 fi
 
-if rg -n 'subprocess|os\.system|os\.popen|Popen|check_call|check_output|execv|spawn' "$ADAPTER_DIR"; then
-  fail "adapters do not invoke external commands" "process execution API found"
-else
+if python3 - "$ADAPTER_DIR" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+pattern = re.compile(r"subprocess|os\.system|os\.popen|Popen|check_call|check_output|execv|spawn")
+errors = []
+for path in sorted(root.glob("*.py")):
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if pattern.search(line):
+            errors.append(f"{path.name}:{line_number}: {line.strip()}")
+if errors:
+    print("\n".join(errors))
+    raise SystemExit(1)
+PY
+then
   pass "adapters do not invoke external commands"
+else
+  fail "adapters do not invoke external commands" "process execution API found"
 fi
 
-if rg -n 'go list|cargo metadata|msbuild|nuget|roslyn' "$ADAPTER_DIR"; then
-  fail "adapters avoid banned external tooling strings" "banned tooling string found"
-else
+if python3 - "$ADAPTER_DIR" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+pattern = re.compile(r"go list|cargo metadata|msbuild|nuget|roslyn")
+errors = []
+for path in sorted(root.glob("*.py")):
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if pattern.search(line):
+            errors.append(f"{path.name}:{line_number}: {line.strip()}")
+if errors:
+    print("\n".join(errors))
+    raise SystemExit(1)
+PY
+then
   pass "adapters avoid banned external tooling strings"
+else
+  fail "adapters avoid banned external tooling strings" "banned tooling string found"
 fi
 
 echo ""
@@ -99,7 +131,7 @@ for test_file in \
   "$ROOT_DIR/tests/test-codebase-rust-adapter.sh" \
   "$ROOT_DIR/tests/test-codebase-csharp-adapter.sh"
 do
-  if rg -q 'sharedCandidates|moduleBoundaries|symbols|imports|tests' "$test_file" && rg -q 'SCANNER=' "$test_file"; then
+  if grep -Eq 'sharedCandidates|moduleBoundaries|symbols|imports|tests' "$test_file" && grep -Eq 'SCANNER=' "$test_file"; then
     pass "$(basename "$test_file") exercises scanner output"
   else
     fail "$(basename "$test_file") exercises scanner output" "expected output assertions missing"


### PR DESCRIPTION
## Summary
- Extracted Codebase Awareness scanner language-specific logic into stdlib-only adapter modules under `scripts/codebase_awareness/adapters/`.
- Kept `build_index.py` responsible for CLI parsing, walking, scan caps, digest cache handling, generic artifact assembly, and final JSON writing.
- Added a layout/parity guard test for adapter module presence, imports, compileability, and banned external tooling strings.

## Files extracted
- `scripts/codebase_awareness/adapters/common.py`: shared path/test/token helpers.
- `scripts/codebase_awareness/adapters/go.py`: Go manifests, package/symbol/import/test extraction, boundary hints, and package module construction.
- `scripts/codebase_awareness/adapters/rust.py`: Cargo manifests, visibility/symbol/use/mod/test extraction, workspace context, boundary hints, and Rust module fields.
- `scripts/codebase_awareness/adapters/csharp.py`: solution/project parsing, visibility/symbol/using/test extraction, project context, boundary hints, and C# project module construction.

## Behavior preservation
- Scanner artifact schemas did not change.
- Matcher scoring and reuse candidate ranking did not change.
- `reuse_decision.json` and `duplicate_scan.json` behavior did not change.
- Verdict mapping and PACK/proofpack behavior did not change.
- No Tree-sitter, Roslyn, Cargo/dotnet/go command execution, embeddings, semantic search, network calls, or user-code auto-refactoring were added.

## Validation
- `git diff --check`
- `git status --short`
- `git ls-files --others --exclude-standard`
- `python3 -m compileall -q scripts/codebase_awareness scripts/build_codebase_index.py scripts/build_reuse_candidates.py scripts/validate_reuse_decision.py scripts/audit_codebase_reuse.py scripts/evaluate_codebase_awareness_audit.py scripts/build_reuse_summary.py`
- `bash tests/test-codebase-index.sh`
- `bash tests/test-codebase-digests-cache.sh`
- `bash tests/test-codebase-adapter-layout.sh`
- `bash tests/test-codebase-go-adapter.sh`
- `bash tests/test-codebase-rust-adapter.sh`
- `bash tests/test-codebase-csharp-adapter.sh`
- `bash tests/test-reuse-candidates.sh`
- `bash tests/test-reuse-decision-validator.sh`
- `bash tests/test-codebase-reuse-audit.sh`
- `bash tests/test-codebase-reuse-summary.sh`
- `bash tests/test-codebase-awareness-execute-wiring.sh`
- `bash tests/test-codebase-awareness-audit-wiring.sh`
- `bash tests/test-codebase-awareness-verdict-mapping.sh`
- `bash tests/test-codebase-awareness-pack-wiring.sh`
- `CDPATH= bash tests/test-artifact-path-inventory.sh`
- `bash tests/test-helper-output-paths.sh`
- `CDPATH= bash tests/test-signum-command-renderer.sh`
- `CDPATH= bash tests/test-signum-fragment-parity.sh`
- `CDPATH= bash tests/test-claude-overlay-runtime-parity.sh`
- `CDPATH= bash tests/test-claude-overlay-doc-mirror.sh`
- `CDPATH= bash tests/test-claude-overlay-pack-parity.sh`
- `CDPATH= bash tests/test-signum-command-structure.sh`
- `CDPATH= bash tests/test-codex-skill-canonical-paths.sh`
- `CDPATH= bash tests/test-codex-plugin-metadata.sh`
- `bash scripts/run-deterministic-tests.sh`
