### PR TITLE
feat(signum-evolve): add historical replay signal

### DIFF
--- a/experiments/signum_evolve/README.md
+++ b/experiments/signum_evolve/README.md
@@ -13,6 +13,14 @@ It does not change scanner behavior, mutate source catalogs, call LLMs, or apply
 - Archives candidate, eval, compare, and leaderboard artifacts under `out/<run_id>/`.
 - Exports a review bundle for one candidate.
 
+## What v0.1 Adds
+
+v0.1 adds optional historical replay drift reporting for reviewers.
+
+When `--historical-root` is provided, `generate` discovers historical contract directories containing `combined.patch`, scans each patch with the baseline catalog and with each candidate catalog, and writes deterministic drift data to each candidate archive.
+
+Historical replay is only a review signal. It is not treated as labeled ground truth and does not auto-apply or rewrite candidate catalogs. Missing historical roots are skipped gracefully.
+
 ## What v0 Does Not Do
 
 - No OpenEvolve.
@@ -24,6 +32,7 @@ It does not change scanner behavior, mutate source catalogs, call LLMs, or apply
 - No Codex prompt change.
 - No source catalog edits.
 - No auto-apply or PR creation.
+- No required `.signum/` artifacts for tests.
 
 ## Mutation Policy
 
@@ -69,6 +78,53 @@ experiments/signum_evolve/out/<run_id>/
 
 `out/` is ignored by git.
 
+To add optional historical replay:
+
+```bash
+python3 -m experiments.signum_evolve.cli generate \
+  --repo-root . \
+  --config experiments/signum_evolve/configs/evolve.v0.json \
+  --run-id replay-smoke \
+  --max-candidates 5 \
+  --seed 42 \
+  --historical-root .signum/contracts
+```
+
+If the historical root does not exist, the run still succeeds and records:
+
+```json
+{"historicalReplay": {"reason": "missing_root", "status": "skipped"}}
+```
+
+## Historical Replay Output
+
+Each candidate with replay enabled gets:
+
+```text
+experiments/signum_evolve/out/<run_id>/candidates/<candidate_id>/historical_replay.json
+```
+
+The report includes:
+
+- replay status
+- item count
+- new findings
+- removed findings
+- changed severity count
+- changed rule count
+- new or removed critical findings
+- per-contract drift items
+
+Finding identity is deterministic and compares:
+
+- `ruleId`
+- `file`
+- `line`
+- `severity`
+- `snippet`
+
+Changed severity and changed rule summaries use deterministic alternate identities to make drift easier to review. Paths are repo-relative when possible; external temporary roots are reported with `external:<root-name>/...` instead of absolute local paths.
+
 ## Read Leaderboard
 
 ```bash
@@ -77,6 +133,22 @@ python3 -m experiments.signum_evolve.cli leaderboard \
 ```
 
 The leaderboard reports candidate decision, status, hard gate result, improvements, regressions, and mutation metadata. A candidate does not need to beat the current baseline to be useful; the current baseline is intentionally strong.
+
+When replay is enabled, each leaderboard candidate also includes compact historical replay data:
+
+```json
+{
+  "historicalReplay": {
+    "itemCount": 12,
+    "newFindingsCount": 1,
+    "removedCriticalFindingsCount": 0,
+    "removedFindingsCount": 0,
+    "status": "ok"
+  }
+}
+```
+
+Replay does not penalize skipped candidates. If replay detects removed CRITICAL findings, the candidate decision is forced to `review` unless the comparison already rejected it.
 
 ## Export Adoption Bundle
 
@@ -93,7 +165,10 @@ The bundle contains:
 - `policy-rules.candidate.json`
 - `eval.json`
 - `compare.json`
+- `historical_replay.json`, when replay was enabled
 - `report.md`
 - `adoption-checklist.md`
 
 Candidate adoption requires a separate normal PR. The generated candidate catalog is never applied automatically.
+
+Adoption reports include a historical replay section when replay data is available. Any non-zero drift requires maintainer review before a candidate is adopted.

--- a/experiments/signum_evolve/cli.py
+++ b/experiments/signum_evolve/cli.py
@@ -11,6 +11,7 @@ from .candidate import DEFAULT_ALLOWED_PREFIXES, canonical_json, generate_candid
 from .export import export_bundle
 from .mutate import validate_scope_only_mutation
 from .report import baseline_summary_from_scorecard, write_leaderboard
