### PR TITLE
docs: add examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The template uploads proofpack artifacts and comments the decision on pull reque
 
 - `docs/README.md` — documentation index separating runtime references, maintainer docs, and historical context.
 - `QUICKSTART.md` — setup and first-run walkthrough.
+- `examples/README.md` — small, validator-backed examples for proofpacks, CI gating, and contract shape.
 - `docs/how-it-works.md` — pipeline narrative and phase details.
 - `docs/reference.md` — canonical reference for behavior, artifacts, and schemas.
 - `docs/migration-notes.md` — compatibility notes for historical artifact roots, proofpack schema versions, and init command naming.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This index points to current Signum documentation. It separates runtime referenc
 
 - `../README.md` - short onboarding entry point.
 - `../QUICKSTART.md` - setup and first-run walkthrough.
+- `../examples/README.md` - small, validator-backed examples.
 - `how-it-works.md` - pipeline narrative and phase details.
 - `reference.md` - current behavior, artifacts, schemas, and reference details.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,35 @@
+# Signum examples
+
+These examples are small, deterministic documentation fixtures. They are meant to show practical file shapes and validation commands without duplicating the full runtime reference.
+
+Normal Signum run artifacts live under `.signum/contracts/<contractId>/`.
+
+## Available examples
+
+- [proofpack-validation](proofpack-validation/) - a minimal proofpack that validates with `scripts/validate_proofpack.py`.
+- [ci-gate](ci-gate/) - notes for using the canonical Signum CI gate template and wrapper.
+- [basic-contract](basic-contract/) - a minimal contract shape example.
+
+## How to validate
+
+Run the proofpack validation example from the repository root:
+
+```bash
+python3 scripts/validate_proofpack.py examples/proofpack-validation/valid-proofpack.json --repo-root .
+```
+
+Run the examples guard:
+
+```bash
+bash tests/test-examples.sh
+```
+
+## Source of truth
+
+Current runtime behavior remains defined by:
+
+- `commands/signum.md`
+- `commands/init.md`
+- `docs/reference.md`
+
+Examples are not a replacement for the full runtime reference. Use `docs/reference.md` when exact behavior, schema details, or artifact semantics matter.

--- a/examples/basic-contract/README.md
+++ b/examples/basic-contract/README.md
@@ -1,0 +1,7 @@
+# Basic contract example
+
+`contract.json` is a minimal static shape example for a file-backed Signum contract. It is not enough by itself to run the full Signum pipeline without the surrounding user request, project context, approval flow, and runtime orchestration.
+
+For exact contract schema behavior and runtime semantics, see `docs/reference.md`.
+
+Normal runs import or generate contracts into the active contract artifact root under `.signum/contracts/<contractId>/`.

--- a/examples/basic-contract/contract.json
+++ b/examples/basic-contract/contract.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": "3.8",
+  "contractId": "sig-basic-contract-example-001",
+  "goal": "Add a minimal examples directory with validator-backed documentation fixtures",
+  "inScope": [
+    "examples/",
+    "tests/test-examples.sh"
+  ],
+  "outOfScope": [
+    "Changing Signum runtime behavior",
+    "Rewriting canonical command or reference documentation"
+  ],
+  "acceptanceCriteria": [
+    {
+      "id": "AC1",
+      "description": "The examples index links to proofpack validation, CI gate, and basic contract examples.",
+      "verify": {
+        "type": "command",
+        "value": "bash tests/test-examples.sh"
+      }
+    },
+    {
+      "id": "AC2",
+      "description": "The proofpack example validates with the repository proofpack validator.",
+      "verify": {
+        "type": "command",
+        "value": "python3 scripts/validate_proofpack.py examples/proofpack-validation/valid-proofpack.json --repo-root ."
+      }
+    }
+  ],
+  "riskLevel": "low",
+  "riskSignals": [
+    "Documentation fixture only",
+    "No runtime behavior changes"
+  ],
+  "assumptions": [
+    {
+      "id": "A1",
+      "text": "The repository root provides the current Signum validator and version metadata."
+    }
+  ],
+  "openQuestions": [],
+  "requiredInputsProvided": true
+}

--- a/examples/ci-gate/README.md
+++ b/examples/ci-gate/README.md
@@ -1,0 +1,19 @@
+# CI gate example
+
+The canonical GitHub Actions workflow template is `lib/templates/signum-gate.yml`. Copy or adapt that template for a repository; do not fork a separate workflow source from this example.
+
+The template runs the CI wrapper:
+
+```bash
+bash lib/signum-ci.sh
+```
+
+`lib/signum-ci.sh` validates the produced proofpack and maps Signum decisions to CI exit codes:
+
+| Exit code | Decision |
+| --- | --- |
+| `0` | `AUTO_OK` |
+| `1` | `AUTO_BLOCK` |
+| `78` | `HUMAN_REVIEW` |
+
+Use `docs/reference.md` for full CI behavior and artifact details.

