### PR TITLE
docs: add API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The template uploads proofpack artifacts and comments the decision on pull reque
 - `examples/README.md` — small, validator-backed examples for proofpacks, CI gating, and contract shape.
 - `docs/how-it-works.md` — pipeline narrative and phase details.
 - `docs/reference.md` — canonical reference for behavior, artifacts, and schemas.
+- `docs/api-reference.md` — concise integration index for schemas and deterministic scripts.
 - `docs/migration-notes.md` — compatibility notes for historical artifact roots, proofpack schema versions, and init command naming.
 - `docs/RELIABILITY.md` — reliability notes and critical journeys.
 - `docs/SECURITY.md` — trust boundaries and security review triggers.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ This index points to current Signum documentation. It separates runtime referenc
 ## Runtime and integration reference
 
 - `reference.md`
+- `api-reference.md`
 - `artifact-path-inventory.md`
 - `migration-notes.md`
 - `init-scanner-behavior.md`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,56 @@
+# Signum API reference
+
+This page summarizes stable integration surfaces for schemas and deterministic scripts.
+
+Current runtime behavior is still defined by:
+
+- `commands/signum.md`
+- `commands/init.md`
+- `docs/reference.md`
+
+This page is an integration index, not the full runtime specification. For compatibility notes, examples, and CI wiring, see `docs/migration-notes.md`, `examples/README.md`, and `lib/templates/signum-gate.yml`.
+
+## Schemas
+
+| Surface | Source of truth | Notes |
+| --- | --- | --- |
+| Contract schema | `lib/schemas/contract.schema.json` | Contract JSON shape used by the CONTRACT phase. |
+| Proofpack schema | `lib/schemas/proofpack.schema.json` | Public proofpack JSON Schema surface. |
+| Proofpack validator | `scripts/validate_proofpack.py` | Deterministic validator for the proofpack shape Signum currently emits. |
+
+## Deterministic scripts
+
+| Script | Purpose | Inputs | Outputs / exit semantics |
+| --- | --- | --- | --- |
+| `scripts/validate_proofpack.py` | Validate proofpack artifacts. | proofpack path; optional `--repo-root`; optional `--contract-root` | exits `0` on valid proofpack and `1` on validation errors; emits warnings/errors to stderr. |
+| `lib/signum-ci.sh` | CI wrapper for file-backed Signum runs. | required `SIGNUM_CONTRACT_PATH`; optional `SIGNUM_PROJECT_ROOT`, `SIGNUM_MAX_TURNS`, `SIGNUM_ALLOWED_TOOLS`, `SIGNUM_AUDIT_MAX_ITERATIONS`, `SIGNUM_CI_RELAXED`, `SIGNUM_PROOFPACK_VALIDATOR` | maps decisions to exit codes: `0=AUTO_OK`, `1=AUTO_BLOCK`, `78=HUMAN_REVIEW`; `SIGNUM_CI_RELAXED=true` maps `HUMAN_REVIEW` to exit `0`. |
+| `lib/policy-scanner.sh` | Deterministic policy scan over added patch lines. | patch file path; optional `SIGNUM_POLICY_RULE_CATALOG` or `SIGNUM_POLICY_PATTERN_CATALOG` override | writes `<patch_dir>/policy_scan.json`; exits `0` when the scan completes and `1` on fatal input/tooling errors. |
+| `lib/init-scanner.sh` / `scripts/init_scanner.py` | Deterministic project-context scan for `/signum:init`. | optional `--project-root <path>`; defaults to `.` | writes JSON scan signals to stdout; exits non-zero on invalid arguments, missing wrapper dependencies, or project-root access errors. |
+| `scripts/run-deterministic-tests.sh` | Local deterministic test runner. | no required arguments; runs from the repository root | runs shell tests and offline evals when present; exits non-zero if any invoked check fails. |
+
+## Usage snippets
+
+Validate a proofpack from a canonical contract artifact root:
+
+```bash
+python3 scripts/validate_proofpack.py .signum/contracts/<contractId>/proofpack.json --repo-root .
+```
+
+Run the CI wrapper with a file-backed contract:
+
+```bash
+SIGNUM_CONTRACT_PATH=contract.json bash lib/signum-ci.sh
+```
+
+Run the init scanner against the current project:
+
+```bash
+bash lib/init-scanner.sh --project-root .
+```
+
+## Related references
+
+- `docs/reference.md` - full current runtime reference.
+- `docs/migration-notes.md` - compatibility notes for historical artifact roots, proofpack schema versions, and init command naming.
+- `examples/README.md` - small validator-backed examples.
+- `lib/templates/signum-gate.yml` - GitHub Actions gate template using `lib/signum-ci.sh`.

