### PR TITLE
docs: refresh README entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,115 +1,31 @@
-<p align="center">
-  <img src="assets/signum-hero-dark.png" alt="Signum — deterministic proof gate for agentic development">
-</p>
-
 # Signum
 
-**A deterministic proof gate for agentic software development.**
+Signum is a contract-first proof gate for agentic software changes: it turns a task into a reviewed contract, executes against that contract, audits the result, and packages evidence that humans and CI can inspect.
 
-Signum helps teams use AI coding agents more safely by turning every change into a contract-driven, auditable workflow.
+## Status
 
-Instead of trusting that an agent “probably did the right thing”, Signum asks for evidence:
+Signum is an active, experimental baseline for local deterministic development and review workflows. It is not a production certification system.
 
-- What was the contract?
-- What changed?
-- Which checks passed?
-- What risks were found?
-- What artifacts prove the result?
-- Is this safe enough to merge?
+The canonical runtime docs are:
 
-At the end, Signum produces a **proofpack**: a structured evidence bundle that CI and humans can inspect.
+- `commands/signum.md` for the main `CONTRACT → EXECUTE → AUDIT → PACK` pipeline.
+- `commands/init.md` for project bootstrap with `/signum:init`.
 
----
+This README is an entry point, not the complete runtime specification. Use `docs/reference.md` when exact behavior matters.
 
-## Why Signum?
+## What Signum does
 
-AI agents can move fast, but fast changes need reliable boundaries.
-
-Signum adds a release-style verification layer around agentic work:
-
-- **Contract-first execution** — define intent, scope, and acceptance criteria before implementation.
-- **Deterministic checks** — validate what can be checked without relying on model judgment.
-- **Policy scanning** — catch risky code patterns, dependency changes, secrets, and incomplete work.
-- **Proofpack output** — package evidence into a structured artifact.
-- **GitHub-ready CI gate** — make merge decisions easier to review.
-
-Signum is not a replacement for engineering judgment. It is a guardrail system that makes agentic changes easier to inspect, reproduce, and trust.
-
----
-
-## How it works
-
-Signum follows a simple flow:
+Signum follows one mental model:
 
 ```text
-Contract → Execute → Audit → Pack → CI Gate
+CONTRACT → EXECUTE → AUDIT → PACK
 ```
 
-### 1. Contract
+First it defines acceptance criteria and scope, then it implements against that contract, audits deterministic and model-assisted evidence, and writes a proofpack for review or CI gating.
 
-A change starts with a contract: the requested outcome, boundaries, risks, and acceptance criteria.
+## Install
 
-### 2. Execute
-
-The implementation runs against the contract. Signum keeps the work tied to the original intent.
-
-### 3. Audit
-
-Signum runs deterministic checks and policy scans. Optional reviewer tools can add additional review signals.
-
-### 4. Pack
-
-Signum creates a proofpack: a structured evidence bundle containing the contract, diff, checks, audit summary, and decision metadata.
-
-### 5. CI Gate
-
-GitHub Actions can validate the proofpack and expose the result as a merge gate.
-
----
-
-## What Signum produces
-
-The `.signum/` directory is a structured registry/state/archive namespace; normal runs do not create root artifact files or root runtime dirs directly in the root `.signum/` folder.
-
-- Normal runs do not create root runtime dirs like `.signum/reviews/`.
-- resume checks use the registry first, with root `.signum/contract.json` only as a legacy import signal.
-
-A Signum run writes canonical artifacts under:
-
-```text
-.signum/contracts/<contractId>/
-```
-
-Typical artifacts include:
-
-```text
-contract.json
-contract-engineer.json
-contract-policy.json
-combined.patch
-execute_log.json
-mechanic_report.json
-policy_scan.json
-holdout_report.json
-audit_summary.json
-proofpack.json
-```
-
-The most important output is:
-
-```text
-proofpack.json
-```
-
-This is the evidence bundle used by CI and reviewers.
-
----
-
-## Quick start
-
-### Requirements
-
-Signum expects a minimal local toolchain (>= v4.18.0):
+Signum expects this local toolchain:
 
 ```text
 bash
@@ -118,17 +34,15 @@ jq
 python3
 ```
 