+from .replay import run_historical_replay, write_historical_replay
 from .run_candidate import evaluate_candidate
 
 
@@ -43,6 +44,7 @@ def command_generate(args: argparse.Namespace) -> int:
         repo_root,
         config.get("baselineScorecard", "evals/policy_scanner/baselines/current.json"),
     ).resolve()
+    historical_root = repo_path(repo_root, args.historical_root).resolve() if args.historical_root else None
     allowed_prefixes = tuple(config.get("allowedPrefixes", DEFAULT_ALLOWED_PREFIXES))
 
     catalog = load_catalog(catalog_path)
@@ -63,6 +65,14 @@ def command_generate(args: argparse.Namespace) -> int:
             raise RuntimeError(f"{candidate['candidateId']} failed mutation validation: {errors}")
         candidate_dir = archive_candidate(run_dir, candidate)
         evaluate_candidate(repo_root, candidate_dir, baseline_path)
+        if historical_root is not None:
+            replay = run_historical_replay(
+                repo_root,
+                historical_root,
+                catalog_path,
+                candidate_dir / "policy-rules.json",
+            )
+            write_historical_replay(candidate_dir, replay)
 
     leaderboard = write_leaderboard(run_dir, args.run_id, baseline_scorecard)
     write_run_manifest(
@@ -101,6 +111,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     generate.add_argument("--run-id", required=True, help="Deterministic run ID.")
     generate.add_argument("--max-candidates", type=int, default=20, help="Maximum candidates to generate.")
     generate.add_argument("--seed", type=int, default=42, help="Recorded deterministic seed.")
+    generate.add_argument(
+        "--historical-root",
+        help="Optional historical contract root containing */combined.patch replay inputs.",
+    )
     generate.set_defaults(func=command_generate)
 
     leaderboard = subcommands.add_parser("leaderboard", help="Print a run leaderboard.")

--- a/experiments/signum_evolve/export.py
+++ b/experiments/signum_evolve/export.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from .candidate import load_json
 from .mutate import mutation_summary
+from .replay import decision_with_replay
 
 
 def copy_required(candidate_dir: Path, out_dir: Path) -> Dict[str, Path]:
@@ -21,21 +22,66 @@ def copy_required(candidate_dir: Path, out_dir: Path) -> Dict[str, Path]:
         if not source.exists():
             raise FileNotFoundError(source)
         shutil.copyfile(source, target)
+    replay_source = candidate_dir / "historical_replay.json"
+    if replay_source.exists():
+        replay_target = out_dir / "historical_replay.json"
+        shutil.copyfile(replay_source, replay_target)
+        mapping["historicalReplay"] = (replay_source, replay_target)
     return {key: target for key, (_source, target) in mapping.items()}
 
 
-def write_report(out_dir: Path, candidate: Dict[str, Any], compare: Dict[str, Any]) -> None:
+def historical_replay_lines(replay: Optional[Dict[str, Any]]) -> list[str]:
+    if replay is None:
+        return []
+
+    drift_count = (
+        int(replay.get("newFindingsCount", 0))
+        + int(replay.get("removedFindingsCount", 0))
+        + int(replay.get("changedSeverityCount", 0))
+        + int(replay.get("changedRuleCount", 0))
+    )
+    lines = [
+        "## Historical Replay",
+        "",
+        f"- Status: `{replay.get('status')}`",
+        f"- Item count: `{replay.get('itemCount', 0)}`",
+        f"- New findings: `{replay.get('newFindingsCount', 0)}`",
+        f"- Removed findings: `{replay.get('removedFindingsCount', 0)}`",
+        f"- Removed critical findings: `{replay.get('removedCriticalFindingsCount', 0)}`",
+        f"- Changed severity: `{replay.get('changedSeverityCount', 0)}`",
+    ]
+    if replay.get("reason"):
+        lines.append(f"- Reason: `{replay.get('reason')}`")
+    if drift_count:
+        lines.extend(
+            [
+                "",
+                "Review required: historical replay drift is a review signal, not ground truth.",
+            ]
+        )
+    lines.append("")
+    return lines
+
+
+def write_report(
+    out_dir: Path,
+    candidate: Dict[str, Any],
+    compare: Dict[str, Any],
+    replay: Optional[Dict[str, Any]],
+) -> None:
+    decision = decision_with_replay(compare, replay)
     lines = [
         "# Signum Evolve Adoption Report",
         "",
         f"- Candidate ID: `{candidate['candidateId']}`",
         f"- Mutation: `{mutation_summary(candidate)}`",
         f"- Comparison status: `{compare.get('status')}`",
-        f"- Decision: `{compare.get('decision')}`",
+        f"- Decision: `{decision}`",
         f"- Hard gate passed: `{compare.get('hardGatePassed')}`",
         f"- Improvements: `{len(compare.get('improvements', []))}`",
         f"- Regressions: `{len(compare.get('regressions', []))}`",
         "",
+        *historical_replay_lines(replay),
         "## Expected Files To Change If Adopted",
         "",
         "- `lib/policy-rules.json`",
@@ -58,6 +104,9 @@ def write_checklist(out_dir: Path) -> None:
         "- [ ] No CRITICAL rules changed.",
         "- [ ] Hard gates passed.",
         "- [ ] Comparison reviewed.",
+        "- [ ] Historical replay reviewed, if available.",
+        "- [ ] Removed critical findings checked.",
+        "- [ ] Drift accepted by maintainer.",
         "- [ ] Maintainer accepts trade-off.",
         "- [ ] Adoption uses a separate normal PR.",
         "",
@@ -72,6 +121,8 @@ def export_bundle(run_dir: Path, candidate_id: str, out_dir: Path) -> Path:
     copy_required(candidate_dir, out_dir)
     candidate = load_json(candidate_dir / "candidate.json")
     compare = load_json(candidate_dir / "compare.json")
-    write_report(out_dir, candidate, compare)
+    replay_path = candidate_dir / "historical_replay.json"
+    replay = load_json(replay_path) if replay_path.exists() else None
+    write_report(out_dir, candidate, compare, replay)
     write_checklist(out_dir)
     return out_dir

--- a/experiments/signum_evolve/replay.py
+++ b/experiments/signum_evolve/replay.py
@@ -1,0 +1,306 @@
+"""Historical replay drift signal for signum-evolve candidates."""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from .candidate import load_json, write_json
+
+
+COUNT_FIELDS = (
+    "newFindingsCount",
+    "removedFindingsCount",
+    "changedSeverityCount",
+    "changedRuleCount",
+    "removedCriticalFindingsCount",
+    "newCriticalFindingsCount",
+)
+
+
+def empty_replay(status: str, *, reason: Optional[str] = None) -> Dict[str, Any]:
+    replay: Dict[str, Any] = {
+        "changedRuleCount": 0,
+        "changedSeverityCount": 0,
+        "itemCount": 0,
+        "items": [],
+        "newCriticalFindingsCount": 0,
+        "newFindingsCount": 0,
+        "removedCriticalFindingsCount": 0,
+        "removedFindingsCount": 0,
+        "status": status,
+    }
+    if reason:
+        replay["reason"] = reason
+    return replay
+
+
+def path_ref(repo_root: Path, historical_root: Path, path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(repo_root).as_posix()
+    except ValueError:
+        pass
+
+    root = historical_root.resolve()
+    try:
+        return f"external:{root.name}/{resolved.relative_to(root).as_posix()}"
+    except ValueError:
+        return f"external:{resolved.name}"
+
+
+def stable_finding(finding: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "file": finding.get("file"),
+        "line": finding.get("line"),
+        "ruleId": finding.get("ruleId"),
+        "severity": finding.get("severity"),
+        "snippet": finding.get("snippet"),
+    }
+
+
+def finding_identity(finding: Dict[str, Any]) -> Tuple[str, str, int, str, str]:
+    line = finding.get("line")
+    line_value = line if isinstance(line, int) else -1
+    return (
+        str(finding.get("ruleId", "")),
+        str(finding.get("file", "")),
+        line_value,
+        str(finding.get("severity", "")),
+        str(finding.get("snippet", "")),
+    )
+
+
+def severity_identity(finding: Dict[str, Any]) -> Tuple[str, str, int, str]:
+    line = finding.get("line")
+    line_value = line if isinstance(line, int) else -1
+    return (
+        str(finding.get("ruleId", "")),
+        str(finding.get("file", "")),
+        line_value,
+        str(finding.get("snippet", "")),
+    )
+
+
+def rule_identity(finding: Dict[str, Any]) -> Tuple[str, int, str, str]:
+    line = finding.get("line")
+    line_value = line if isinstance(line, int) else -1
+    return (
+        str(finding.get("file", "")),
+        line_value,
+        str(finding.get("severity", "")),
+        str(finding.get("snippet", "")),
+    )
+
+
+def sorted_findings(findings: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return sorted((stable_finding(item) for item in findings), key=finding_identity)
+
+
+def scan_patch(repo_root: Path, patch_path: Path, catalog_path: Path) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    with tempfile.TemporaryDirectory(prefix="signum-evolve-replay-") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        temp_patch = temp_dir / "combined.patch"
+        temp_patch.write_text(patch_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+        env = os.environ.copy()
+        env["SIGNUM_POLICY_RULE_CATALOG"] = str(catalog_path)
+        proc = subprocess.run(
+            ["bash", "lib/policy-scanner.sh", str(temp_patch)],
+            cwd=str(repo_root),
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        output_path = temp_dir / "policy_scan.json"
+        if proc.returncode != 0:
+            return [], "scanner_failed"
+        if not output_path.exists():
+            return [], "missing_policy_scan"
+        output = load_json(output_path)
+        findings = output.get("findings")
+        if not isinstance(findings, list):
+            return [], "invalid_policy_scan"
+        return sorted_findings(item for item in findings if isinstance(item, dict)), None
+
+
+def changed_severity(
+    baseline_findings: List[Dict[str, Any]],
+    candidate_findings: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    baseline_by_identity = {severity_identity(item): item for item in baseline_findings}
+    candidate_by_identity = {severity_identity(item): item for item in candidate_findings}
+    changes: List[Dict[str, Any]] = []
+    for identity in sorted(set(baseline_by_identity) & set(candidate_by_identity)):
+        baseline = baseline_by_identity[identity]
+        candidate = candidate_by_identity[identity]
+        if baseline.get("severity") == candidate.get("severity"):
+            continue
+        changes.append(
+            {
+                "baselineSeverity": baseline.get("severity"),
+                "candidateSeverity": candidate.get("severity"),
+                "file": baseline.get("file"),
+                "line": baseline.get("line"),
+                "ruleId": baseline.get("ruleId"),
+                "snippet": baseline.get("snippet"),
+            }
+        )
+    return changes
+
+
+def changed_rule(
+    baseline_findings: List[Dict[str, Any]],
+    candidate_findings: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    baseline_by_identity = {rule_identity(item): item for item in baseline_findings}
+    candidate_by_identity = {rule_identity(item): item for item in candidate_findings}
+    changes: List[Dict[str, Any]] = []
+    for identity in sorted(set(baseline_by_identity) & set(candidate_by_identity)):
+        baseline = baseline_by_identity[identity]
+        candidate = candidate_by_identity[identity]
+        if baseline.get("ruleId") == candidate.get("ruleId"):
+            continue
+        changes.append(
+            {
+                "baselineRuleId": baseline.get("ruleId"),
+                "candidateRuleId": candidate.get("ruleId"),
+                "file": baseline.get("file"),
+                "line": baseline.get("line"),
+                "severity": baseline.get("severity"),
+                "snippet": baseline.get("snippet"),
+            }
+        )
+    return changes
+
+
+def replay_item(
+    repo_root: Path,
+    historical_root: Path,
+    patch_path: Path,
+    baseline_catalog_path: Path,
+    candidate_catalog_path: Path,
+) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    baseline_findings, baseline_error = scan_patch(repo_root, patch_path, baseline_catalog_path)
+    if baseline_error:
+        return None, baseline_error
+    candidate_findings, candidate_error = scan_patch(repo_root, patch_path, candidate_catalog_path)
+    if candidate_error:
+        return None, candidate_error
+
+    baseline_by_identity = {finding_identity(item): item for item in baseline_findings}
+    candidate_by_identity = {finding_identity(item): item for item in candidate_findings}
+    new_findings = [candidate_by_identity[key] for key in sorted(set(candidate_by_identity) - set(baseline_by_identity))]
+    removed_findings = [baseline_by_identity[key] for key in sorted(set(baseline_by_identity) - set(candidate_by_identity))]
+
+    return (
+        {
+            "baselineFindingCount": len(baseline_findings),
+            "candidateFindingCount": len(candidate_findings),
+            "changedRule": changed_rule(baseline_findings, candidate_findings),
+            "changedSeverity": changed_severity(baseline_findings, candidate_findings),
+            "contractId": patch_path.parent.name,
+            "newFindings": new_findings,
+            "patchPath": path_ref(repo_root, historical_root, patch_path),
+            "removedFindings": removed_findings,
+        },
+        None,
+    )
+
+
+def summarize_items(items: List[Dict[str, Any]]) -> Dict[str, int]:
+    new_findings = [finding for item in items for finding in item.get("newFindings", [])]
+    removed_findings = [finding for item in items for finding in item.get("removedFindings", [])]
+    changed_severity_items = [finding for item in items for finding in item.get("changedSeverity", [])]
+    changed_rule_items = [finding for item in items for finding in item.get("changedRule", [])]
+    return {
+        "changedRuleCount": len(changed_rule_items),
+        "changedSeverityCount": len(changed_severity_items),
+        "newCriticalFindingsCount": sum(1 for finding in new_findings if finding.get("severity") == "CRITICAL"),
+        "newFindingsCount": len(new_findings),
+        "removedCriticalFindingsCount": sum(
+            1 for finding in removed_findings if finding.get("severity") == "CRITICAL"
+        ),
+        "removedFindingsCount": len(removed_findings),
+    }
+
+
+def discover_patch_paths(historical_root: Path) -> List[Path]:
+    if not historical_root.is_dir():
+        return []
+    return sorted(
+        (path / "combined.patch" for path in historical_root.iterdir() if (path / "combined.patch").is_file()),
+        key=lambda path: (path.parent.name, path.as_posix()),
+    )
+
+
+def run_historical_replay(
+    repo_root: Path,
+    historical_root: Path,
+    baseline_catalog_path: Path,
+    candidate_catalog_path: Path,
+) -> Dict[str, Any]:
+    if not historical_root.exists():
+        return empty_replay("skipped", reason="missing_root")
+    if not historical_root.is_dir():
+        return empty_replay("skipped", reason="not_directory")
+
+    items: List[Dict[str, Any]] = []
+    for patch_path in discover_patch_paths(historical_root):
+        item, error = replay_item(
+            repo_root,
+            historical_root,
+            patch_path,
+            baseline_catalog_path,
+            candidate_catalog_path,
+        )
+        if error:
+            replay = empty_replay("error", reason=error)
+            replay["itemCount"] = len(items)
+            replay["items"] = items
+            return replay
+        if item:
+            items.append(item)
+
+    summary = summarize_items(items)
+    return {
+        **summary,
+        "itemCount": len(items),
+        "items": items,
+        "status": "ok",
+    }
+
+
+def write_historical_replay(candidate_dir: Path, replay: Dict[str, Any]) -> Path:
+    path = candidate_dir / "historical_replay.json"
+    write_json(path, replay)
+    return path
+
+
+def compact_historical_replay(replay: Dict[str, Any]) -> Dict[str, Any]:
+    compact: Dict[str, Any] = {
+        "itemCount": replay.get("itemCount", 0),
+        "newFindingsCount": replay.get("newFindingsCount", 0),
+        "removedCriticalFindingsCount": replay.get("removedCriticalFindingsCount", 0),
+        "removedFindingsCount": replay.get("removedFindingsCount", 0),
+        "status": replay.get("status"),
+    }
+    if replay.get("reason"):
+        compact["reason"] = replay.get("reason")
+    return compact
+
+
+def decision_with_replay(compare: Dict[str, Any], replay: Optional[Dict[str, Any]]) -> Any:
+    decision = compare.get("decision")
+    if not replay or replay.get("status") == "skipped":
+        return decision
+    if replay.get("removedCriticalFindingsCount", 0) <= 0:
+        return decision
+    if decision == "reject":
+        return "reject"
+    return "review"

--- a/experiments/signum_evolve/report.py
+++ b/experiments/signum_evolve/report.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from .candidate import load_json, write_json
+from .replay import compact_historical_replay, decision_with_replay
 
 
 def baseline_summary_from_scorecard(scorecard: Dict[str, Any]) -> Dict[str, Any]:
@@ -20,15 +21,20 @@ def baseline_summary_from_scorecard(scorecard: Dict[str, Any]) -> Dict[str, Any]
 def leaderboard_entry(candidate_dir: Path) -> Dict[str, Any]:
     candidate = load_json(candidate_dir / "candidate.json")
     compare = load_json(candidate_dir / "compare.json")
-    return {
+    replay_path = candidate_dir / "historical_replay.json"
+    replay = load_json(replay_path) if replay_path.exists() else None
+    entry = {
         "candidateId": candidate["candidateId"],
-        "decision": compare.get("decision"),
+        "decision": decision_with_replay(compare, replay),
         "hardGatePassed": compare.get("hardGatePassed"),
         "improvements": compare.get("improvements", []),
         "mutation": candidate.get("mutation", {}),
         "regressions": compare.get("regressions", []),
         "status": compare.get("status"),
     }
+    if replay is not None:
+        entry["historicalReplay"] = compact_historical_replay(replay)
+    return entry
 
 
 def build_leaderboard(run_dir: Path, run_id: str, baseline_scorecard: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/test-signum-evolve-replay.sh
+++ b/tests/test-signum-evolve-replay.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+RUN_ID="test-replay"
+MISSING_RUN_ID="test-replay-missing"
+RUN_DIR="$ROOT_DIR/experiments/signum_evolve/out/$RUN_ID"
+MISSING_RUN_DIR="$ROOT_DIR/experiments/signum_evolve/out/$MISSING_RUN_ID"
+WORK="$(mktemp -d)"
+EXPORT_DIR="$(mktemp -d)"
+HISTORICAL_ROOT="$WORK/history"
+MISSING_ROOT="$WORK/missing-history"
+trap 'rm -rf "$WORK" "$EXPORT_DIR"; rm -rf "$RUN_DIR" "$MISSING_RUN_DIR"' EXIT
+
+hash_file() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+SCANNER_HASH_BEFORE=$(hash_file "$ROOT_DIR/lib/policy-scanner.sh")
+CATALOG_HASH_BEFORE=$(hash_file "$ROOT_DIR/lib/policy-rules.json")
+OVERLAY_SCANNER_HASH_BEFORE=$(hash_file "$ROOT_DIR/platforms/claude-code/lib/policy-scanner.sh")
+OVERLAY_CATALOG_HASH_BEFORE=$(hash_file "$ROOT_DIR/platforms/claude-code/lib/policy-rules.json")
+
+rm -rf "$RUN_DIR" "$MISSING_RUN_DIR"
+
+python3 -m experiments.signum_evolve.cli generate \
+  --repo-root "$ROOT_DIR" \
+  --config experiments/signum_evolve/configs/evolve.v0.json \
+  --run-id "$MISSING_RUN_ID" \
+  --max-candidates 1 \
+  --seed 42 \
+  --historical-root "$MISSING_ROOT" \
+  > "$WORK/generate-missing.json"
+
+MISSING_REPLAY="$MISSING_RUN_DIR/candidates/cand_000001/historical_replay.json"
+test -f "$MISSING_REPLAY"
+python3 -m json.tool "$MISSING_REPLAY" >/dev/null
+jq -e '.status == "skipped" and .reason == "missing_root"' "$MISSING_REPLAY" >/dev/null
+jq -e '.candidates[0].historicalReplay.status == "skipped"' "$MISSING_RUN_DIR/leaderboard.json" >/dev/null
+
+mkdir -p "$HISTORICAL_ROOT/sig-clean" "$HISTORICAL_ROOT/sig-weak-docs"
+cat > "$HISTORICAL_ROOT/sig-clean/combined.patch" <<'PATCH'
+diff --git a/src/readme.txt b/src/readme.txt
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/src/readme.txt
+@@ -0,0 +1 @@
++plain text with no scanner finding
+PATCH
+
+cat > "$HISTORICAL_ROOT/sig-weak-docs/combined.patch" <<'PATCH'
+diff --git a/docs/legacy.py b/docs/legacy.py
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/docs/legacy.py
+@@ -0,0 +1,2 @@
++import hashlib
++digest = hashlib.md5(data).hexdigest()
+PATCH
+
+python3 -m experiments.signum_evolve.cli generate \
+  --repo-root "$ROOT_DIR" \
+  --config experiments/signum_evolve/configs/evolve.v0.json \
+  --run-id "$RUN_ID" \
+  --max-candidates 1 \
+  --seed 42 \
+  --historical-root "$HISTORICAL_ROOT" \
+  > "$WORK/generate.json"
+
+REPLAY="$RUN_DIR/candidates/cand_000001/historical_replay.json"
+test -f "$REPLAY"
+python3 -m json.tool "$REPLAY" >/dev/null
+jq -e '.status == "ok"' "$REPLAY" >/dev/null
+jq -e '.itemCount == 2' "$REPLAY" >/dev/null
+jq -e '.removedFindingsCount == 1' "$REPLAY" >/dev/null
+jq -e '.removedCriticalFindingsCount == 0' "$REPLAY" >/dev/null
+jq -e '.items | length == 2' "$REPLAY" >/dev/null
+jq -e '.items[] | select(.contractId == "sig-weak-docs") | .removedFindings[] | select(.ruleId == "POLICY_WEAK_CRYPTO")' "$REPLAY" >/dev/null
+
+if grep -Fq "$WORK" "$REPLAY"; then
+  echo "historical replay output contains absolute temporary path" >&2
+  exit 1
+fi
+jq -e '.items[].patchPath | startswith("external:")' "$REPLAY" >/dev/null
+
+jq -e '.candidates[0].historicalReplay.itemCount == 2' "$RUN_DIR/leaderboard.json" >/dev/null
+jq -e '.candidates[0].historicalReplay.removedFindingsCount == 1' "$RUN_DIR/leaderboard.json" >/dev/null
+
+python3 -m experiments.signum_evolve.cli export \
+  --run "$RUN_DIR" \
+  --candidate cand_000001 \
+  --out "$EXPORT_DIR/adoption-bundle" \
+  > "$WORK/export.json"
+
+test -f "$EXPORT_DIR/adoption-bundle/historical_replay.json"
+grep -Fq "## Historical Replay" "$EXPORT_DIR/adoption-bundle/report.md"
+grep -Fq "Removed findings: \`1\`" "$EXPORT_DIR/adoption-bundle/report.md"
+grep -Fq "Review required: historical replay drift is a review signal" "$EXPORT_DIR/adoption-bundle/report.md"
+grep -Fq "Historical replay reviewed" "$EXPORT_DIR/adoption-bundle/adoption-checklist.md"
+grep -Fq "Removed critical findings checked" "$EXPORT_DIR/adoption-bundle/adoption-checklist.md"
+grep -Fq "Drift accepted by maintainer" "$EXPORT_DIR/adoption-bundle/adoption-checklist.md"
+
+jq '.decision = "accept" | .status = "better" | .hardGatePassed = true' \
+  "$RUN_DIR/candidates/cand_000001/compare.json" > "$WORK/compare-critical.json"
+mv "$WORK/compare-critical.json" "$RUN_DIR/candidates/cand_000001/compare.json"
+jq '.removedCriticalFindingsCount = 1 | .removedFindingsCount = 1' \
+  "$RUN_DIR/candidates/cand_000001/historical_replay.json" > "$WORK/replay-critical.json"
+mv "$WORK/replay-critical.json" "$RUN_DIR/candidates/cand_000001/historical_replay.json"
+
+python3 - "$RUN_DIR/candidates/cand_000001" > "$WORK/leaderboard-critical.json" <<'PY'
+import sys
+from pathlib import Path
+
+from experiments.signum_evolve.candidate import canonical_json
+from experiments.signum_evolve.report import leaderboard_entry
+
+sys.stdout.write(canonical_json({"candidates": [leaderboard_entry(Path(sys.argv[1]))]}))
+PY
+
+jq -e '.candidates[0].decision == "review"' "$WORK/leaderboard-critical.json" >/dev/null
+jq -e '.candidates[0].historicalReplay.removedCriticalFindingsCount == 1' "$WORK/leaderboard-critical.json" >/dev/null
+
+python3 -m experiments.signum_evolve.cli export \
+  --run "$RUN_DIR" \
+  --candidate cand_000001 \
+  --out "$EXPORT_DIR/critical-adoption-bundle" \
+  > "$WORK/export-critical.json"
+
+grep -Fq "Decision: \`review\`" "$EXPORT_DIR/critical-adoption-bundle/report.md"
+grep -Fq "Removed critical findings: \`1\`" "$EXPORT_DIR/critical-adoption-bundle/report.md"
+
+if [ "$SCANNER_HASH_BEFORE" != "$(hash_file "$ROOT_DIR/lib/policy-scanner.sh")" ]; then
+  echo "root scanner changed during replay run" >&2
+  exit 1
+fi
+if [ "$CATALOG_HASH_BEFORE" != "$(hash_file "$ROOT_DIR/lib/policy-rules.json")" ]; then
+  echo "root policy catalog changed during replay run" >&2
+  exit 1
+fi
+if [ "$OVERLAY_SCANNER_HASH_BEFORE" != "$(hash_file "$ROOT_DIR/platforms/claude-code/lib/policy-scanner.sh")" ]; then
+  echo "overlay scanner changed during replay run" >&2
+  exit 1
+fi
+if [ "$OVERLAY_CATALOG_HASH_BEFORE" != "$(hash_file "$ROOT_DIR/platforms/claude-code/lib/policy-rules.json")" ]; then
+  echo "overlay policy catalog changed during replay run" >&2
+  exit 1
+fi
+
+if git -C "$ROOT_DIR" status --short .signum | grep -q .; then
+  echo ".signum has tracked or staged changes" >&2
+  exit 1
+fi
+
+git -C "$ROOT_DIR" check-ignore -q experiments/signum_evolve/out/test-replay
+
+echo "signum-evolve replay smoke passed"


### PR DESCRIPTION
# Add historical replay signal for signum-evolve

## Summary

Adds optional historical replay to `signum-evolve` candidate evaluation.

## Why

`signum-evolve v0` can evaluate candidates on frozen fixtures, but reviewers also need to know what a candidate would change on historical Signum artifacts. Historical replay provides drift visibility without treating historical artifacts as ground truth.

## What changed

- optional `--historical-root`
- replay over historical `*/combined.patch`
- baseline-vs-candidate scanner drift
- per-candidate `historical_replay.json`
- compact `historicalReplay` in leaderboard
- replay section in adoption bundle report
- replay review item in adoption checklist
- graceful skip for missing historical root
- fake historical-root regression test
- synthetic removed-critical replay safety regression test

## What did not change

- scanner behavior
- policy rule catalog
- Codex prompt
- Claude overlay runtime
- commands
- CI wiring
- eval baselines
- candidate auto-apply behavior

## Smoke result

- generated candidates: 5
- top candidate: `cand_000001`
- mutation: `POLICY_WEAK_CRYPTO + docs/`
- status: `equivalent`
- decision: `review`
- hardGatePassed: true
- regressions: []
- historical replay on current `.signum/contracts`: status ok, itemCount 0

## Verification

PASS:

- `python3 -m py_compile experiments/signum_evolve/*.py`
- `python3 -m experiments.signum_evolve.cli generate --repo-root . --config experiments/signum_evolve/configs/evolve.v0.json --run-id replay-smoke --max-candidates 5 --seed 42 --historical-root .signum/contracts`
- `python3 -m experiments.signum_evolve.cli leaderboard --run experiments/signum_evolve/out/replay-smoke`
- `python3 -m experiments.signum_evolve.cli export --run experiments/signum_evolve/out/replay-smoke --candidate cand_000001 --out /tmp/signum-evolve-replay-bundle`
- `bash tests/test-signum-evolve-v0.sh`
- `bash tests/test-signum-evolve-replay.sh`
- `bash tests/test-policy-scanner-evals.sh`
- `bash tests/test-policy-scanner-eval-compare.sh`
- `bash tests/test-codex-prompt-evals.sh`
- `bash tests/test-codex-prompt-eval-compare.sh`
- `bash scripts/run-deterministic-tests.sh`

## Follow-up

Future PRs can:

- add richer replay summaries
- add historical artifact corpus fixtures
- add additional safe mutation families
- only later consider OpenEvolve adapter
