### PR TITLE
docs: fix P0 documentation drift

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,7 +38,7 @@ review_cadence: quarterly
 5. PACK assembles `proofpack.json` under the active contract artifact root.
 
 ### 2. Project-context bootstrap flow
-1. User runs `/signum init`.
+1. User runs `/signum:init`.
 2. `lib/init-scanner.sh` extracts deterministic repo signals.
 3. `agents/init-synthesizer.md` turns those signals into `project.intent.md` and `project.glossary.json`.
 4. Optional `--harness` mode adds deterministic repo-level docs through `lib/init-harness-scaffold.sh`.
@@ -49,7 +49,8 @@ review_cadence: quarterly
 3. `lib/doc-parity-check.sh` validates parity assumptions and emits warnings in CI.
 
 ## State and Data
-- `.signum/` is the runtime workspace for contracts, patches, mechanic reports, reviews, and proofpacks.
+- `.signum/contracts/<contractId>/` is the active contract artifact root for run/pipeline artifacts such as contracts, patches, mechanic reports, reviews, and proofpacks.
+- Root `.signum/` is the registry/state/archive/compatibility namespace, not the canonical per-run artifact root.
 - `project.intent.md` and `project.glossary.json` are project-level upstream context inputs that can affect contract generation.
 - `modules.yaml` is the repo’s lightweight module inventory and lifecycle manifest.
 - `docs/plans/*.md` and `docs/research/*.md` hold planning and research context, but are derived documentation, not runtime state.

--- a/SKILL.md
+++ b/SKILL.md
@@ -26,5 +26,6 @@ Run a CONTRACT → EXECUTE → AUDIT → PACK pipeline for any implementation ta
 - Do not start implementation before a contract exists
 - If the contract is vague, stop and improve it
 - Check against deterministic criteria, not just model opinion
-- Keep all artifacts in `.signum/`
+- Keep active run/pipeline artifacts under `.signum/contracts/<contractId>/`
+- Treat root `.signum/` as the registry/state/archive/compatibility namespace, not the canonical per-run artifact root
 - If reduced audit coverage on medium/high-risk task → HUMAN_REVIEW, not AUTO_OK

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -292,37 +292,52 @@ Iteration artifacts are stored under the active contract artifact root, for exam
 
 The proofpack includes an `iterativeAudit` section when >1 iteration was used, with per-iteration summaries, resolved/remaining findings, and the best iteration number.
 
-### proofpack.json fields (v4.6)
+### proofpack.json fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `schemaVersion` | `"4.6"` | Schema version (v4.6 adds iterativeAudit, ciContext, baselineComparison, contractSource) |
-| `signumVersion` | string | Signum version that generated this proofpack |
-| `createdAt` | string | ISO 8601 timestamp of proofpack creation |
-| `runId` | string | `signum-YYYY-MM-DD-XXXXXX` |
-| `decision` | `AUTO_OK\|AUTO_BLOCK\|HUMAN_REVIEW` | Final verdict |
-| `summary` | string | One-line human-readable summary |
-| `confidence` | object | `{ overall: 0-100 }` — weighted confidence score |
-| `auditChain` | object | `{ contractSha256, approvedAt, baseCommit }` — immutable audit anchors |
-| `contract` | envelope | Redacted contract (holdouts stripped), `fullSha256` for original |
-| `diff` | envelope | Patch content (omitted if >100KB) |
-| `baseline` | envelope | Pre-change lint/typecheck/test results |
-| `executeLog` | envelope | Attempt history and check results |
-| `checks.mechanic` | envelope | Lint, typecheck, test with regression flags |
-| `checks.holdout` | envelope | Holdout scenario pass/fail (if applicable) |
-| `checks.reviews.*` | envelope | Per-provider review (dynamic keys) |
-| `checks.auditSummary` | envelope | Synthesized decision with confidence |
-| `iterativeAudit` | object | Iteration metadata (v4.6+, present only when >1 iteration) |
-| `iterativeAudit.iterationsUsed` | integer | Total iterations run |
-| `iterativeAudit.bestIteration` | integer | Iteration with best score |
-| `iterativeAudit.auditIterations` | array | Per-iteration summaries (score, findings count, decision) |
-| `iterativeAudit.resolvedFindings` | array | Findings fixed during iterations |
-| `iterativeAudit.remainingFindings` | array | Findings still present after all iterations |
+Proofpack shape is defined by two current sources of truth:
 