-### Initialize a project
-
-Use the canonical init command:
+For Claude Code, install the plugin from the Emporium marketplace:
 
 ```bash
-/signum:init --harness
+claude plugin marketplace add heurema/emporium
+claude plugin install signum@emporium
+claude "/signum explain"
 ```
 
-For Claude Code usage, install the Claude Code CLI according to your environment.
-
-For Codex App usage, Signum ships a direct-install manifest at `.codex-plugin/plugin.json`, a repo-level marketplace at `.agents/plugins/marketplace.json`, and the marketplace plugin root at `platforms/codex/.codex-plugin/plugin.json`. In **Plugins -> Add marketplace**, use:
+For Codex App, Signum ships plugin metadata in this repository: `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`, and `platforms/codex/.codex-plugin/plugin.json`. In **Plugins -> Add marketplace**, use:
 
 ```text
 Source: heurema/signum
@@ -136,263 +50,106 @@ Git ref: main
 Sparse paths: leave blank
 ```
 
-After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**.
+After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**. For fuller setup and platform notes, see `QUICKSTART.md`.
 
-If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. Include `.codex-plugin` only for direct local-folder installs. For pinned installs, use `v4.21.7` or a newer release tag.
+## First run
 
-In Codex, invoke the workflow with a prompt such as:
-
-```text
-Use Signum to add a health check endpoint that returns {status: ok}
-```
-
-Optional reviewer tools may be used when available, but Signum keeps deterministic checks separate from model-based review.
-
-### Run local deterministic checks
-
-```bash
-bash scripts/run-deterministic-tests.sh
-```
-
-### Run clean-room smoke
-
-```bash
-bash scripts/run-cleanroom-smoke.sh
-```
-
-For a deeper pre-publish check:
-
-```bash
-SIGNUM_CLEANROOM_FULL=1 bash scripts/run-cleanroom-smoke.sh
-```
-
-### Validate a proofpack
-
-```bash
-python3 scripts/validate_proofpack.py \
-  .signum/contracts/<contractId>/proofpack.json \
-  --repo-root .
-```
-
----
-
-## GitHub CI gate
-
-Signum includes a GitHub Actions template for validating proofpacks in CI.
-
-The CI path is intentionally deterministic:
-
-- no hidden background work;
-- no required external AI reviewer;
-- no secrets needed for deterministic tests;
-- pinned GitHub Actions refs;
-- fixed Ubuntu runner label;
-- clean-room smoke coverage.
-
-The high-risk PR intake gate is intentionally strict. PRs touching sensitive paths such as workflows, scripts, command orchestration, or policy logic may require maintainer review or override.
-
----
-
-## Safety model
-
-Signum separates three kinds of evidence.
-
-### Deterministic evidence
-
-Checks that can run without model judgment:
-
-- proofpack validation;
-- policy scanner;
-- DSL runner validation;
-- artifact path guards;
-- command renderer parity;
-- clean-room smoke tests.
-
-### Model-assisted review
-
-Optional reviewer outputs can be included when available, but they are treated as review signals, not as the only source of truth.
-
-### Human review
-
-Large or high-risk changes still require human judgment. Signum makes that review easier by packaging the relevant evidence.
-
----
-
-## Policy scanner
-
-Signum includes a deterministic policy scanner with stable rule IDs.
-
-It can detect patterns such as:
-
-- dynamic code execution;
-- XSS sinks;
-- SQL injection patterns;
-- shell injection risks;
-- weak crypto;
-- suspicious incomplete code markers;
-- dependency additions.
-
-False positives can be explicitly suppressed with a visible rule-based marker:
+Run the main pipeline with a task:
 
 ```text
-SIGNUM_POLICY_ALLOW:<RULE_ID>:<reason>
+/signum "your task"
 ```
 
-Critical findings are not suppressible by default.
+Signum asks for contract approval before execution. Normal run artifacts are written under:
 
----
+```text
+.signum/contracts/<contractId>/
+```
 
-## Proofpack validation
+## Command surface
 
