### PR TITLE
ci: harden documentation parity checks

### DIFF
--- a/.github/workflows/doc-parity.yml
+++ b/.github/workflows/doc-parity.yml
@@ -22,14 +22,18 @@ jobs:
 
       - name: Run doc parity check
         run: |
+          set +e
           bash lib/doc-parity-check.sh > doc-parity.json
+          STATUS=$?
+          set -e
+          echo "doc_parity_exit=$STATUS" >> "$GITHUB_ENV"
           cat doc-parity.json
 
       - name: Emit warnings
         run: |
           COUNT=$(jq '.findings | length' doc-parity.json)
           echo "doc_parity_findings=$COUNT" >> "$GITHUB_ENV"
-          jq -r '.findings[] | "::warning file=\(.file)::[\(.code)] \(.message) -- \(.details)"' doc-parity.json || true
+          jq -r '.findings[] | if .severity == "error" then "::error file=\(.file)::[\(.code)] \(.message) -- \(.details)" else "::warning file=\(.file)::[\(.code)] \(.message) -- \(.details)" end' doc-parity.json || true
 
       - name: Add summary
         run: |
@@ -42,6 +46,13 @@ jobs:
             echo "### Findings"
             jq -r '.findings[] | "- [\(.code)] \(.file): \(.message) — \(.details)"' doc-parity.json || echo "- none"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail on blocking doc parity drift
+        run: |
+          if [ "$doc_parity_exit" -ne 0 ] || [ "$(jq -r '.status' doc-parity.json)" = "error" ]; then
+            echo "Blocking doc parity drift detected."
+            exit 1
+          fi
 
       - name: Run doc parity unit tests
         run: bash tests/test-doc-parity.sh

--- a/lib/doc-parity-check.sh
+++ b/lib/doc-parity-check.sh
@@ -2,8 +2,8 @@
 # doc-parity-check.sh -- detect documentation drift against canonical Signum sources
 # Usage: doc-parity-check.sh [--repo-root <dir>]
 # Output: {"check":"doc_parity","status":"ok|warn|error","summary":"...","findings":[...]}
-# Exit 0: check completed (ok/warn)
-# Exit 1: infra error
+# Exit 0: check completed with no blocking drift (ok/warn)
+# Exit 1: infra error or blocking documentation drift
 
 set -euo pipefail
 
@@ -25,11 +25,13 @@ fi
 ROOT_DOC="$REPO_ROOT/commands/signum.md"
 OVERLAY_DOC="$REPO_ROOT/platforms/claude-code/commands/signum.md"
 REFERENCE_DOC="$REPO_ROOT/docs/reference.md"
+SKILL_DOC="$REPO_ROOT/SKILL.md"
+ARCHITECTURE_DOC="$REPO_ROOT/ARCHITECTURE.md"
 ROADMAP_DOC="$REPO_ROOT/docs/plans/2026-03-15-large-project-support-roadmap.md"
 SCHEMA_DOC="$REPO_ROOT/lib/schemas/contract.schema.json"
 OVERLAY_DEVIATIONS_DOC="$REPO_ROOT/docs/overlay-deviations.json"
 
-for required in "$ROOT_DOC" "$OVERLAY_DOC" "$REFERENCE_DOC" "$ROADMAP_DOC" "$SCHEMA_DOC" "$OVERLAY_DEVIATIONS_DOC"; do
+for required in "$ROOT_DOC" "$OVERLAY_DOC" "$REFERENCE_DOC" "$SKILL_DOC" "$ARCHITECTURE_DOC" "$ROADMAP_DOC" "$SCHEMA_DOC" "$OVERLAY_DEVIATIONS_DOC"; do
   if [ ! -f "$required" ]; then
     echo "{\"check\":\"doc_parity\",\"status\":\"error\",\"summary\":\"Required file not found: $required\",\"findings\":[]}" >&2
     exit 1