-Each artifact uses the **envelope format**: `{ content, sha256, sizeBytes, status, omitReason? }`.
-- `status: present` — content embedded
-- `status: omitted` — content null, validate by sha256
-- `status: error` — generation failed, see omitReason
+- `lib/schemas/proofpack.schema.json` defines the documented JSON Schema surface.
+- `scripts/validate_proofpack.py` is the deterministic validator for the proofpack shape Signum currently emits.
+
+The runtime PACK phase writes the proofpack to the active contract artifact root as `.signum/contracts/<contractId>/proofpack.json`.
+
+| Field | Required by current validator | Type / allowed values | Description |
+|-------|-------------------------------|-----------------------|-------------|
+| `schemaVersion` | Yes | string; schema enum `"4.0"` through `"4.8"`; current runtime emits `"4.8"` | Proofpack schema version. The validator checks it against the runtime source of truth. |
+| `signumVersion` | Yes | string | Signum version that generated this proofpack. |
+| `createdAt` | Yes | string | Proofpack creation timestamp. |
+| `runId` | Yes | string starting with `signum-` | Runtime run identifier. |
+| `contractId` | Yes | string starting with `sig-` | Links the proofpack to its source contract and canonical artifact root. |
+| `decision` | Yes | `AUTO_OK\|AUTO_BLOCK\|HUMAN_REVIEW` | Final Signum decision. `checks.auditSummary.content.decision`, when embedded, must match this value. |
+| `releaseVerdict` | Yes | string | Release verdict copied from `audit_summary.json`; current PACK defaults to `HOLD` when absent. |
+| `riskLevel` | Yes | string | Contract risk level copied from `contract.json`; current PACK defaults to `low` when absent. |
+| `summary` | Yes | string | Human-readable run summary. |
+| `confidence` | Yes | object with numeric `overall` from 0 to 100 | Weighted confidence score. |
+| `timing` | Yes | object | Runtime timing metadata. If present, `startedAt` and `completedAt` must be strings and `durationMs` must be numeric. Current PACK emits all three. |
+| `reviewCoverage` | Yes | object | Review coverage metadata. If `availableReviews` is present, it must be an integer. Current PACK emits `availableReviews`. |
+| `contractSource` | Yes | `interactive\|file\|template` | How the contract was provided. |
+| `auditChain` | Yes | object | Audit anchors such as `contractSha256`, `approvedAt`, and `baseCommit`. |
+| `contract` | Yes | envelope with `fullSha256` | Redacted contract evidence. The validator requires `fullSha256` to be lowercase SHA-256 hex. |
+| `diff` | Yes | envelope | Patch evidence. |
+| `baseline` | Yes | envelope | Pre-change check evidence. |
+| `executeLog` | Yes | envelope | Execution attempt evidence. |
+| `approval` | Yes | envelope | Approval-gate evidence. |
+| `checks.mechanic` | Yes | envelope | Mechanic check evidence. |
+| `checks.holdout` | Yes | envelope | Holdout check evidence. |
+| `checks.policy_scan` | Yes | envelope | Deterministic policy-scan evidence from `policy_scan.json`. |
+| `checks.reviews` | Yes | object of provider-name to envelope | Per-provider review evidence. Provider names must be non-empty strings. |
+| `checks.auditSummary` | Yes | envelope | Synthesized audit summary evidence. |
+| `ciContext` | Optional | object; `provider` is `github-actions\|gitlab-ci\|circleci\|local` when present | CI metadata. `runUrl` is a URI; `prNumber` is an integer; `triggerEvent` is a string. |
+| `baselineComparison` | Optional | object | Previous-run comparison metadata. Numeric confidence fields are 0-100 where constrained by schema; finding counts are non-negative integers. |
+| `iterativeAudit` | Optional | object | Iteration metadata, present only when AUDIT used more than one iteration. |
+| `removalEvidence` | Optional | object | Removal and cleanup-obligation evidence. `removals[].id` must match `RM<number>`, paths must be safe relative paths, `removed` must be boolean, and optional `type` is `file` or `directory`. `obligations[].id` must match `CO<number>` and `fulfilled` must be boolean. |
+
+Each artifact envelope uses this format: `{ content, sha256, sizeBytes, status, omitReason? }`.
+- `status: present` — content embedded; `sha256` must be lowercase SHA-256 hex.
+- `status: omitted` — content is omitted, with checksum metadata retained when available.
+- `status: error` — generation failed, see `omitReason`.
+
+Any artifact references in proofpacks must be safe relative paths. When the validator can resolve the contract root, referenced artifacts must stay inside `.signum/contracts/<contractId>/` and exist there.
 
 ### Confidence scoring
 

