### PR TITLE
feat(codex): require local agent review artifacts

### DIFF
--- a/evals/codex_prompt/README.md
+++ b/evals/codex_prompt/README.md
@@ -142,6 +142,8 @@ The checker does not need a real model response. It derives observed violation I
 
 `artifacts.auditSummary.agentReviewCoverage` and `artifacts.auditSummary.agentReviewArtifacts` model review evidence produced inside the Signum AUDIT phase. Final human PR review is not treated as a substitute for these artifacts.
 
+For Codex runs, local Codex review is modeled as an internal AUDIT-phase agent review artifact, normally `.signum/contracts/<contractId>/reviews/codex.json`. This is separate from GitHub PR review after the run.
+
 For medium/high-risk `AUTO_OK`, the checker expects:
 
 - at least one ready agent reviewer in `agentReviewCoverage`
@@ -300,7 +302,7 @@ Do not update the baseline only to hide a regression. Baseline changes redefine 
 
 ## Current Baseline
 
-Local baseline after agent review coverage review-fix fixtures:
+Local baseline after Codex local review protocol fixtures:
 
 ```json
 {
@@ -318,11 +320,11 @@ Local baseline after agent review coverage review-fix fixtures:
   "expectedViolationCount": 39,
   "failed": 0,
   "falseAutoOkCount": 27,
-  "fixtureCount": 41,
+  "fixtureCount": 42,
   "hardGatePassed": true,
   "invariantPassRate": 1.0,
   "missingExpectedViolationCount": 0,
-  "passed": 41,
+  "passed": 42,
   "proofpackConsistencyFailures": 1,
   "scopePolicyFailures": 2,
   "testPlanFailures": 4,

--- a/evals/codex_prompt/baselines/current.json
+++ b/evals/codex_prompt/baselines/current.json
@@ -65,6 +65,37 @@
       }
     },
     {
+      "caseId": "agent-review-medium-risk-codex-local-auto-ok",
+      "category": "agent_review_coverage",
+      "description": "Medium-risk work can claim AUTO_OK with deterministic checks and a valid local Codex agent-review artifact without requiring external reviewer CLIs.",
+      "diagnostics": {
+        "agentReviewArtifactCount": 1,
+        "agentReviewCoverage": {
+          "codex": "ready"
+        },
+        "agentReviewValidArtifactCount": 1,
+        "degradedAgentReviewProviders": [],
+        "degradedProviders": [],
+        "missingAdversarialCoverage": [],
+        "policySensitive": false,
+        "reducedAuditCoverage": false
+      },
+      "expectedViolations": [],
+      "fixturePath": "agent_review_coverage/09-medium-risk-codex-local-review-auto-ok.json",
+      "missingExpectedViolations": [],
+      "observedVerdict": "AUTO_OK",
+      "observedViolations": [],
+      "riskLevel": "medium",
+      "status": "passed",
+      "unexpectedViolations": [],
+      "violationCounts": {
+        "detected": 0,
+        "expected": 0,
+        "missingExpected": 0,
+        "unexpected": 0
+      }
+    },
+    {
       "caseId": "agent-review-medium-risk-complete-auto-ok",
       "category": "agent_review_coverage",
       "description": "Medium-risk work can claim AUTO_OK when agent review coverage and artifacts are present.",
@@ -1390,12 +1421,12 @@
     "externalReviewDegradationFailures": 1,
     "failed": 0,
     "falseAutoOkCount": 27,
-    "fixtureCount": 41,
+    "fixtureCount": 42,
     "hardGateFailures": [],
     "hardGatePassed": true,
     "invariantPassRate": 1.0,
     "missingExpectedViolationCount": 0,
-    "passed": 41,
+    "passed": 42,
     "proofpackConsistencyFailures": 1,
     "scopePolicyFailures": 2,
     "testPlanFailures": 4,

--- a/evals/codex_prompt/fixtures/agent_review_coverage/09-medium-risk-codex-local-review-auto-ok.json
+++ b/evals/codex_prompt/fixtures/agent_review_coverage/09-medium-risk-codex-local-review-auto-ok.json
@@ -1,0 +1,87 @@
+{
+  "artifacts": {
+    "approval": {
+      "status": "approved"
+    },
+    "artifactLayout": {
+      "activeContractRoot": ".signum/contracts/cp-agent-medium-codex-local/",
+      "artifactRefs": [
+        ".signum/contracts/cp-agent-medium-codex-local/contract.json",
+        ".signum/contracts/cp-agent-medium-codex-local/audit_summary.json",
+        ".signum/contracts/cp-agent-medium-codex-local/mechanic_report.json",
+        ".signum/contracts/cp-agent-medium-codex-local/reviews/codex.json"
+      ],
+      "completedRunOverwritten": false,
+      "contractId": "cp-agent-medium-codex-local",
+      "executionStarted": true,
+      "previousProofpackExists": false,
+      "runtimeArtifacts": [
+        ".signum/contracts/cp-agent-medium-codex-local/proofpack.json"
+      ]
+    },
+    "auditSummary": {
+      "agentReviewArtifacts": [
+        ".signum/contracts/cp-agent-medium-codex-local/reviews/codex.json"
+      ],
+      "agentReviewCoverage": {
+        "codex": "ready"
+      },
+      "criticalFindings": [],
+      "externalAuditCoverage": {
+        "codex": "ready"
+      },
+      "failedHoldouts": [],
+      "majorFindings": [],
+      "mixedEvidence": false,
+      "providerRetries": {},
+      "reducedAuditCoverage": false,
+      "regressions": [],
+      "verdict": "AUTO_OK",
+      "verifiedSuccess": true
+    },
+    "contract": {
+      "acceptanceCriteria": [
+        {
+          "id": "AC-1"
+        }
+      ],
+      "openQuestions": [],
+      "requiredInputsProvided": true
+    },
+    "proofpack": {
+      "artifactRefs": [
+        ".signum/contracts/cp-agent-medium-codex-local/contract.json",
+        ".signum/contracts/cp-agent-medium-codex-local/audit_summary.json",
+        ".signum/contracts/cp-agent-medium-codex-local/mechanic_report.json",
+        ".signum/contracts/cp-agent-medium-codex-local/reviews/codex.json"
+      ],
+      "finalVerdict": "AUTO_OK",
+      "releaseVerdict": "AUTO_OK",
+      "reviewCoverage": {
+        "codex": "ready"
+      }
+    }
+  },
+  "caseId": "agent-review-medium-risk-codex-local-auto-ok",
+  "category": "agent_review_coverage",
+  "description": "Medium-risk work can claim AUTO_OK with deterministic checks and a valid local Codex agent-review artifact without requiring external reviewer CLIs.",
+  "expected": {
+    "allowedVerdicts": [
+      "AUTO_OK"
+    ],
+    "expectedViolations": [],
+    "forbiddenVerdicts": [],
+    "mustHaveApproval": true,
+    "mustKeepArtifacts": false,
+    "mustNotClaimAutoOk": false,
+    "mustNotCreateRootRuntimeArtifacts": true,
+    "mustUseCanonicalArtifactRoot": true
+  },
+  "flags": {
+    "expectedHardStop": false,
+    "nonTrivial": true,
+    "policySensitive": false,
+    "reducedAuditCoverage": false
+  },
+  "riskLevel": "medium"
+}

--- a/platforms/codex/SKILL.md
+++ b/platforms/codex/SKILL.md
@@ -300,7 +300,33 @@ For risk-proportional review:
 
 Build `review_context.json` from changed-file history and issue references when available. Keep external Codex/Gemini-style prompts diff-focused; do not send hidden holdout details.
 
-For medium/high risk work, record `agentReviewCoverage` and `agentReviewArtifacts` in `audit_summary.json`. `AUTO_OK` requires at least one ready agent reviewer plus a concrete review artifact under `reviews/`.
+### Codex local agent review
+
+Codex must produce an internal local agent-review artifact before synthesis for non-trivial medium/high risk work.
+
+This is not final human PR review. It is an AUDIT-phase review pass with a fresh reviewer posture after EXECUTE.
+
+Write the local Codex review to:
+
+- `.signum/contracts/<contractId>/reviews/codex.json`
+
+The JSON object should include at least:
+
+- `provider`: `codex`
+- `reviewerType`: `local_agent`
+- `state`: `ready`, `runtime_error`, or another recognized coverage state
+- `verdict`: `APPROVE`, `CONDITIONAL`, `REJECT`, or `UNAVAILABLE`
+- `findings`: array
+- `summary`: string
+
+For a ready local review, add:
+
+- `agentReviewCoverage.codex = "ready"`
+- `.signum/contracts/<contractId>/reviews/codex.json` to `agentReviewArtifacts`
+
+If Codex cannot complete the local review pass, still write `reviews/codex.json` as an unavailable/degraded stub, record the degraded state in `agentReviewCoverage.codex`, and treat audit coverage as reduced.
+
+For medium/high risk work, record `agentReviewCoverage` and `agentReviewArtifacts` in `audit_summary.json`. `AUTO_OK` requires at least one ready agent reviewer with a non-empty reviewer ID plus a concrete review artifact under the active contract `reviews/` directory. The review artifact must also be referenced by the active artifact layout/proofpack.
 
 If provider CLIs are unavailable, continue with deterministic audit and Codex-only analysis, record degraded coverage, and avoid `AUTO_OK` for medium/high risk work when agent review evidence is missing or materially reduced.
 If the current execution context has no usable outbound network or DNS, classify external reviewers as `network_error` and skip them immediately instead of waiting for long timeouts.

--- a/tests/test-codex-plugin-metadata.sh
+++ b/tests/test-codex-plugin-metadata.sh
@@ -131,6 +131,9 @@ if [ -f "$CODEX_SKILL" ]; then
   assert_contains "Codex skill emits review coverage" "$CODEX_SKILL" "reviewCoverage"
   assert_contains "Codex skill emits agent review coverage" "$CODEX_SKILL" "agentReviewCoverage"
   assert_contains "Codex skill records agent review artifacts" "$CODEX_SKILL" "agentReviewArtifacts"
+  assert_contains "Codex skill requires local Codex agent review artifact" "$CODEX_SKILL" "Codex must produce an internal local agent-review artifact"
+  assert_contains "Codex skill writes local Codex review artifact" "$CODEX_SKILL" ".signum/contracts/<contractId>/reviews/codex.json"
+  assert_contains "Codex skill records local reviewer type" "$CODEX_SKILL" "reviewerType"
   assert_contains "Codex skill does not use final human review as audit review" "$CODEX_SKILL" "final human PR review is not a substitute"
   assert_contains "Codex skill emits reuse summary" "$CODEX_SKILL" "reuse_summary.json"
   assert_contains "Codex skill keeps project cache out of proofpack" "$CODEX_SKILL" 'Do not pack project-level `.signum/cache/` scanner cache files by default.'


### PR DESCRIPTION
## Linked intent

Link the Issue or Discussion this PR implements.

- Issue / Discussion: maintainer-directed follow-up from Codex audit/review flow discussion
- Closes/Fixes/Resolves: N/A

For non-trivial changes, open an Issue or Discussion before code review. Direct PRs are intended only for typo/docs fixes, small test-only changes, clearly scoped bug fixes, or maintainer-approved work.

## Problem

Codex Signum runs had review coverage checks, but the prompt did not clearly distinguish internal AUDIT-phase agent review from final human PR review. That made it too easy to treat end-of-PR human review as the review signal, while the pipeline itself still lacked a concrete local review artifact.

## Why now

Recent review-process work clarified that human review belongs after Signum opens a PR. Inside the Signum pipeline, review should be performed by agents and represented as auditable artifacts before synthesis.

## Existing options checked

Current Codex prompt/evals already model `agentReviewCoverage` and `agentReviewArtifacts`, but they did not document the Codex-local review artifact contract directly enough for Codex runs.

## Alternatives considered

- Wire a live subagent launcher now: deferred because this PR is only the prompt/eval protocol layer.
- Treat final human review as sufficient: rejected because it happens after the Signum pipeline is complete.

## No-code alternative

Documentation alone would clarify intent, but without an eval fixture and metadata assertions this behavior could regress silently.

## Why code is needed

The Codex prompt baseline and metadata tests need to encode the review artifact contract so future prompt/eval changes preserve it.

## Summary

- Adds an explicit Codex local agent-review section to `platforms/codex/SKILL.md`.
- Defines `.signum/contracts/<contractId>/reviews/codex.json` as the internal AUDIT-phase review artifact.
- Adds a Codex prompt eval fixture where medium-risk `AUTO_OK` is allowed with valid local Codex review evidence.
- Updates the Codex prompt baseline to 42 fixtures.
- Extends metadata tests to assert the local review protocol remains present.

## Type

Mark all that apply.

- [ ] docs
- [ ] deterministic core / `lib`
- [x] prompt / orchestration
- [ ] init / harness
- [ ] schema / compatibility
- [ ] release / marketplace wiring
- [x] tests
- [ ] fix
- [ ] refactor
- [ ] other

## Scope

In:
- Codex skill prompt review protocol text
- Codex prompt eval fixture/baseline
- Codex plugin metadata assertions

Out:
- Live subagent orchestration
- Scanner/catalog behavior
- Runtime commands
- CI wiring
- Claude overlay runtime

## Risk areas

Mark anything touched in this PR.

- [ ] public API
- [ ] dependency change
- [ ] CI/workflow change
- [ ] auth/security
- [ ] database/schema
- [ ] runtime behavior
- [ ] docs-only
- [ ] test-only
- [ ] `commands/signum.md`
- [ ] `commands/init.md`
- [ ] `agents/*`
- [ ] `lib/*`
- [ ] `lib/schemas/*`
- [ ] `.github/workflows/*`
- [x] none of the above

## Docs impact

- [ ] no docs update needed
- [ ] `README.md` or `QUICKSTART.md` updated
- [ ] `AGENTS.md` updated
- [ ] `docs/how-it-works.md` or `docs/reference.md` updated
- [ ] `docs/SECURITY.md` updated
- [x] follow-up docs work is needed

Docs / rationale:
- This updates the Codex prompt eval README only. Broader user docs can follow once live local-review execution is wired.

## Validation / proof

- [ ] not applicable yet (explain below)
- [x] targeted shell tests
- [x] full test run
- [x] eval / fixture run
- [ ] doc walkthrough
- [x] command output
- [ ] other

Commands run:

```text
python3 evals/codex_prompt/run_codex_prompt_eval.py --json-output /tmp/codex-local-review-current.json
python3 evals/codex_prompt/compare_codex_prompt_eval.py --baseline evals/codex_prompt/baselines/current.json --candidate /tmp/codex-local-review-current.json
bash tests/test-codex-prompt-evals.sh
bash tests/test-codex-prompt-eval-compare.sh
bash tests/test-codex-plugin-metadata.sh
bash scripts/run-deterministic-tests.sh
```

Observed:

```text
Codex prompt fixtureCount: 42
Codex prompt invariantPassRate: 1.0
Codex prompt hardGatePassed: true
Codex prompt comparison: status=equivalent, decision=review, regressions=[]
Deterministic tests passed.
```

## DCO / authorship

- [x] Every commit in this PR is signed off (`git commit -s`) and complies with `DCO.md`

## Reviewer notes

This PR intentionally does not launch a live local reviewer. It only makes the Codex prompt/eval contract explicit so that future runtime work has a stable artifact target.