-Proofpacks are validated before CI consumes their result.
+| Command | Purpose |
+| --- | --- |
+| `/signum "<task>"` | Run the canonical Signum pipeline. |
+| `/signum explain` | Explain the current pipeline and artifact model. |
+| `/signum archive [contractId]` | Archive a completed contract; uses the active contract when no ID is provided. |
+| `/signum close [contractId]` | Close or abandon a contract without generating a proofpack; uses the active contract when no ID is provided. |
+| `/signum:init` | Bootstrap project context files. |
+| `/signum:init --harness` | Bootstrap project context and scaffold repo-level harness docs. Requires Signum `>= v4.18.0`. |
+| `/signum:init --force` | Overwrite existing bootstrap files. |
+| `/signum:init --project-root <path>` | Run bootstrap against a specific project root. |
 
-The validator checks:
+Use the colon form for init commands: `/signum:init` is the canonical init surface.
 
-- required fields;
-- schema and Signum version;
-- decision metadata;
-- artifact references;
-- safe relative paths;
-- optional removal evidence shape when present.
+## Artifact model
 
-Run it directly:
+`.signum/contracts/<contractId>/` is the canonical active contract artifact root. It holds run evidence such as `contract.json`, `combined.patch`, `audit_summary.json`, and `proofpack.json`.
+
+Root `.signum/` is a registry/state/archive namespace with compatibility helpers; normal runs do not create root artifact files or root runtime dirs there.
+
+For compatibility, resume checks use the registry first, with root `.signum/contract.json` only as a legacy import signal.
+
+For the detailed artifact inventory, see `docs/artifact-path-inventory.md` and `docs/reference.md`.
+
+## CI integration
+
+Run the CI wrapper with:
 
 ```bash
-python3 scripts/validate_proofpack.py path/to/proofpack.json --repo-root .
+bash lib/signum-ci.sh
 ```
 
----
+The GitHub Actions workflow template lives at:
 
-## Command renderer
-
-The main Signum command is generated from fragments.
-
-Runtime command files remain checked in, but renderer checks ensure fragments reproduce them byte-for-byte:
-
-```bash
-python3 scripts/render_signum_command.py \
-  --manifest commands/signum.fragments/manifest.json \
-  --output commands/signum.md \
-  --check
+```text
+lib/templates/signum-gate.yml
 ```
 
-Claude Code overlay rendering is checked separately:
+`lib/signum-ci.sh` maps proofpack decisions to exit codes:
 
-```bash
-python3 platforms/claude-code/scripts/render_signum_command.py \
-  --manifest platforms/claude-code/commands/signum.fragments/manifest.json \
-  --output platforms/claude-code/commands/signum.md \
-  --check
-```
+| Exit code | Decision |
+| --- | --- |
+| `0` | `AUTO_OK` |
+| `1` | `AUTO_BLOCK` |
+| `78` | `HUMAN_REVIEW` |
 
----
+The template uploads proofpack artifacts and comments the decision on pull requests. See `lib/signum-ci.sh`, `lib/templates/signum-gate.yml`, and `docs/reference.md` for the full CI behavior.
 
-## When to use Signum
+## Documentation
 
-Use Signum when:
+- `QUICKSTART.md` — setup and first-run walkthrough.
+- `docs/how-it-works.md` — pipeline narrative and phase details.
+- `docs/reference.md` — canonical reference for behavior, artifacts, and schemas.
+- `docs/RELIABILITY.md` — reliability notes and critical journeys.
+- `docs/SECURITY.md` — trust boundaries and security review triggers.
+- `ARCHITECTURE.md` — system overview and component map.
 
-- AI agents are modifying important code;
-- changes need auditability;
-- PRs should include structured evidence;
-- you want deterministic gates before merge;
-- you need a repeatable contract-first workflow.
+## Limitations
 
-Signum is especially useful for:
-
-- AI coding agent workflows;
-- internal developer tools;
-- CI/CD guardrails;
-- security-sensitive automation;
-- multi-agent development experiments.
-
----
-
-## When not to use Signum
-
-Signum may be too heavy if:
-
-- you only need a simple one-off script;
-- there is no CI or review process;
-- you do not need audit artifacts;
-- you want fully autonomous merging without human oversight.
-
-Signum is designed to make agentic work safer, not invisible.
-
----
-
-## Current limitations
-
-Signum is a stabilized baseline, not a full production certification system.
-
-Known limitations:
-
-- policy scanning is still regex-based, not a full semantic parser;
-- optional reviewer tools depend on external CLI availability and authentication;
-- GitHub-hosted runner images can still receive upstream patch updates;
-- clean-room smoke is not a real package publish/install test;
-- remote Emporium push is not tested by the local smoke path;
-- high-risk PRs may still require maintainer review or override.
-
----
+- Policy scanning is deterministic and regex-based, not a full semantic parser.
+- Optional reviewer tools depend on external CLI availability and authentication.
+- High-risk changes can still require maintainer review or an explicit override.
+- Clean-room smoke checks are not a real package publish/install test.
 
 ## Development
 
-Run the deterministic suite:
+Run the deterministic test suite:
 
 ```bash
 bash scripts/run-deterministic-tests.sh
 ```
 
-Run clean-room smoke:
+Useful focused checks while editing docs:
 
 ```bash