--- a/platforms/claude-code/docs/reference.md
+++ b/platforms/claude-code/docs/reference.md
@@ -292,37 +292,52 @@ Iteration artifacts are stored under the active contract artifact root, for exam
 
 The proofpack includes an `iterativeAudit` section when >1 iteration was used, with per-iteration summaries, resolved/remaining findings, and the best iteration number.
 
-### proofpack.json fields (v4.6)
+### proofpack.json fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `schemaVersion` | `"4.6"` | Schema version (v4.6 adds iterativeAudit, ciContext, baselineComparison, contractSource) |
-| `signumVersion` | string | Signum version that generated this proofpack |
-| `createdAt` | string | ISO 8601 timestamp of proofpack creation |
-| `runId` | string | `signum-YYYY-MM-DD-XXXXXX` |
-| `decision` | `AUTO_OK\|AUTO_BLOCK\|HUMAN_REVIEW` | Final verdict |
-| `summary` | string | One-line human-readable summary |
-| `confidence` | object | `{ overall: 0-100 }` — weighted confidence score |
-| `auditChain` | object | `{ contractSha256, approvedAt, baseCommit }` — immutable audit anchors |
-| `contract` | envelope | Redacted contract (holdouts stripped), `fullSha256` for original |
-| `diff` | envelope | Patch content (omitted if >100KB) |
-| `baseline` | envelope | Pre-change lint/typecheck/test results |
-| `executeLog` | envelope | Attempt history and check results |
-| `checks.mechanic` | envelope | Lint, typecheck, test with regression flags |
-| `checks.holdout` | envelope | Holdout scenario pass/fail (if applicable) |
-| `checks.reviews.*` | envelope | Per-provider review (dynamic keys) |
-| `checks.auditSummary` | envelope | Synthesized decision with confidence |
-| `iterativeAudit` | object | Iteration metadata (v4.6+, present only when >1 iteration) |
-| `iterativeAudit.iterationsUsed` | integer | Total iterations run |
-| `iterativeAudit.bestIteration` | integer | Iteration with best score |
-| `iterativeAudit.auditIterations` | array | Per-iteration summaries (score, findings count, decision) |
-| `iterativeAudit.resolvedFindings` | array | Findings fixed during iterations |
-| `iterativeAudit.remainingFindings` | array | Findings still present after all iterations |
+Proofpack shape is defined by two current sources of truth:
 