--- a/examples/proofpack-validation/README.md
+++ b/examples/proofpack-validation/README.md
@@ -1,0 +1,11 @@
+# Proofpack validation example
+
+This directory contains a minimal proofpack documentation fixture derived from the current valid proofpack test fixtures. It is intentionally small, but it includes the fields required by `scripts/validate_proofpack.py`.
+
+Validate it from the repository root:
+
+```bash
+python3 scripts/validate_proofpack.py examples/proofpack-validation/valid-proofpack.json --repo-root .
+```
+
+This example does not include artifact path references, so no companion contract artifact directory is needed. Normal Signum runs write proofpacks under `.signum/contracts/<contractId>/`.

--- a/examples/proofpack-validation/valid-proofpack.json
+++ b/examples/proofpack-validation/valid-proofpack.json
@@ -1,0 +1,115 @@
+{
+  "schemaVersion": "4.8",
+  "signumVersion": "4.21.7",
+  "createdAt": "2026-04-26T00:00:00Z",
+  "runId": "signum-2026-04-26-example01",
+  "contractId": "sig-proofpack-example-001",
+  "decision": "AUTO_OK",
+  "releaseVerdict": "HOLD",
+  "riskLevel": "low",
+  "summary": "Goal: validate example proofpack | Risk: low | Decision: AUTO_OK",
+  "confidence": {
+    "overall": 91
+  },
+  "timing": {
+    "startedAt": "2026-04-26T00:00:00Z",
+    "completedAt": "2026-04-26T00:00:01Z",
+    "durationMs": 1000
+  },
+  "reviewCoverage": {
+    "availableReviews": 1
+  },
+  "contractSource": "file",
+  "auditChain": {
+    "contractSha256": "unavailable",
+    "approvedAt": "unavailable",
+    "baseCommit": "unavailable"
+  },
+  "contract": {
+    "content": {
+      "schemaVersion": "3.8",
+      "goal": "Validate a minimal example proofpack",
+      "riskLevel": "low"
+    },
+    "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "sizeBytes": 91,
+    "status": "present",
+    "fullSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "diff": {
+    "content": "diff --git a/example b/example\n",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "sizeBytes": 31,
+    "status": "present"
+  },
+  "baseline": {
+    "content": null,
+    "sha256": null,
+    "sizeBytes": 0,
+    "status": "error",
+    "omitReason": "file not found"
+  },
+  "executeLog": {
+    "content": {
+      "totalAttempts": 1
+    },
+    "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "sizeBytes": 19,
+    "status": "present"
+  },
+  "approval": {
+    "content": null,
+    "sha256": null,
+    "sizeBytes": 0,
+    "status": "error",
+    "omitReason": "file not found"
+  },
+  "checks": {
+    "mechanic": {
+      "content": {
+        "mechanic": "PASS"
+      },
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "sizeBytes": 19,
+      "status": "present"
+    },
+    "holdout": {
+      "content": {
+        "status": "PASS"
+      },
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "sizeBytes": 17,
+      "status": "present"
+    },
+    "policy_scan": {
+      "content": {
+        "findings": []
+      },
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "sizeBytes": 15,
+      "status": "present"
+    },
+    "reviews": {
+      "claude": {
+        "content": {
+          "provider": "claude",
+          "findings": []
+        },
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "sizeBytes": 35,
+        "status": "present"
+      }
+    },
+    "auditSummary": {
+      "content": {
+        "decision": "AUTO_OK",
+        "confidence": {
+          "overall": 91
+        }
+      },
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "sizeBytes": 50,
+      "status": "present"
+    }
+  }
+}

