### PR TITLE
docs: add documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The template uploads proofpack artifacts and comments the decision on pull reque
 
 ## Documentation
 
+- `docs/README.md` — documentation index separating runtime references, maintainer docs, and historical context.
 - `QUICKSTART.md` — setup and first-run walkthrough.
 - `docs/how-it-works.md` — pipeline narrative and phase details.
 - `docs/reference.md` — canonical reference for behavior, artifacts, and schemas.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,39 @@
+# Signum documentation
+
+This index points to current Signum documentation. It separates runtime references from historical planning and research notes.
+
+## Start here
+
+- `../README.md` - short onboarding entry point.
+- `../QUICKSTART.md` - setup and first-run walkthrough.
+- `how-it-works.md` - pipeline narrative and phase details.
+- `reference.md` - current behavior, artifacts, schemas, and reference details.
+
+## Canonical runtime sources
+
+- `../commands/signum.md` - source of truth for the main `CONTRACT -> EXECUTE -> AUDIT -> PACK` pipeline.
+- `../commands/init.md` - source of truth for `/signum:init`.
+
+## Runtime and integration reference
+
+- `reference.md`
+- `artifact-path-inventory.md`
+- `migration-notes.md`
+- `init-scanner-behavior.md`
+- `signum-command-structure.md`
+- `shared-receipt-mapping.md`
+
+## Maintainer and reliability docs
+
+- `../ARCHITECTURE.md`
+- `RELIABILITY.md`
+- `SECURITY.md`
+- `QUALITY_SCORE.md`
+- `PLANS.md`
+
+## Historical context
+
+- `plans/`
+- `research/`
+
+Files under `plans/` and `research/` are background material. They are not canonical runtime documentation unless a current runtime doc or test explicitly says so.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,12 @@
+# Planning notes
+
+These documents are planning and historical context for Signum.
+
+They are not the primary runtime reference. For current behavior, use:
+
+- `../../commands/signum.md`
+- `../../commands/init.md`
+- `../reference.md`
+- `../migration-notes.md`
+
+Some plans may describe work that has already shipped, changed shape, or been superseded by later implementation.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,12 @@
+# Research notes
+
+These documents are background research notes for Signum.
+
+They may explain design reasoning, prior investigations, or future ideas. They are not the primary runtime reference.
+
+For current behavior, use:
+
+- `../../commands/signum.md`
+- `../../commands/init.md`
+- `../reference.md`
+- `../migration-notes.md`

--- a/tests/test-docs-navigation.sh
+++ b/tests/test-docs-navigation.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# test-docs-navigation.sh -- documentation navigation and historical marker guard
+set -euo pipefail
+
+export CDPATH=
+
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd "$SCRIPT_DIR/.." && pwd)"
+DOCS_INDEX="$REPO_ROOT/docs/README.md"
+PLANS_INDEX="$REPO_ROOT/docs/plans/README.md"
+RESEARCH_INDEX="$REPO_ROOT/docs/research/README.md"
+ROOT_README="$REPO_ROOT/README.md"
+
+passed=0
+failed=0
+
+assert_file_exists() {
+  local name="$1" file="$2"
+  if [ -f "$file" ]; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing %s\n' "$name" "$file"
+    failed=$((failed + 1))
+  fi
+}
+
+assert_contains() {
+  local name="$1" file="$2" needle="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    printf '  PASS: %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL: %s -- missing "%s"\n' "$name" "$needle"
+    failed=$((failed + 1))
+  fi
+}
+
+echo "=== Documentation navigation ==="
+
+assert_file_exists "docs index exists" "$DOCS_INDEX"
+assert_contains "docs index links root README" "$DOCS_INDEX" "../README.md"
+assert_contains "docs index links quickstart" "$DOCS_INDEX" "../QUICKSTART.md"
+assert_contains "docs index links reference" "$DOCS_INDEX" "reference.md"
+assert_contains "docs index links how it works" "$DOCS_INDEX" "how-it-works.md"
+assert_contains "docs index links migration notes" "$DOCS_INDEX" "migration-notes.md"
+assert_contains "docs index links signum command" "$DOCS_INDEX" "../commands/signum.md"
+assert_contains "docs index links init command" "$DOCS_INDEX" "../commands/init.md"
+assert_contains "docs index links plans directory" "$DOCS_INDEX" "plans/"
+assert_contains "docs index links research directory" "$DOCS_INDEX" "research/"
+assert_contains "docs index marks plans and research as background" "$DOCS_INDEX" 'Files under `plans/` and `research/` are background material.'
+assert_contains "docs index says plans and research are not canonical runtime docs" "$DOCS_INDEX" "They are not canonical runtime documentation"
+
+assert_file_exists "plans index exists" "$PLANS_INDEX"
+assert_contains "plans index links signum command" "$PLANS_INDEX" "../../commands/signum.md"
+assert_contains "plans index links init command" "$PLANS_INDEX" "../../commands/init.md"
+assert_contains "plans index links reference" "$PLANS_INDEX" "../reference.md"
+assert_contains "plans index links migration notes" "$PLANS_INDEX" "../migration-notes.md"
+
+assert_file_exists "research index exists" "$RESEARCH_INDEX"
+assert_contains "research index links signum command" "$RESEARCH_INDEX" "../../commands/signum.md"
+assert_contains "research index links init command" "$RESEARCH_INDEX" "../../commands/init.md"
+assert_contains "research index links reference" "$RESEARCH_INDEX" "../reference.md"
+assert_contains "research index links migration notes" "$RESEARCH_INDEX" "../migration-notes.md"
+
+assert_contains "README links docs index" "$ROOT_README" "docs/README.md"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary

- Added `docs/README.md` as a concise documentation index that separates start-here docs, canonical runtime sources, runtime/integration references, maintainer docs, and historical context.
- Added `docs/plans/README.md` and `docs/research/README.md` markers explaining that those directories are planning/background material, not primary runtime references.
- Added one root `README.md` Documentation bullet pointing to `docs/README.md`.
- Added `tests/test-docs-navigation.sh` to guard the new navigation and historical-marker wording.

## Validation

All checks passed:

- `bash tests/test-docs-navigation.sh`
- `bash tests/test-migration-notes.sh`
- `bash tests/test-readme-command-surface.sh`
- `bash tests/test-doc-parity.sh`
- `bash tests/test-reference-proofpack-fields.sh`
- `bash tests/test-skill-artifact-root.sh`
- `bash tests/test-architecture-command-surface.sh`
- `bash tests/test-artifact-path-inventory.sh`
- `bash lib/doc-parity-check.sh`
- `git diff --check`
- `bash scripts/run-deterministic-tests.sh`

Note: the first local run of `tests/test-docs-navigation.sh` exposed a shell quoting bug in the new test assertion; that was fixed before the final passing runs above.

## Signum skill

- The local `signum` Codex skill was available.
- I read its instructions before editing.
- I used it as a lightweight contract-first workflow for this docs-only change, treating the task text as the implementation contract and validating against the requested shell checks.

## Assumptions

- Files under `docs/plans/` and `docs/research/` are treated as historical/background material unless a current runtime doc or test explicitly elevates a specific claim.
- Root `commands/signum.md`, root `commands/init.md`, `docs/reference.md`, and `docs/migration-notes.md` remain the current-runtime reference path for this navigation update.