-bash scripts/run-cleanroom-smoke.sh
+bash tests/test-doc-parity.sh
+bash lib/doc-parity-check.sh
 ```
 
-Run evals:
+Maintainer release checks stay lower-level and deterministic:
 
 ```bash
-python3 evals/run.py
+bash lib/release-smoke.sh
 ```
 
-Run renderer checks:
-
-```bash
-python3 scripts/render_signum_command.py \
-  --manifest commands/signum.fragments/manifest.json \
-  --output commands/signum.md \
-  --check
-
-python3 platforms/claude-code/scripts/render_signum_command.py \
-  --manifest platforms/claude-code/commands/signum.fragments/manifest.json \
-  --output platforms/claude-code/commands/signum.md \
-  --check
-```
-
----
-
-### Maintainer release process
-
-Signum includes a maintainer release path for syncing the plugin entry with the Emporium marketplace.
-
-- **Release smoke test**: run `bash lib/release-smoke.sh` before publishing release metadata.
-- **Marketplace sync**: the `Sync Emporium marketplace entry` workflow updates `heurema/emporium/.claude-plugin/marketplace.json`.
-- **Codex plugin metadata**: `.codex-plugin/plugin.json` defines the direct Codex App install manifest; `.agents/plugins/marketplace.json` points marketplace installs at `platforms/codex/.codex-plugin/plugin.json`, which loads `platforms/codex/SKILL.md`.
-- **Automation secret**: non-dry-run cross-repo sync requires `EMPORIUM_SSH_KEY`.
-- **Manual trigger**: the workflow supports `workflow_dispatch` so maintainers can run a controlled release dry-run or sync.
-- **Release trigger**: the workflow also runs on release publication so marketplace metadata stays aligned with Signum releases.
-
-This is maintainer-facing release documentation. It does not change the user-facing Signum runtime flow.
-
----
-
-## Philosophy
-
-Signum is built around a simple principle:
-
-> AI-generated changes should be easy to inspect, reproduce, and verify.
-
-A good agentic workflow should not ask reviewers to trust invisible reasoning.  
-It should produce a clear contract, deterministic checks, and a verifiable proofpack.
-
-Signum is the seal on that process.
+The `Sync Emporium marketplace entry` workflow updates `heurema/emporium/.claude-plugin/marketplace.json`; non-dry-run sync needs `EMPORIUM_SSH_KEY`. It supports `workflow_dispatch` for controlled manual runs.

--- a/tests/fixtures/artifact-path-allowlist.txt
+++ b/tests/fixtures/artifact-path-allowlist.txt
@@ -42,6 +42,7 @@ legacy-compat-helper|lib/contract-dir.sh|4|.signum/${rel}
 legacy-scan-fallback|lib/contract-injection-scan.sh|2|.signum/contract.json
 project-bootstrap-input|scripts/init_scanner.py|1|.signum/project.glossary.json
 project-bootstrap-input|scripts/init_scanner.py|1|.signum/project.intent.md
+docs-legacy-note|README.md|1|.signum/contract.json
 project-metrics|lib/metric-ratchet.sh|1|.signum/metrics
 project-metrics|lib/metric-ratchet.sh|1|.signum/metrics/ratchet-report.json
 project-metrics|lib/metric-ratchet.sh|1|.signum/proofpack-index.jsonl
@@ -93,5 +94,3 @@ project-bootstrap-input|platforms/claude-code/scripts/init_scanner.py|1|.signum/
 project-bootstrap-input|platforms/claude-code/scripts/init_scanner.py|1|.signum/project.intent.md
 project-metrics|platforms/claude-code/lib/pack-anti-entropy.sh|3|.signum/metrics/ratchet-report.json
 ci-legacy-fallback|platforms/claude-code/lib/signum-ci.sh|2|.signum/proofpack.json
-docs-legacy-note|README.md|1|.signum/contract.json
-docs-legacy-note|README.md|1|.signum/reviews/

--- a/tests/test-readme-command-surface.sh
+++ b/tests/test-readme-command-surface.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# test-readme-command-surface.sh -- README public command surface guard
+set -euo pipefail
+
+export CDPATH=
+
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd "$SCRIPT_DIR/.." && pwd)"
+README_FILE="$REPO_ROOT/README.md"
+
+passed=0
+failed=0
+
+assert_contains() {
+  local name="$1" needle="$2"
+  if grep -Fq -- "$needle" "$README_FILE"; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$name" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" needle="$2"
+  if grep -Fq -- "$needle" "$README_FILE"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$name" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== README command surface ==="
+
+assert_contains "README has command surface section" "## Command surface"
+assert_contains "README uses canonical init command" "/signum:init"
+assert_not_contains "README avoids spaced init command" "/signum init"
+assert_contains "README documents active contract artifact root" ".signum/contracts/<contractId>/"
+assert_contains "README mentions CI wrapper" "lib/signum-ci.sh"
+assert_contains "README mentions workflow template" "lib/templates/signum-gate.yml"
+assert_contains "README mentions AUTO_OK" "AUTO_OK"
+assert_contains "README mentions AUTO_BLOCK" "AUTO_BLOCK"
+assert_contains "README mentions HUMAN_REVIEW" "HUMAN_REVIEW"
+assert_contains "README references reference docs" "docs/reference.md"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- Reworked the root `README.md` into a concise user-facing entry point covering status, install, first run, command surface, artifact model, CI integration, documentation, limitations, and development.
- Kept README content bounded to onboarding and linked deeper behavior to `commands/signum.md`, `commands/init.md`, and `docs/reference.md`.
- Preserved the guarded compatibility note for root `.signum/contract.json` as a legacy import signal.

## README regression test
- Added `tests/test-readme-command-surface.sh` to guard the README command surface, canonical `/signum:init` spelling, active contract artifact root, CI wrapper/template references, decision labels, and reference-doc link.
- Updated `tests/fixtures/artifact-path-allowlist.txt` for the remaining intentional README legacy-root compatibility mention.

## Validation
- `bash tests/test-readme-command-surface.sh` — passed
- `bash tests/test-doc-parity.sh` — passed
- `bash tests/test-reference-proofpack-fields.sh` — passed
- `bash tests/test-skill-artifact-root.sh` — passed
- `bash tests/test-architecture-command-surface.sh` — passed
- `bash lib/doc-parity-check.sh` — passed (`status: ok`)
- `git diff --check` — passed
- `bash scripts/run-deterministic-tests.sh` — passed

## Signum skill
- Available: yes
- Instructions read: yes (`/Users/limerc/.codex/skills/signum/SKILL.md`)
- Used: yes, as a contract-first workflow for this docs/test change.

## Verified assumptions
- `/signum explain`, `/signum archive [contractId]`, and `/signum close [contractId]` were verified against `commands/signum.md`.
- `/signum:init`, `--harness`, `--force`, and `--project-root <path>` were verified against `commands/init.md`.
- The branch was created from current `origin/main` after fetching PR #99 (`ca08178`), not from the stale deleted `codex/harden-doc-parity` branch.