-Each artifact uses the **envelope format**: `{ content, sha256, sizeBytes, status, omitReason? }`.
-- `status: present` — content embedded
-- `status: omitted` — content null, validate by sha256
-- `status: error` — generation failed, see omitReason
+- `lib/schemas/proofpack.schema.json` defines the documented JSON Schema surface.
+- `scripts/validate_proofpack.py` is the deterministic validator for the proofpack shape Signum currently emits.
+
+The runtime PACK phase writes the proofpack to the active contract artifact root as `.signum/contracts/<contractId>/proofpack.json`.
+
+| Field | Required by current validator | Type / allowed values | Description |
+|-------|-------------------------------|-----------------------|-------------|
+| `schemaVersion` | Yes | string; schema enum `"4.0"` through `"4.8"`; current runtime emits `"4.8"` | Proofpack schema version. The validator checks it against the runtime source of truth. |
+| `signumVersion` | Yes | string | Signum version that generated this proofpack. |
+| `createdAt` | Yes | string | Proofpack creation timestamp. |
+| `runId` | Yes | string starting with `signum-` | Runtime run identifier. |
+| `contractId` | Yes | string starting with `sig-` | Links the proofpack to its source contract and canonical artifact root. |
+| `decision` | Yes | `AUTO_OK\|AUTO_BLOCK\|HUMAN_REVIEW` | Final Signum decision. `checks.auditSummary.content.decision`, when embedded, must match this value. |
+| `releaseVerdict` | Yes | string | Release verdict copied from `audit_summary.json`; current PACK defaults to `HOLD` when absent. |
+| `riskLevel` | Yes | string | Contract risk level copied from `contract.json`; current PACK defaults to `low` when absent. |
+| `summary` | Yes | string | Human-readable run summary. |
+| `confidence` | Yes | object with numeric `overall` from 0 to 100 | Weighted confidence score. |
+| `timing` | Yes | object | Runtime timing metadata. If present, `startedAt` and `completedAt` must be strings and `durationMs` must be numeric. Current PACK emits all three. |
+| `reviewCoverage` | Yes | object | Review coverage metadata. If `availableReviews` is present, it must be an integer. Current PACK emits `availableReviews`. |
+| `contractSource` | Yes | `interactive\|file\|template` | How the contract was provided. |
+| `auditChain` | Yes | object | Audit anchors such as `contractSha256`, `approvedAt`, and `baseCommit`. |
+| `contract` | Yes | envelope with `fullSha256` | Redacted contract evidence. The validator requires `fullSha256` to be lowercase SHA-256 hex. |
+| `diff` | Yes | envelope | Patch evidence. |
+| `baseline` | Yes | envelope | Pre-change check evidence. |
+| `executeLog` | Yes | envelope | Execution attempt evidence. |
+| `approval` | Yes | envelope | Approval-gate evidence. |
+| `checks.mechanic` | Yes | envelope | Mechanic check evidence. |
+| `checks.holdout` | Yes | envelope | Holdout check evidence. |
+| `checks.policy_scan` | Yes | envelope | Deterministic policy-scan evidence from `policy_scan.json`. |
+| `checks.reviews` | Yes | object of provider-name to envelope | Per-provider review evidence. Provider names must be non-empty strings. |
+| `checks.auditSummary` | Yes | envelope | Synthesized audit summary evidence. |
+| `ciContext` | Optional | object; `provider` is `github-actions\|gitlab-ci\|circleci\|local` when present | CI metadata. `runUrl` is a URI; `prNumber` is an integer; `triggerEvent` is a string. |
+| `baselineComparison` | Optional | object | Previous-run comparison metadata. Numeric confidence fields are 0-100 where constrained by schema; finding counts are non-negative integers. |
+| `iterativeAudit` | Optional | object | Iteration metadata, present only when AUDIT used more than one iteration. |
+| `removalEvidence` | Optional | object | Removal and cleanup-obligation evidence. `removals[].id` must match `RM<number>`, paths must be safe relative paths, `removed` must be boolean, and optional `type` is `file` or `directory`. `obligations[].id` must match `CO<number>` and `fulfilled` must be boolean. |
+
+Each artifact envelope uses this format: `{ content, sha256, sizeBytes, status, omitReason? }`.
+- `status: present` — content embedded; `sha256` must be lowercase SHA-256 hex.
+- `status: omitted` — content is omitted, with checksum metadata retained when available.
+- `status: error` — generation failed, see `omitReason`.
+
+Any artifact references in proofpacks must be safe relative paths. When the validator can resolve the contract root, referenced artifacts must stay inside `.signum/contracts/<contractId>/` and exist there.
 
 ### Confidence scoring
 

