### PR TITLE
docs: add migration notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The template uploads proofpack artifacts and comments the decision on pull reque
 - `QUICKSTART.md` — setup and first-run walkthrough.
 - `docs/how-it-works.md` — pipeline narrative and phase details.
 - `docs/reference.md` — canonical reference for behavior, artifacts, and schemas.
+- `docs/migration-notes.md` — compatibility notes for historical artifact roots, proofpack schema versions, and init command naming.
 - `docs/RELIABILITY.md` — reliability notes and critical journeys.
 - `docs/SECURITY.md` — trust boundaries and security review triggers.
 - `ARCHITECTURE.md` — system overview and component map.

--- a/docs/migration-notes.md
+++ b/docs/migration-notes.md
@@ -1,0 +1,35 @@
+# Migration notes
+
+This document explains compatibility and historical transitions users or maintainers may encounter in older docs, old runs, or compatibility code. Current runtime behavior is defined by `commands/signum.md`, `commands/init.md`, and `docs/reference.md`. This file is not the primary runtime reference.
+
+## Artifact root migration
+
+Older Signum material may describe a root-based artifact model where root `.signum/` or root `.signum/*` artifact paths are treated as the normal place for run evidence. Those paths may still appear in older runs, old documentation, and compatibility code.
+
+The current canonical model uses `.signum/contracts/<contractId>/` as the active contract artifact root for normal run artifacts. Contract evidence, execution logs, audit outputs, and proofpacks belong under that contract directory.
+
+Root `.signum/` is now a registry/state/archive/compatibility namespace. Root `.signum/contract.json` is only a legacy import or resume signal where current docs and code still support it.
+
+For the maintained artifact inventory and current reference behavior, see `docs/artifact-path-inventory.md` and `docs/reference.md`.
+
+## Proofpack schema evolution
+
+Older docs or runs may mention proofpack schema `v4.6`. That era introduced the iterative audit repair loop and related CI or baseline-comparison evolution.
+
+The `4.7` era added removal and cleanup evidence for contracts that remove files or carry cleanup obligations.
+
+Current PACK behavior emits proofpack schema `4.8`, as shown by `commands/signum.md`, the PACK fragments, and the validator's runtime source-of-truth check. The current proofpack surface includes fields such as `contractId`, `releaseVerdict`, `riskLevel`, `timing`, `reviewCoverage`, `approval`, `checks.policy_scan`, and optional `ciContext`, `baselineComparison`, `iterativeAudit`, and `removalEvidence`.
+
+Do not treat this section as the field table. For the schema and validator contract, use `lib/schemas/proofpack.schema.json`, `scripts/validate_proofpack.py`, and `docs/reference.md`.
+
+## Init command migration
+
+`/signum:init` is the canonical init command. The init command with a space between `signum` and `init` is not the current command and should not be documented as current usage.
+
+Current supported flags are `--harness`, `--force`, and `--project-root <path>`. See `commands/init.md`.
+
+## Compatibility guidance
+
+Old runs may contain root `.signum/*` artifacts or legacy root contract files. New runs should use `.signum/contracts/<contractId>/` for normal run artifacts.
+
+For docs and integrations, prefer the canonical command docs, reference docs, schema, and validator over these historical notes.

--- a/tests/fixtures/artifact-path-allowlist.txt
+++ b/tests/fixtures/artifact-path-allowlist.txt
@@ -43,6 +43,8 @@ legacy-scan-fallback|lib/contract-injection-scan.sh|2|.signum/contract.json
 project-bootstrap-input|scripts/init_scanner.py|1|.signum/project.glossary.json
 project-bootstrap-input|scripts/init_scanner.py|1|.signum/project.intent.md
 docs-legacy-note|README.md|1|.signum/contract.json