--- a/tests/test-api-reference.sh
+++ b/tests/test-api-reference.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# test-api-reference.sh -- guard concise API reference navigation and surfaces
+set -euo pipefail
+
+export CDPATH=
+
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd "$SCRIPT_DIR/.." && pwd)"
+
+API_REFERENCE="$REPO_ROOT/docs/api-reference.md"
+ROOT_README="$REPO_ROOT/README.md"
+DOCS_README="$REPO_ROOT/docs/README.md"
+
+passed=0
+failed=0
+
+pass() {
+  printf '  PASS: %s\n' "$1"
+  passed=$((passed + 1))
+}
+
+fail() {
+  printf '  FAIL: %s -- %s\n' "$1" "$2"
+  failed=$((failed + 1))
+}
+
+assert_file_exists() {
+  local name="$1" file="$2"
+  if [ -f "$file" ]; then
+    pass "$name"
+  else
+    fail "$name" "missing $file"
+  fi
+}
+
+assert_contains() {
+  local name="$1" file="$2" needle="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    pass "$name"
+  else
+    fail "$name" "$file does not contain $needle"
+  fi
+}
+
+echo "=== API reference documentation ==="
+
+assert_file_exists "API reference exists" "$API_REFERENCE"
+
+assert_contains "API reference links signum command" "$API_REFERENCE" "commands/signum.md"
+assert_contains "API reference links init command" "$API_REFERENCE" "commands/init.md"
+assert_contains "API reference links runtime reference" "$API_REFERENCE" "docs/reference.md"
+assert_contains "API reference links contract schema" "$API_REFERENCE" "lib/schemas/contract.schema.json"
+assert_contains "API reference links proofpack schema" "$API_REFERENCE" "lib/schemas/proofpack.schema.json"
+assert_contains "API reference links proofpack validator" "$API_REFERENCE" "scripts/validate_proofpack.py"
+assert_contains "API reference links CI wrapper" "$API_REFERENCE" "lib/signum-ci.sh"
+assert_contains "API reference links gate template" "$API_REFERENCE" "lib/templates/signum-gate.yml"
+assert_contains "API reference links policy scanner" "$API_REFERENCE" "lib/policy-scanner.sh"
+assert_contains "API reference links init scanner wrapper" "$API_REFERENCE" "lib/init-scanner.sh"
+assert_contains "API reference links init scanner implementation" "$API_REFERENCE" "scripts/init_scanner.py"
+assert_contains "API reference documents AUTO_OK" "$API_REFERENCE" "AUTO_OK"
+assert_contains "API reference documents AUTO_BLOCK" "$API_REFERENCE" "AUTO_BLOCK"
+assert_contains "API reference documents HUMAN_REVIEW" "$API_REFERENCE" "HUMAN_REVIEW"
+assert_contains "API reference shows canonical proofpack path" "$API_REFERENCE" ".signum/contracts/<contractId>/proofpack.json"
+
+assert_contains "root README links API reference" "$ROOT_README" "docs/api-reference.md"
+assert_contains "docs README links API reference" "$DOCS_README" "api-reference.md"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"


### PR DESCRIPTION
## Summary

- Added `docs/api-reference.md` as a concise integration index for schema surfaces and deterministic scripts.
- Linked the new reference from `README.md` and `docs/README.md` without expanding either index beyond one short entry.
- Added `tests/test-api-reference.sh` to guard the new page and navigation links.

## Validation

All checks passed:

- `bash tests/test-api-reference.sh`
- `bash tests/test-examples.sh`
- `bash tests/test-docs-navigation.sh`
- `bash tests/test-migration-notes.sh`
- `bash tests/test-readme-command-surface.sh`
- `bash tests/test-doc-parity.sh`
- `bash tests/test-reference-proofpack-fields.sh`
- `bash tests/test-skill-artifact-root.sh`
- `bash tests/test-architecture-command-surface.sh`
- `bash tests/test-artifact-path-inventory.sh`
- `bash lib/doc-parity-check.sh`
- `git diff --check`
- `bash scripts/run-deterministic-tests.sh`

`bash scripts/run-deterministic-tests.sh` completed top-level shell tests, Claude Code platform shell tests, and offline eval snapshots successfully.

## Signum Skill

The `signum` skill was available. Its instructions were read before implementation and used as a reduced contract-first workflow for this bounded documentation-only change.

## Assumptions

- `scripts/validate_proofpack.py` is documented from its argparse interface and return behavior: positional proofpack path, optional `--repo-root`, optional `--contract-root`, exit `0` on valid proofpacks and `1` on validation errors.
- `lib/signum-ci.sh` is documented from its header and decision mapping, including the existing `SIGNUM_CI_RELAXED=true` exception for `HUMAN_REVIEW`.
- `lib/policy-scanner.sh` is documented conservatively from its usage comment and implementation: patch-file input, catalog env override support, `policy_scan.json` output beside the patch, and fatal errors as non-zero.
- `lib/init-scanner.sh` / `scripts/init_scanner.py` is documented from the wrapper and parser: optional `--project-root <path>`, JSON stdout, and non-zero on invalid args or access/tooling errors.
- Work started from current `origin/main`: fetched/pruned origin, fast-forwarded local `main` from `cc2e730` to `f7ba0f7`, then created `codex/add-api-reference`.