### PR TITLE
[codex] Tighten shell and Go adapter boundary detection

### DIFF
--- a/scripts/codebase_awareness/adapters/go.py
+++ b/scripts/codebase_awareness/adapters/go.py
@@ -340,8 +340,9 @@ def test_info(rel: str, text: str, language: str | None) -> dict[str, Any]:
 def boundary_hints_for_path(rel: str) -> list[dict[str, Any]]:
     path = Path(rel)
     parts = path.parts
+    part_set = set(parts)
     hints: list[dict[str, Any]] = []
-    if "internal" in parts:
+    if "internal" in part_set:
         index = parts.index("internal")
         allowed_root = "/".join(parts[:index]) or "."
         hints.append(
@@ -352,7 +353,7 @@ def boundary_hints_for_path(rel: str) -> list[dict[str, Any]]:
                 "weak": False,
             }
         )
-    if parts and parts[0] == "cmd":
+    if "cmd" in part_set:
         hints.append(
             {
                 "kind": "go-cmd",
@@ -360,7 +361,7 @@ def boundary_hints_for_path(rel: str) -> list[dict[str, Any]]:
                 "weak": False,
             }
         )
-    if parts and parts[0] == "pkg":
+    if "pkg" in part_set:
         hints.append(
             {
                 "kind": "go-pkg",

--- a/scripts/codebase_awareness/adapters/shell.py
+++ b/scripts/codebase_awareness/adapters/shell.py
@@ -18,7 +18,7 @@ SHELL_NAMES = {"bash", "sh", "zsh"}
 SHARED_DIR_HINTS = {"common", "lib", "shared", "utils"}
 
 SHELL_SHEBANG_RE = re.compile(
-    r"^#!\s*(?:/usr/bin/env\s+(?:bash|sh)|/bin/(?:bash|sh))(?:\s|$)"
+    r"^#!\s*(?:/usr/bin/env\s+(?:bash|sh|zsh)|/bin/(?:bash|sh|zsh))(?:\s|$)"
 )
 FUNCTION_PATTERNS = (
     re.compile(r"^\s*(?:function\s+)?([A-Za-z_][A-Za-z0-9_-]*)\s*\(\s*\)\s*(?:\{|$)"),

--- a/tests/fixtures/codebase-awareness/go-basic/services/api/cmd/server/main.go
+++ b/tests/fixtures/codebase-awareness/go-basic/services/api/cmd/server/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("ok")
+}

--- a/tests/fixtures/codebase-awareness/go-basic/services/api/pkg/validation/token.go
+++ b/tests/fixtures/codebase-awareness/go-basic/services/api/pkg/validation/token.go
@@ -1,0 +1,5 @@
+package validation
+
+func ValidateToken(value string) bool {
+	return value != ""
+}

--- a/tests/fixtures/codebase-awareness/golden/go-basic-summary.json
+++ b/tests/fixtures/codebase-awareness/golden/go-basic-summary.json
@@ -23,7 +23,8 @@
   "sharedCandidatePaths": [
     "internal/auth",
     "internal/users",
-    "pkg/validation"
+    "pkg/validation",
+    "services/api/pkg/validation"
   ],
   "symbolNames": [
     "BenchmarkValidateToken",

--- a/tests/fixtures/codebase-awareness/shell-basic/scripts/zsh-entry
+++ b/tests/fixtures/codebase-awareness/shell-basic/scripts/zsh-entry
@@ -1,0 +1,8 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+main() {
+  print "ok"
+}
+
+main "$@"

--- a/tests/test-codebase-go-adapter.sh
+++ b/tests/test-codebase-go-adapter.sh
@@ -127,11 +127,14 @@ if not go_work or go_work.get("workspaceUses") != ["./libs/shared", "./services/
     errors.append("go.work workspaceUses missing")
 
 validate = symbol("ValidateToken", "function", "internal/auth/token.go")
+nested_validate = symbol("ValidateToken", "function", "services/api/pkg/validation/token.go")
 parse = symbol("parseToken", "function", "internal/auth/token.go")
 method = symbol("ValidateToken", "method", "internal/auth/token.go")
 save = symbol("Save", "method", "internal/auth/token.go")
 if not validate or validate.get("exported") is not True or validate.get("receiver") is not None:
     errors.append("ValidateToken function extraction/export failed")
+if not nested_validate or nested_validate.get("exported") is not True:
+    errors.append("nested services/api/pkg ValidateToken function extraction/export failed")
 if not parse or parse.get("exported") is not False:
     errors.append("parseToken unexported extraction failed")
 if not method or method.get("receiver") != "Service" or method.get("exported") is not True:
@@ -180,12 +183,18 @@ modules = index.get("modules", [])
 pkg_module = next((item for item in modules if item.get("path") == "pkg/validation" and item.get("kind") == "package"), None)
 internal_module = next((item for item in modules if item.get("path") == "internal/auth" and item.get("kind") == "package"), None)
 cmd_module = next((item for item in modules if item.get("path") == "cmd/api" and item.get("kind") == "package"), None)
+nested_cmd_module = next((item for item in modules if item.get("path") == "services/api/cmd/server" and item.get("kind") == "package"), None)
+nested_pkg_module = next((item for item in modules if item.get("path") == "services/api/pkg/validation" and item.get("kind") == "package"), None)
 if not pkg_module or pkg_module.get("weakReusablePackageConvention") is not True:
     errors.append("pkg/ weak package boundary missing")
 if not internal_module or internal_module.get("internalBoundary") is not True:
     errors.append("internal/ boundary missing")
 if not cmd_module or cmd_module.get("entrypointBoundary") is not True:
     errors.append("cmd/ boundary missing")
+if not nested_cmd_module or nested_cmd_module.get("entrypointBoundary") is not True:
+    errors.append("nested cmd/ boundary missing")
+if not nested_pkg_module or nested_pkg_module.get("weakReusablePackageConvention") is not True:
+    errors.append("nested pkg/ weak package boundary missing")
 
 boundaries = index.get("moduleBoundaries", [])
 if not any(item.get("path") == "internal/auth" and item.get("kind") == "go-internal" for item in boundaries):
@@ -194,6 +203,10 @@ if not any(item.get("path") == "cmd/api" and item.get("kind") == "go-cmd" for it
     errors.append("go-cmd module boundary missing")
 if not any(item.get("path") == "pkg/validation" and item.get("kind") == "go-pkg" and item.get("weak") is True for item in boundaries):
     errors.append("go-pkg weak module boundary missing")
+if not any(item.get("path") == "services/api/cmd/server" and item.get("kind") == "go-cmd" for item in boundaries):
+    errors.append("nested go-cmd module boundary missing")
+if not any(item.get("path") == "services/api/pkg/validation" and item.get("kind") == "go-pkg" and item.get("weak") is True for item in boundaries):
+    errors.append("nested go-pkg weak module boundary missing")
 if "pkg/validation/testdata/valid.txt" not in index.get("conventions", {}).get("goTestdataPaths", []):
     errors.append("testdata convention missing")
 
@@ -214,6 +227,18 @@ else:
 internal_candidate = next((item for item in shared if item.get("path") == "internal/auth"), None)
 if not internal_candidate or internal_candidate.get("internalBoundary") is not True:
     errors.append("internal/auth candidate is not boundary-aware")
+nested_cmd_candidate = next((item for item in shared if item.get("path") == "services/api/cmd/server"), None)
+if nested_cmd_candidate:
+    errors.append("nested cmd entrypoint became shared candidate from path alone")
+nested_pkg_candidate = next((item for item in shared if item.get("path") == "services/api/pkg/validation"), None)
+if nested_pkg_candidate:
+    nested_pkg_reasons = set(nested_pkg_candidate.get("reasons", []))
+    if nested_pkg_reasons <= {"go-pkg-weak-convention"}:
+        errors.append("nested pkg candidate relies only on weak pkg convention")
+    if "exported-symbols" not in nested_pkg_reasons:
+        errors.append("nested pkg candidate lacks stronger exported-symbol evidence")
+    if not any(hint.get("kind") == "go-pkg" and hint.get("weak") is True for hint in nested_pkg_candidate.get("boundaryHints", [])):
+        errors.append("nested pkg candidate lost weak go-pkg boundary evidence")
 
 style_tests = style.get("testConventions", [])
 if not any(item.get("language") == "go" and item.get("value") == "*_test.go" for item in style_tests):
@@ -225,7 +250,7 @@ if not any(item.get("value") == "package-local tests" for item in style_go):
     errors.append("Go package-local test convention missing")
 
 digest_files = digests.get("files", {})
-for rel in ("go.mod", "cmd/api/main.go", "internal/auth/token.go", "internal/auth/token_test.go", "pkg/validation/email.go"):
+for rel in ("go.mod", "cmd/api/main.go", "internal/auth/token.go", "internal/auth/token_test.go", "pkg/validation/email.go", "services/api/cmd/server/main.go", "services/api/pkg/validation/token.go"):
     record = digest_files.get(rel)
     if not record or record.get("indexed") is not True:
         errors.append(f"missing indexed digest for {rel}")

--- a/tests/test-codebase-shell-adapter.sh
+++ b/tests/test-codebase-shell-adapter.sh
@@ -166,11 +166,14 @@ detected = {item.get("language"): item.get("fileCount") for item in records("lan
 require(detected.get("shell", 0) >= 7, "Shell language detection missing or too small")
 require(index.get("primaryLanguages") == ["shell"], "Shell primary language missing")
 require(find("modules", path="scripts/policy-entry", language="shell") is not None, "extensionless /bin/sh shebang script not detected")
+require(find("modules", path="scripts/zsh-entry", language="shell") is not None, "extensionless /usr/bin/env zsh shebang script not detected")
 
 json_payload = extract_payload("lib/json-output.sh")
 policy_payload = extract_payload("lib/policy-check.sh")
 test_payload = extract_payload("tests/test-policy-check.sh")
+zsh_payload = extract_payload("scripts/zsh-entry")
 require(json_payload.get("fileTextSignals", {}).get("shellShebang") is True, "shell shebang signal missing")
+require(zsh_payload.get("fileTextSignals", {}).get("shellShebang") is True, "zsh shebang signal missing")
 require(json_payload.get("fileTextSignals", {}).get("shellStrictMode") is True, "set -euo pipefail signal missing")
 
 expected_symbols = {
@@ -238,7 +241,9 @@ require(boundary("commands/signum.fragments/90-phase-audit.md", "shell-command-f
 require(find("sharedCandidates", path="commands/signum.fragments/90-phase-audit.md") is None, "command fragment became shared helper candidate")
 require(boundary("scripts/run-policy-check.sh", "shell-executable-script"), "shell executable script boundary missing")
 require(boundary("scripts/policy-entry", "shell-executable-script"), "extensionless executable script boundary missing")
+require(boundary("scripts/zsh-entry", "shell-executable-script"), "extensionless zsh executable script boundary missing")
 require(find("sharedCandidates", path="scripts/run-policy-check.sh") is None, "executable wrapper became shared helper candidate")
+require(find("sharedCandidates", path="scripts/zsh-entry") is None, "extensionless zsh executable script became shared helper candidate")
 require(boundary("scripts/run-policy-check.sh", "shell-tempdir-trap-cleanup"), "tempdir/trap cleanup boundary missing")
 require(boundary("tests/test-policy-check.sh", "shell-test-file"), "shell test boundary missing")
 
@@ -246,6 +251,7 @@ for cache, label in ((digests, "digests"), (extracts, "extracts")):
     files = cache.get("files", {})
     require("lib/json-output.sh" in files, f"{label} missing shell helper")
     require("scripts/policy-entry" in files, f"{label} missing shebang extensionless shell script")
+    require("scripts/zsh-entry" in files, f"{label} missing zsh shebang extensionless shell script")
     require("tests/test-policy-check.sh" in files, f"{label} missing shell test")
 require(any(item.get("name") == "emit_json_report" for item in json_payload.get("symbols", [])), "extract cache missing shell symbols")
 require(any(item.get("imported") == "$ROOT_DIR/lib/json-output.sh" for item in policy_payload.get("imports", [])), "extract cache missing shell source imports")
@@ -386,7 +392,7 @@ for candidate in json_helpers[:2]:
     require("imported" in why or "sourced" in why, "JSON helper candidate lacks fan-in whyRelevant evidence")
     require("paired test" in why or "multiple reuse signals" in why, "JSON helper candidate lacks paired-test/multi-signal evidence")
 
-weak_paths = {"lib/utils.sh", "commands/signum.fragments/90-phase-audit.md", "scripts/run-policy-check.sh", "scripts/policy-entry"}
+weak_paths = {"lib/utils.sh", "commands/signum.fragments/90-phase-audit.md", "scripts/run-policy-check.sh", "scripts/policy-entry", "scripts/zsh-entry"}
 require(not any(candidate.get("path") in weak_paths and candidate.get("kind") in {"existing-helper", "shared-module"} for candidate in candidates), "weak/orchestrator/executable path surfaced as reusable shell helper")
 test_candidates = [candidate for candidate in candidates if candidate.get("path") == "tests/test-policy-check.sh"]
 for candidate in test_candidates:


### PR DESCRIPTION
## Summary
- Fixes shell adapter precision so extensionless zsh shebang scripts are recognized lexically as shell.
- Fixes Go adapter boundary precision so `cmd` and `pkg` path segments are detected in nested Go layouts.
- Adds focused shell and Go fixtures plus regression assertions.

## Shell zsh shebang support
- `SHELL_SHEBANG_RE` now recognizes `#!/usr/bin/env zsh` and `#!/bin/zsh` while preserving existing bash/sh shebang support.
- Added `tests/fixtures/codebase-awareness/shell-basic/scripts/zsh-entry` as static fixture content.
- Regression coverage asserts shell indexing, digest/extract presence, executable boundary evidence, and non-promotion to shared helper candidate.

## Go nested cmd/pkg boundary support
- Go boundary detection now checks path segment membership for `internal`, `cmd`, and `pkg`.
- Added nested fixtures under `services/api/cmd/server/main.go` and `services/api/pkg/validation/token.go`.
- Regression coverage asserts nested `go-cmd`, weak nested `go-pkg`, and candidate behavior that does not rely on path names alone.

## Explicit non-goals
- No scanner architecture changes.
- No artifact schema changes.
- No file-extract cache semantic changes.
- No matcher scoring or reuse candidate ranking changes.
- No reuse decision validation changes.
- No duplicate scan schema or duplicate audit logic changes.
- No verdict mapping or PACK/proofpack behavior changes.
- No new adapters, external tooling, or implementation network calls.

## Validation commands
- `git diff --check`
- `git status --short`
- `git ls-files --others --exclude-standard`
- `python3 -m compileall -q scripts/codebase_awareness scripts/build_codebase_index.py scripts/build_reuse_candidates.py scripts/validate_reuse_decision.py scripts/audit_codebase_reuse.py scripts/evaluate_codebase_awareness_audit.py scripts/build_reuse_summary.py`
- `bash tests/test-codebase-shell-adapter.sh`
- `bash tests/test-codebase-go-adapter.sh`
- `bash tests/test-codebase-extracts-adapter-parity.sh`
- `bash tests/test-codebase-awareness-multilang-acceptance.sh`
- `bash tests/test-codebase-index.sh`
- `bash tests/test-codebase-digests-cache.sh`
- `bash tests/test-codebase-extracts-cache.sh`
- `bash tests/test-codebase-adapter-layout.sh`
- `bash tests/test-codebase-rust-adapter.sh`
- `bash tests/test-codebase-csharp-adapter.sh`
- `bash tests/test-codebase-typescript-adapter.sh`
- `bash tests/test-codebase-python-adapter.sh`
- `bash tests/test-reuse-candidates.sh`
- `bash tests/test-reuse-decision-validator.sh`
- `bash tests/test-engineer-reuse-decision-protocol.sh`
- `bash tests/test-codebase-awareness-execute-wiring.sh`
- `bash tests/test-codebase-reuse-audit.sh`
- `bash tests/test-codebase-reuse-summary.sh`
- `bash tests/test-codebase-awareness-audit-wiring.sh`
- `bash tests/test-codebase-awareness-verdict-mapping.sh`
- `bash tests/test-codebase-awareness-pack-wiring.sh`
- `CDPATH= bash tests/test-artifact-path-inventory.sh`
- `bash tests/test-helper-output-paths.sh`
- `CDPATH= bash tests/test-signum-command-renderer.sh`
- `CDPATH= bash tests/test-signum-fragment-parity.sh`
- `CDPATH= bash tests/test-claude-overlay-runtime-parity.sh`
- `CDPATH= bash tests/test-claude-overlay-doc-mirror.sh`
- `CDPATH= bash tests/test-claude-overlay-pack-parity.sh`
- `CDPATH= bash tests/test-signum-command-structure.sh`
- `CDPATH= bash tests/test-codex-skill-canonical-paths.sh`
- `CDPATH= bash tests/test-codex-plugin-metadata.sh`
- `bash scripts/run-deterministic-tests.sh`