+docs-legacy-note|docs/migration-notes.md|2|.signum/*
+docs-legacy-note|docs/migration-notes.md|1|.signum/contract.json
 project-metrics|lib/metric-ratchet.sh|1|.signum/metrics
 project-metrics|lib/metric-ratchet.sh|1|.signum/metrics/ratchet-report.json
 project-metrics|lib/metric-ratchet.sh|1|.signum/proofpack-index.jsonl

--- a/tests/test-artifact-path-inventory.sh
+++ b/tests/test-artifact-path-inventory.sh
@@ -2,6 +2,8 @@
 # test-artifact-path-inventory.sh -- guard classified root .signum usages
 set -euo pipefail
 
+export CDPATH=
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -44,6 +46,7 @@ def live_files():
         repo_root / "commands" / "signum.md",
         repo_root / "platforms" / "claude-code" / "commands" / "signum.md",
         repo_root / "README.md",
+        repo_root / "docs" / "migration-notes.md",
         repo_root / "docs" / "how-it-works.md",
         repo_root / "platforms" / "claude-code" / "docs" / "how-it-works.md",
     ]

--- a/tests/test-intentional-root-compatibility-mentions.sh
+++ b/tests/test-intentional-root-compatibility-mentions.sh
@@ -191,7 +191,7 @@ CONTRACT_HITS="$(
     '!lib/proofpack-index.sh'
 )"
 
-EXPECTED_CONTRACT_HITS=$'./README.md\n./agents/contractor.md\n./docs/reference.md\n./platforms/claude-code/agents/contractor.md\n./platforms/claude-code/docs/reference.md'
+EXPECTED_CONTRACT_HITS=$'./README.md\n./agents/contractor.md\n./docs/migration-notes.md\n./docs/reference.md\n./platforms/claude-code/agents/contractor.md\n./platforms/claude-code/docs/reference.md'
 
 assert_exact_file_set \
   "only intentional non-test root contract mentions remain" \
@@ -204,6 +204,9 @@ assert_contains "$ROOT_DIR/README.md" \
 assert_contains "$ROOT_DIR/docs/reference.md" \
   'Root `.signum/contract.json` is only a legacy import signal' \
   "reference doc frames root contract path as legacy import signal"
+assert_contains "$ROOT_DIR/docs/migration-notes.md" \
+  'Root `.signum/contract.json` is only a legacy import or resume signal' \
+  "migration notes frame root contract path as legacy import/resume signal"
 assert_contains "$ROOT_DIR/platforms/claude-code/docs/reference.md" \
   'Root `.signum/contract.json` is only a legacy import signal' \
   "overlay reference doc frames root contract path as legacy import signal"

--- a/tests/test-migration-notes.sh
+++ b/tests/test-migration-notes.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# test-migration-notes.sh -- migration notes coverage guard
+set -euo pipefail
+
+export CDPATH=
+
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd "$SCRIPT_DIR/.." && pwd)"
+DOC="$REPO_ROOT/docs/migration-notes.md"
+README="$REPO_ROOT/README.md"
+
+passed=0
+failed=0
+
+assert_file_exists() {
+  local name="$1" file="$2"
+  if [ -f "$file" ]; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing %s\n' "$name" "$file"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_contains() {
+  local name="$1" file="$2" needle="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$name" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" file="$2" needle="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  FAIL: %s -- unexpectedly found "%s"\n' "$name" "$needle"
+    failed=$((failed + 1))
+  else
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== Migration notes ==="
+
+assert_file_exists "migration notes doc exists" "$DOC"
+assert_contains "migration notes document canonical artifact root" "$DOC" ".signum/contracts/<contractId>/"
+assert_contains "migration notes document canonical init command" "$DOC" "/signum:init"
+assert_not_contains "migration notes avoid spaced init command" "$DOC" "/signum init"
+assert_contains "migration notes reference proofpack schema" "$DOC" "lib/schemas/proofpack.schema.json"
+assert_contains "migration notes reference proofpack validator" "$DOC" "scripts/validate_proofpack.py"
+assert_contains "migration notes reference docs/reference" "$DOC" "docs/reference.md"
+assert_contains "migration notes mention current proofpack version" "$DOC" "4.8"
+assert_contains "README links migration notes" "$README" "docs/migration-notes.md"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- Adds docs/migration-notes.md for compatibility and historical transitions around artifact roots, proofpack schema versions, and init command naming.
- Links the migration notes from the README Documentation section.
- Adds tests/test-migration-notes.sh plus targeted compatibility guard and artifact-path allowlist updates for intentional root .signum mentions.

## Validation
- PASS: bash tests/test-migration-notes.sh
- PASS: bash tests/test-readme-command-surface.sh
- PASS: bash tests/test-doc-parity.sh
- PASS: bash tests/test-reference-proofpack-fields.sh
- PASS: bash tests/test-skill-artifact-root.sh
- PASS: bash tests/test-architecture-command-surface.sh
- PASS: bash tests/test-artifact-path-inventory.sh
- PASS: bash lib/doc-parity-check.sh
- PASS: git diff --check
- PASS: bash scripts/run-deterministic-tests.sh

## Signum skill
- Available: yes.
- Instructions read: yes, /Users/limerc/.codex/skills/signum/SKILL.md.
- Used: yes, as a reduced contract-first workflow for this low-risk docs-only change.

## Verified assumptions
- Current proofpack schema emission target is 4.8, verified against commands/signum.md, commands/signum.fragments/100-phase-pack.md, lib/schemas/proofpack.schema.json, scripts/validate_proofpack.py, and docs/reference.md.
- Current init command is /signum:init with --harness, --force, and --project-root <path>, verified against commands/init.md.
- Current canonical artifact root is .signum/contracts/<contractId>/, with root .signum/ retained as registry/state/archive/compatibility namespace and root .signum/contract.json as a legacy import/resume signal where supported.