@@ -40,20 +42,155 @@ FINDINGS_FILE=$(mktemp "${TMPDIR:-/tmp}/signum-doc-parity.XXXXXX")
 trap 'rm -f "$FINDINGS_FILE"' EXIT
 
 add_finding() {
-  local code="$1" file="$2" message="$3" details="${4:-}"
+  local severity="$1" code="$2" file="$3" message="$4" details="${5:-}"
   jq -cn \
+    --arg severity "$severity" \
     --arg code "$code" \
     --arg file "$file" \
     --arg message "$message" \
     --arg details "$details" \
-    '{code:$code,severity:"warn",file:$file,message:$message,details:$details}' >> "$FINDINGS_FILE"
+    '{code:$code,severity:$severity,file:$file,message:$message,details:$details}' >> "$FINDINGS_FILE"
+}
+
+add_warning() {
+  add_finding "warn" "$@"
+}
+
+add_error() {
+  add_finding "error" "$@"
+}
+
+require_contains() {
+  local file="$1" display_file="$2" needle="$3" code="$4" message="$5" details="${6:-}"
+  if ! grep -Fq -- "$needle" "$file"; then
+    add_error "$code" "$display_file" "$message" "$details"
+  fi
+}
+
+require_not_contains() {
+  local file="$1" display_file="$2" needle="$3" code="$4" message="$5" details="${6:-}"
+  if grep -Fq -- "$needle" "$file"; then
+    add_error "$code" "$display_file" "$message" "$details"
+  fi
+}
+
+check_current_proofpack_reference() {
+  local field
+
+  require_contains \
+    "$REFERENCE_DOC" \
+    "docs/reference.md" \
+    "lib/schemas/proofpack.schema.json" \
+    "reference_proofpack_schema_missing" \
+    "Reference docs do not name the current proofpack schema source" \
+    "Expected docs/reference.md to reference lib/schemas/proofpack.schema.json"
+
+  require_contains \
+    "$REFERENCE_DOC" \
+    "docs/reference.md" \
+    "scripts/validate_proofpack.py" \
+    "reference_proofpack_validator_missing" \
+    "Reference docs do not name the current proofpack validator source" \
+    "Expected docs/reference.md to reference scripts/validate_proofpack.py"
+
+  require_contains \
+    "$REFERENCE_DOC" \
+    "docs/reference.md" \
+    ".signum/contracts/<contractId>/proofpack.json" \
+    "reference_proofpack_target_missing" \
+    "Reference docs do not document the active contract proofpack path" \
+    "Expected docs/reference.md to mention .signum/contracts/<contractId>/proofpack.json"
+
+  require_not_contains \
+    "$REFERENCE_DOC" \
+    "docs/reference.md" \
+    "proofpack.json fields (v4.6)" \
+    "reference_proofpack_v46_stale" \
+    "Reference docs still contain stale proofpack v4.6 wording" \
+    "Remove the stale heading/string 'proofpack.json fields (v4.6)'"
+
+  for field in \
+    "schemaVersion" \
+    "contractId" \
+    "decision" \
+    "releaseVerdict" \
+    "riskLevel" \
+    "timing" \
+    "reviewCoverage" \
+    "contractSource" \
+    "ciContext" \
+    "baselineComparison" \
+    "approval" \
+    "checks.policy_scan" \
+    "removalEvidence"
+  do
+    require_contains \
+      "$REFERENCE_DOC" \
+      "docs/reference.md" \
+      "\`$field\`" \
+      "reference_proofpack_field_missing" \
+      "Reference docs do not document proofpack field $field" \
+      "Expected docs/reference.md to contain \`$field\` in the proofpack field documentation"
+  done
+}
+
+check_current_skill_artifact_root() {
+  require_contains \
+    "$SKILL_DOC" \
+    "SKILL.md" \
+    ".signum/contracts/<contractId>/" \
+    "skill_contract_root_missing" \
+    "Root skill does not document the active contract artifact root" \
+    "Expected SKILL.md to mention .signum/contracts/<contractId>/"
+
+  require_not_contains \
+    "$SKILL_DOC" \
+    "SKILL.md" \
+    "Keep all artifacts in .signum" \
+    "skill_root_artifacts_stale" \
+    "Root skill still contains stale root .signum artifact wording" \
+    "Remove stale wording that says to keep all artifacts in .signum"
+
+  require_not_contains \
+    "$SKILL_DOC" \
+    "SKILL.md" \
+    "Keep all artifacts in \`.signum/\`" \
+    "skill_root_artifacts_stale" \
+    "Root skill still contains stale root .signum artifact wording" \
+    "Remove stale wording that says to keep all artifacts in \`.signum/\`"
+}
+
+check_current_architecture_surface() {
+  require_contains \
+    "$ARCHITECTURE_DOC" \
+    "ARCHITECTURE.md" \
+    "/signum:init" \
+    "architecture_init_command_missing" \
+    "Architecture docs do not use the current init command surface" \
+    "Expected ARCHITECTURE.md to mention /signum:init"
+
+  require_not_contains \
+    "$ARCHITECTURE_DOC" \
+    "ARCHITECTURE.md" \
+    "/signum init" \
+    "architecture_init_command_stale" \
+    "Architecture docs still contain the stale spaced init command" \
+    "Remove stale /signum init wording"
+
+  require_contains \
+    "$ARCHITECTURE_DOC" \
+    "ARCHITECTURE.md" \
+    ".signum/contracts/<contractId>/" \
+    "architecture_contract_root_missing" \
+    "Architecture docs do not document the active contract artifact root" \
+    "Expected ARCHITECTURE.md to mention .signum/contracts/<contractId>/"
 }
 
 # 1. Canonical source policy exists in docs/reference.md
 if ! grep -Fq 'Canonical pipeline behavior:' "$REFERENCE_DOC" || \
    ! grep -Fq 'root `commands/signum.md`' "$REFERENCE_DOC" || \
    ! grep -Fq 'Platform-specific overlays:' "$REFERENCE_DOC"; then