--- a/tests/test-architecture-command-surface.sh
+++ b/tests/test-architecture-command-surface.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# test-architecture-command-surface.sh -- keep ARCHITECTURE.md init and artifact-root wording current
+set -euo pipefail
+
+export CDPATH=
+
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd "$SCRIPT_DIR/.." && pwd)"
+DOC="$REPO_ROOT/ARCHITECTURE.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Architecture command surface ==="
+
+assert_contains '/signum:init' "architecture uses canonical init command"
+assert_not_contains '/signum init' "architecture no longer uses spaced init command"
+assert_contains '.signum/contracts/<contractId>/' "architecture documents active contract artifact root"
+assert_contains 'registry/state/archive/compatibility namespace' "architecture classifies root signum namespace"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-reference-proofpack-fields.sh
+++ b/tests/test-reference-proofpack-fields.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# test-reference-proofpack-fields.sh -- keep docs/reference.md aligned with current proofpack schema/validator fields
+set -euo pipefail
+
+export CDPATH=
+
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd "$SCRIPT_DIR/.." && pwd)"
+DOC="$REPO_ROOT/docs/reference.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Reference proofpack fields ==="
+
+assert_contains 'lib/schemas/proofpack.schema.json' "reference names proofpack schema source"
+assert_contains 'scripts/validate_proofpack.py' "reference names proofpack validator source"
+assert_contains '.signum/contracts/<contractId>/proofpack.json' "reference documents current proofpack emission target"
+assert_not_contains 'proofpack.json fields (v4.6)' "old v4.6 proofpack heading removed"
+
+for field in \
+  'schemaVersion' \
+  'contractId' \
+  'decision' \
+  'releaseVerdict' \
+  'riskLevel' \
+  'timing' \
+  'reviewCoverage' \
+  'contractSource' \
+  'ciContext' \
+  'baselineComparison' \
+  'approval' \
+  'checks.policy_scan' \
+  'removalEvidence'
+do
+  assert_contains "\`$field\`" "reference documents $field"
+done
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-skill-artifact-root.sh
+++ b/tests/test-skill-artifact-root.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# test-skill-artifact-root.sh -- keep root SKILL.md aligned with canonical contract-root storage
+set -euo pipefail
+
+export CDPATH=
+
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd "$SCRIPT_DIR/.." && pwd)"
+DOC="$REPO_ROOT/SKILL.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local label="$2"
+  if grep -Fq -- "$needle" "$DOC"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$label" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$label"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Root skill artifact root ==="
+
+assert_contains '.signum/contracts/<contractId>/' "skill uses canonical active contract artifact root"
+assert_contains 'registry/state/archive/compatibility namespace' "skill classifies root signum namespace"
+assert_not_contains 'Keep all artifacts in .signum' "unquoted stale root artifact wording removed"
+assert_not_contains 'Keep all artifacts in `.signum/`' "quoted stale root artifact wording removed"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- Updated `docs/reference.md` proofpack field documentation to point at the current sources of truth: `lib/schemas/proofpack.schema.json` and `scripts/validate_proofpack.py`.
- Mirrored the reference doc update into `platforms/claude-code/docs/reference.md` to satisfy existing overlay mirror parity.
- Updated root `SKILL.md` and `ARCHITECTURE.md` to use `.signum/contracts/<contractId>/` as the active contract artifact root, with root `.signum/` described as registry/state/archive/compatibility namespace.
- Replaced the stale `/signum init` architecture syntax with `/signum:init`.
- Added targeted executable regression tests for the reference proofpack fields, root skill artifact-root wording, and architecture command/artifact wording.

## Tests
Passed:
- `bash tests/test-reference-proofpack-fields.sh`
- `bash tests/test-skill-artifact-root.sh`
- `bash tests/test-architecture-command-surface.sh`
- `CDPATH= bash tests/test-proofpack-validation.sh`
- `CDPATH= bash tests/test-doc-canonical-artifact-root.sh`
- `CDPATH= bash tests/test-architecture-canonical-artifact-root.sh`
- `CDPATH= bash tests/test-init-command-surface.sh`
- `CDPATH= bash tests/test-doc-parity.sh`
- `CDPATH= bash tests/test-artifact-path-inventory.sh`
- `CDPATH= bash tests/test-claude-overlay-doc-mirror.sh`
- `git diff --cached --check`

Attempted:
- `bash scripts/run-deterministic-tests.sh` failed in `tests/test-codebase-awareness-multilang-acceptance.sh` under local `Python 3.9.6` with `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` from an inline assertion using newer type-union syntax. This appears unrelated to the docs/test changes in this PR.

## Signum skill
- Available: yes.
- Instructions read: yes, from `/Users/limerc/.codex/skills/signum/SKILL.md`.
- Used: yes, as a reduced contract-first workflow for this bounded documentation/test drift fix.

## Assumptions and optional fields
- `ciContext`, `baselineComparison`, `iterativeAudit`, and `removalEvidence` are documented as optional because the schema/runtime only include or validate them when present.
- `releaseVerdict`, `riskLevel`, `timing`, `reviewCoverage`, `approval`, and `checks.policy_scan` are documented as required by the current validator/runtime emission path even where the JSON Schema required list is less strict.
- `timing.startedAt`, `timing.completedAt`, `timing.durationMs`, and `reviewCoverage.availableReviews` are described with their validator type rules; current PACK emits these values.