--- a/tests/test-examples.sh
+++ b/tests/test-examples.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# test-examples.sh -- guard first-class examples documentation fixtures
+set -euo pipefail
+
+export CDPATH=
+
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd "$SCRIPT_DIR/.." && pwd)"
+
+ROOT_README="$REPO_ROOT/README.md"
+DOCS_README="$REPO_ROOT/docs/README.md"
+EXAMPLES_README="$REPO_ROOT/examples/README.md"
+PROOFPACK_README="$REPO_ROOT/examples/proofpack-validation/README.md"
+PROOFPACK_JSON="$REPO_ROOT/examples/proofpack-validation/valid-proofpack.json"
+CI_GATE_README="$REPO_ROOT/examples/ci-gate/README.md"
+BASIC_CONTRACT_README="$REPO_ROOT/examples/basic-contract/README.md"
+BASIC_CONTRACT_JSON="$REPO_ROOT/examples/basic-contract/contract.json"
+
+passed=0
+failed=0
+
+pass() {
+  printf '  PASS: %s\n' "$1"
+  passed=$((passed + 1))
+}
+
+fail() {
+  printf '  FAIL: %s -- %s\n' "$1" "$2"
+  failed=$((failed + 1))
+}
+
+assert_file_exists() {
+  local name="$1" file="$2"
+  if [ -f "$file" ]; then
+    pass "$name"
+  else
+    fail "$name" "missing $file"
+  fi
+}
+
+assert_dir_exists() {
+  local name="$1" dir="$2"
+  if [ -d "$dir" ]; then
+    pass "$name"
+  else
+    fail "$name" "missing $dir"
+  fi
+}
+
+assert_contains() {
+  local name="$1" file="$2" needle="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    pass "$name"
+  else
+    fail "$name" "$file does not contain $needle"
+  fi
+}
+
+assert_ok() {
+  local name="$1"
+  shift
+  local output
+  if output=$("$@" 2>&1); then
+    pass "$name"
+  else
+    fail "$name" "$output"
+  fi
+}
+
+echo "=== Examples documentation fixtures ==="
+
+assert_file_exists "examples index exists" "$EXAMPLES_README"
+assert_dir_exists "proofpack validation example exists" "$REPO_ROOT/examples/proofpack-validation"
+assert_dir_exists "CI gate example exists" "$REPO_ROOT/examples/ci-gate"
+assert_dir_exists "basic contract example exists" "$REPO_ROOT/examples/basic-contract"
+
+assert_contains "root README links examples index" "$ROOT_README" "examples/README.md"
+assert_contains "docs README links examples index" "$DOCS_README" "../examples/README.md"
+assert_contains "examples index documents canonical artifact root" "$EXAMPLES_README" ".signum/contracts/<contractId>/"
+
+assert_contains "proofpack README references validator" "$PROOFPACK_README" "scripts/validate_proofpack.py"
+assert_file_exists "valid proofpack example exists" "$PROOFPACK_JSON"
+assert_ok "valid proofpack example validates" \
+  python3 "$REPO_ROOT/scripts/validate_proofpack.py" "$PROOFPACK_JSON" --repo-root "$REPO_ROOT"
+
+assert_contains "CI gate README references wrapper" "$CI_GATE_README" "lib/signum-ci.sh"
+assert_contains "CI gate README references workflow template" "$CI_GATE_README" "lib/templates/signum-gate.yml"
+assert_contains "CI gate README references AUTO_OK" "$CI_GATE_README" "AUTO_OK"
+assert_contains "CI gate README references AUTO_BLOCK" "$CI_GATE_README" "AUTO_BLOCK"
+assert_contains "CI gate README references HUMAN_REVIEW" "$CI_GATE_README" "HUMAN_REVIEW"
+
+assert_file_exists "basic contract example exists" "$BASIC_CONTRACT_JSON"
+assert_ok "basic contract example is valid JSON" python3 -m json.tool "$BASIC_CONTRACT_JSON"
+assert_contains "basic contract README references reference docs" "$BASIC_CONTRACT_README" "docs/reference.md"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary
- Adds a first-class `examples/` index that points to proofpack validation, CI gate, and basic contract examples.
- Adds `examples/proofpack-validation/valid-proofpack.json`, derived from the current validator-backed valid proofpack fixture shape.
- Adds `examples/ci-gate/README.md` that points to the canonical workflow template and `bash lib/signum-ci.sh` without forking the template.
- Adds `examples/basic-contract/contract.json` as a minimal static contract shape example.
- Adds concise navigation links from the root README and docs index.
- Adds `tests/test-examples.sh` to guard the example surface and validate the proofpack example.

## Validator-backed examples
- `examples/proofpack-validation/valid-proofpack.json` is validator-backed with `python3 scripts/validate_proofpack.py examples/proofpack-validation/valid-proofpack.json --repo-root .`.
- `examples/basic-contract/contract.json` is valid JSON and follows the current contract schema shape where practical, but it is documented as a static shape example rather than a runnable Signum artifact by itself.

## Tests run
- PASS: `bash tests/test-examples.sh`
- PASS: `bash tests/test-docs-navigation.sh`
- PASS: `bash tests/test-migration-notes.sh`
- PASS: `bash tests/test-readme-command-surface.sh`
- PASS: `bash tests/test-doc-parity.sh`
- PASS: `bash tests/test-reference-proofpack-fields.sh`
- PASS: `bash tests/test-skill-artifact-root.sh`
- PASS: `bash tests/test-architecture-command-surface.sh`
- PASS: `bash tests/test-artifact-path-inventory.sh`
- PASS: `bash lib/doc-parity-check.sh`
- PASS: `git diff --check`
- PASS: `bash scripts/run-deterministic-tests.sh`

## Signum skill
- The local `signum` skill was available.
- Its instructions were read before implementation.
- It was used in reduced form for this bounded docs/test change: contract-first scope, deterministic validation, audit via the requested test suite, and this proof summary.

## Assumptions
- The proofpack example can use the current minimal valid proofpack fixture shape because `scripts/validate_proofpack.py` is the repository-backed validator for this surface.
- The proofpack example intentionally omits `artifactRefs`, so no companion artifact files or explicit contract root are needed.
- The basic contract example is a shape fixture, not a complete standalone runtime invocation.