-  add_finding \
+  add_warning \
     "canonical_source_policy_missing" \
     "docs/reference.md" \
     "Reference docs do not clearly declare canonical pipeline source and overlay policy" \
@@ -67,7 +204,7 @@ DOC_RANGE=$(echo "$SCHEMA_ROW" | sed -En 's/.*\| `schemaVersion` \| `\"([0-9.]+)
 DOC_MIN=$(echo "$DOC_RANGE" | awk '{print $1}')
 DOC_MAX=$(echo "$DOC_RANGE" | awk '{print $2}')
 if [ -z "$SCHEMA_ROW" ] || [ "$DOC_MIN" != "3.0" ] || [ "$DOC_MAX" != "$SCHEMA_MAX" ]; then
-  add_finding \
+  add_warning \
     "schema_version_range_mismatch" \
     "docs/reference.md" \
     "Reference schemaVersion range does not match lib/schemas/contract.schema.json" \
@@ -105,7 +242,7 @@ fi
 if [ "$(echo "$MISSING_PHASES" | jq 'length')" -gt 0 ] || \
    [ "$(echo "$EXTRA_UNDOCUMENTED" | jq 'length')" -gt 0 ] || \
    { [ "$(echo "$EXTRA_PHASES" | jq 'length')" -gt 0 ] && [ "$DOC_MENTIONS_RECONCILE" != "true" ]; }; then
-  add_finding \
+  add_warning \
     "phase_inventory_mismatch" \
     "platforms/claude-code/commands/signum.md" \
     "Overlay command phase inventory differs from canonical root command" \
@@ -114,7 +251,7 @@ fi
 
 # 4. Large-project roadmap maintenance update exists
 if ! grep -Fq '**2026-04-10 maintenance update**' "$ROADMAP_DOC"; then
-  add_finding \
+  add_warning \
     "roadmap_maintenance_note_missing" \
     "docs/plans/2026-03-15-large-project-support-roadmap.md" \
     "Large-project roadmap is missing the maintenance note that explains shipped-vs-follow-up interpretation" \
@@ -132,7 +269,7 @@ for phase in 1 2 3 4 5; do
     flag && count < 5 { print; count++ }
   ' "$ROADMAP_DOC")
   if ! echo "$block" | grep -Fq '**Status:** shipped in core'; then
-    add_finding \
+    add_warning \
       "roadmap_phase_status_mismatch" \
       "docs/plans/2026-03-15-large-project-support-roadmap.md" \
       "Roadmap Phase $phase is not marked shipped in core" \
@@ -140,14 +277,25 @@ for phase in 1 2 3 4 5; do
   fi
 done
 
-FINDINGS=$(jq -s '.' "$FINDINGS_FILE")
-COUNT=$(echo "$FINDINGS" | jq 'length')
+# 6. Critical PR #98 drift hardening: current proofpack, artifact-root, and init docs
+check_current_proofpack_reference
+check_current_skill_artifact_root
+check_current_architecture_surface
 
-if [ "$COUNT" -gt 0 ]; then
-  echo "doc_parity_check: $COUNT warning(s) found" >&2
+FINDINGS=$(jq -s '.' "$FINDINGS_FILE")
+ERROR_COUNT=$(echo "$FINDINGS" | jq '[.[] | select(.severity == "error")] | length')
+WARN_COUNT=$(echo "$FINDINGS" | jq '[.[] | select(.severity == "warn")] | length')
+
+if [ "$ERROR_COUNT" -gt 0 ]; then
+  echo "doc_parity_check: $ERROR_COUNT error(s), $WARN_COUNT warning(s) found" >&2
+  echo "$FINDINGS" | jq -r '.[] | "  " + (.severity | ascii_upcase) + " [" + .code + "] " + .file + ": " + .message' >&2
+  STATUS="error"
+  SUMMARY="$ERROR_COUNT blocking documentation/parity error(s), $WARN_COUNT warning(s) found"
+elif [ "$WARN_COUNT" -gt 0 ]; then
+  echo "doc_parity_check: $WARN_COUNT warning(s) found" >&2
   echo "$FINDINGS" | jq -r '.[] | "  WARN [" + .code + "] " + .file + ": " + .message' >&2
   STATUS="warn"
-  SUMMARY="$COUNT documentation/parity warning(s) found"
+  SUMMARY="$WARN_COUNT documentation/parity warning(s) found"
 else
   echo "doc_parity_check: no documentation/parity drift found" >&2
   STATUS="ok"
@@ -159,3 +307,7 @@ jq -n \
   --arg summary "$SUMMARY" \
   --argjson findings "$FINDINGS" \
   '{check:"doc_parity",status:$status,summary:$summary,findings:$findings}'
+
+if [ "$ERROR_COUNT" -gt 0 ]; then
+  exit 1
+fi

--- a/tests/test-doc-parity.sh
+++ b/tests/test-doc-parity.sh
@@ -2,7 +2,9 @@
 # test-doc-parity.sh -- tests for lib/doc-parity-check.sh
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export CDPATH=
+
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 CHECK_SCRIPT="$SCRIPT_DIR/../lib/doc-parity-check.sh"
 
 passed=0
@@ -33,6 +35,19 @@ assert_contains() {
   fi
 }
 
+run_check() {
+  local repo="$1" output_var="$2" exit_var="$3"
+  local output status
+
+  set +e
+  output=$(bash "$CHECK_SCRIPT" --repo-root "$repo" 2>/dev/null)
+  status=$?
+  set -e
+
+  printf -v "$output_var" '%s' "$output"
+  printf -v "$exit_var" '%s' "$status"
+}
+
 write_common_files() {
   local dir="$1"
   mkdir -p "$dir/commands" "$dir/platforms/claude-code/commands" "$dir/docs/plans" "$dir/docs" "$dir/lib/schemas"
@@ -60,6 +75,45 @@ EOF
 - Treat it as valid only while it remains listed in `docs/overlay-deviations.json`.
 
 | `schemaVersion` | `"3.0"`–`"3.8"` | Schema version |
+
+### proofpack.json fields
+
+- `lib/schemas/proofpack.schema.json` defines the proofpack schema.
+- `scripts/validate_proofpack.py` validates emitted proofpacks.
+
+The runtime PACK phase writes `.signum/contracts/<contractId>/proofpack.json`.
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `schemaVersion` | Yes | Proofpack schema version |
+| `contractId` | Yes | Contract identifier |
+| `decision` | Yes | Decision |
+| `releaseVerdict` | Yes | Release verdict |
+| `riskLevel` | Yes | Risk level |
+| `timing` | Yes | Timing metadata |
+| `reviewCoverage` | Yes | Review coverage |
+| `contractSource` | Yes | Contract source |
+| `approval` | Yes | Approval evidence |
+| `checks.policy_scan` | Yes | Policy scan evidence |
+| `ciContext` | Optional | CI metadata |
+| `baselineComparison` | Optional | Baseline comparison |
+| `removalEvidence` | Optional | Removal evidence |
+EOF
+
+  cat > "$dir/SKILL.md" <<'EOF'
+# Signum
+
+- Keep active run/pipeline artifacts under `.signum/contracts/<contractId>/`
+- Treat root `.signum/` as a registry/state/archive/compatibility namespace.
+EOF
+
+  cat > "$dir/ARCHITECTURE.md" <<'EOF'
+# Architecture
+
+1. User runs `/signum:init`.
+2. Signum writes run artifacts under `.signum/contracts/<contractId>/`.
+
+Root `.signum/` is a registry/state/archive/compatibility namespace.
 EOF
 
   cat > "$dir/lib/schemas/contract.schema.json" <<'EOF'
@@ -115,9 +169,10 @@ OK_REPO="$WORK/ok"
 write_common_files "$OK_REPO"
 cp "$OK_REPO/commands/signum.md" "$OK_REPO/platforms/claude-code/commands/signum.md"
 
-OK_OUTPUT=$(bash "$CHECK_SCRIPT" --repo-root "$OK_REPO" 2>/dev/null)
+run_check "$OK_REPO" OK_OUTPUT OK_EXIT
 OK_STATUS=$(echo "$OK_OUTPUT" | jq -r '.status')
 OK_COUNT=$(echo "$OK_OUTPUT" | jq '.findings | length')
+assert_eq "ok repo exits zero" "$OK_EXIT" "0"
 assert_eq "ok repo returns status ok" "$OK_STATUS" "ok"
 assert_eq "ok repo has zero findings" "$OK_COUNT" "0"
 
@@ -138,6 +193,29 @@ cat > "$WARN_REPO/docs/reference.md" <<'EOF'
 # Signum Reference
 
 | `schemaVersion` | `"3.0"`–`"3.7"` | Schema version |
+
+### proofpack.json fields
+
+- `lib/schemas/proofpack.schema.json` defines the proofpack schema.
+- `scripts/validate_proofpack.py` validates emitted proofpacks.
+
+The runtime PACK phase writes `.signum/contracts/<contractId>/proofpack.json`.
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `schemaVersion` | Yes | Proofpack schema version |
+| `contractId` | Yes | Contract identifier |
+| `decision` | Yes | Decision |
+| `releaseVerdict` | Yes | Release verdict |
+| `riskLevel` | Yes | Risk level |
+| `timing` | Yes | Timing metadata |
+| `reviewCoverage` | Yes | Review coverage |
+| `contractSource` | Yes | Contract source |
+| `approval` | Yes | Approval evidence |
+| `checks.policy_scan` | Yes | Policy scan evidence |
+| `ciContext` | Optional | CI metadata |
+| `baselineComparison` | Optional | Baseline comparison |
+| `removalEvidence` | Optional | Removal evidence |
 EOF
 
 cat > "$WARN_REPO/docs/overlay-deviations.json" <<'EOF'
@@ -170,9 +248,10 @@ cat > "$WARN_REPO/docs/plans/2026-03-15-large-project-support-roadmap.md" <<'EOF
 - **Status:** shipped in core
 EOF
 
-WARN_OUTPUT=$(bash "$CHECK_SCRIPT" --repo-root "$WARN_REPO" 2>/dev/null)
+run_check "$WARN_REPO" WARN_OUTPUT WARN_EXIT
 WARN_STATUS=$(echo "$WARN_OUTPUT" | jq -r '.status')
 WARN_CODES=$(echo "$WARN_OUTPUT" | jq -r '.findings[].code')
+assert_eq "warn repo exits zero" "$WARN_EXIT" "0"
 assert_eq "warn repo returns status warn" "$WARN_STATUS" "warn"
 assert_contains "warn repo flags missing canonical policy" "$WARN_CODES" "canonical_source_policy_missing"
 assert_contains "warn repo flags schema mismatch" "$WARN_CODES" "schema_version_range_mismatch"
@@ -193,11 +272,54 @@ cat > "$ALLOW_REPO/platforms/claude-code/commands/signum.md" <<'EOF'
 ## Phase 5: RECONCILE
 EOF
 
-ALLOW_OUTPUT=$(bash "$CHECK_SCRIPT" --repo-root "$ALLOW_REPO" 2>/dev/null)
+run_check "$ALLOW_REPO" ALLOW_OUTPUT ALLOW_EXIT
 ALLOW_STATUS=$(echo "$ALLOW_OUTPUT" | jq -r '.status')
 ALLOW_COUNT=$(echo "$ALLOW_OUTPUT" | jq '.findings | length')
+assert_eq "allowlisted overlay exits zero" "$ALLOW_EXIT" "0"
 assert_eq "allowlisted overlay returns status ok" "$ALLOW_STATUS" "ok"
 assert_eq "allowlisted overlay has zero findings" "$ALLOW_COUNT" "0"
+
+echo ""
+echo "=== Critical proofpack drift case ==="
+PROOFPACK_DRIFT_REPO="$WORK/proofpack-drift"
+write_common_files "$PROOFPACK_DRIFT_REPO"
+cp "$PROOFPACK_DRIFT_REPO/commands/signum.md" "$PROOFPACK_DRIFT_REPO/platforms/claude-code/commands/signum.md"
+printf '\n### proofpack.json fields (v4.6)\n' >> "$PROOFPACK_DRIFT_REPO/docs/reference.md"
+
+run_check "$PROOFPACK_DRIFT_REPO" PROOFPACK_DRIFT_OUTPUT PROOFPACK_DRIFT_EXIT
+PROOFPACK_DRIFT_STATUS=$(echo "$PROOFPACK_DRIFT_OUTPUT" | jq -r '.status')
+PROOFPACK_DRIFT_CODES=$(echo "$PROOFPACK_DRIFT_OUTPUT" | jq -r '.findings[].code')
+assert_eq "proofpack drift exits nonzero" "$PROOFPACK_DRIFT_EXIT" "1"
+assert_eq "proofpack drift returns status error" "$PROOFPACK_DRIFT_STATUS" "error"
+assert_contains "proofpack drift flags stale v4.6 heading" "$PROOFPACK_DRIFT_CODES" "reference_proofpack_v46_stale"
+
+echo ""
+echo "=== Critical skill artifact-root drift case ==="
+SKILL_DRIFT_REPO="$WORK/skill-drift"
+write_common_files "$SKILL_DRIFT_REPO"
+cp "$SKILL_DRIFT_REPO/commands/signum.md" "$SKILL_DRIFT_REPO/platforms/claude-code/commands/signum.md"
+printf '\nKeep all artifacts in `.signum/`.\n' >> "$SKILL_DRIFT_REPO/SKILL.md"
+
+run_check "$SKILL_DRIFT_REPO" SKILL_DRIFT_OUTPUT SKILL_DRIFT_EXIT
+SKILL_DRIFT_STATUS=$(echo "$SKILL_DRIFT_OUTPUT" | jq -r '.status')
+SKILL_DRIFT_CODES=$(echo "$SKILL_DRIFT_OUTPUT" | jq -r '.findings[].code')
+assert_eq "skill drift exits nonzero" "$SKILL_DRIFT_EXIT" "1"
+assert_eq "skill drift returns status error" "$SKILL_DRIFT_STATUS" "error"
+assert_contains "skill drift flags stale root wording" "$SKILL_DRIFT_CODES" "skill_root_artifacts_stale"
+
+echo ""
+echo "=== Critical architecture command drift case ==="
+ARCH_DRIFT_REPO="$WORK/architecture-drift"
+write_common_files "$ARCH_DRIFT_REPO"
+cp "$ARCH_DRIFT_REPO/commands/signum.md" "$ARCH_DRIFT_REPO/platforms/claude-code/commands/signum.md"
+printf '\nLegacy command: /signum init\n' >> "$ARCH_DRIFT_REPO/ARCHITECTURE.md"
+
+run_check "$ARCH_DRIFT_REPO" ARCH_DRIFT_OUTPUT ARCH_DRIFT_EXIT
+ARCH_DRIFT_STATUS=$(echo "$ARCH_DRIFT_OUTPUT" | jq -r '.status')
+ARCH_DRIFT_CODES=$(echo "$ARCH_DRIFT_OUTPUT" | jq -r '.findings[].code')
+assert_eq "architecture drift exits nonzero" "$ARCH_DRIFT_EXIT" "1"
+assert_eq "architecture drift returns status error" "$ARCH_DRIFT_STATUS" "error"
+assert_contains "architecture drift flags stale init command" "$ARCH_DRIFT_CODES" "architecture_init_command_stale"
 
 echo ""
 echo "=== Results ==="


### PR DESCRIPTION
## Summary
- Added blocking `error` findings to `lib/doc-parity-check.sh` for the PR #98 documentation drift cases while preserving the existing warn-only parity checks.
- Updated `.github/workflows/doc-parity.yml` so the job still emits annotations and a summary, then fails only when the checker reports blocking doc parity drift.
- Expanded `tests/test-doc-parity.sh` fixtures to cover OK, warn-only, and blocking drift cases without full-file snapshots.

## Blocking Drift Cases
The checker now fails on these critical drift cases:
- `docs/reference.md` missing the proofpack schema source, validator source, active contract proofpack path, or key proofpack fields.
- `docs/reference.md` containing stale `proofpack.json fields (v4.6)` wording.
- root `SKILL.md` missing `.signum/contracts/<contractId>/` or containing stale root `.signum` artifact wording.
- `ARCHITECTURE.md` missing `/signum:init`, containing stale `/signum init`, or missing `.signum/contracts/<contractId>/`.

Existing canonical source, schema range, overlay phase, and roadmap maintenance checks remain warn-only.

## Validation
- `bash tests/test-doc-parity.sh` - passed.
- `bash tests/test-reference-proofpack-fields.sh` - passed.
- `bash tests/test-skill-artifact-root.sh` - passed.
- `bash tests/test-architecture-command-surface.sh` - passed.
- `bash lib/doc-parity-check.sh` - passed with status `ok`.
- `git diff --check` - passed.
- `bash scripts/run-deterministic-tests.sh` - attempted; failed outside this PR's scope in `tests/test-codebase-awareness-multilang-acceptance.sh` under Python 3.9.6 with `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` from a Python 3.10-style type expression.

## Signum Skill
- The `signum` skill was available.
- Its instructions were read before implementation.
- It was used as a lightweight CONTRACT -> EXECUTE -> AUDIT -> PACK workflow for this bounded doc parity hardening change.

## Assumptions
- Historical roadmap/research/overlay parity findings should remain warn-only.
- The PR #98 drift checks are critical and should block both direct script execution and the doc parity workflow.
