### PR TITLE
feat(codex): add local review evidence checker

### DIFF
--- a/platforms/codex/SKILL.md
+++ b/platforms/codex/SKILL.md
@@ -328,6 +328,15 @@ If Codex cannot complete the local review pass, still write `reviews/codex.json`
 
 For medium/high risk work, record `agentReviewCoverage` and `agentReviewArtifacts` in `audit_summary.json`. `AUTO_OK` requires at least one ready agent reviewer with a non-empty reviewer ID plus a concrete review artifact under the active contract `reviews/` directory. The review artifact must also be referenced by the active artifact layout/proofpack.
 
+Before accepting a medium/high-risk `AUTO_OK`, run the deterministic local review gate:
+
+```bash
+python3 scripts/check_codex_agent_review.py \
+  --contract-root .signum/contracts/<contractId>
+```
+
+If this checker fails, do not claim `AUTO_OK`; downgrade to `HUMAN_REVIEW` or repair the missing local review evidence first.
+
 If provider CLIs are unavailable, continue with deterministic audit and Codex-only analysis, record degraded coverage, and avoid `AUTO_OK` for medium/high risk work when agent review evidence is missing or materially reduced.
 If the current execution context has no usable outbound network or DNS, classify external reviewers as `network_error` and skip them immediately instead of waiting for long timeouts.
 If a provider returns a transient upstream failure, retry once with a short backoff, then mark reduced coverage.

--- a/scripts/check_codex_agent_review.py
+++ b/scripts/check_codex_agent_review.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Validate Codex local agent-review evidence for a Signum contract root.
+
+This checker is intentionally stdlib-only and narrow. It is a deterministic
+guard for the Codex prompt contract: medium/high-risk AUTO_OK runs need a ready
+local Codex review artifact before they can be treated as fully audited.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "1.0"
+REQUIRED_RISKS = {"medium", "high"}
+READY_STATE = "ready"
+APPROVING_VERDICTS = {"APPROVE", "CONDITIONAL"}
+
+
+def _load_json(path: Path) -> tuple[Any | None, str | None]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle), None
+    except FileNotFoundError:
+        return None, "missing"
+    except json.JSONDecodeError as exc:
+        return None, f"invalid_json:{exc.lineno}:{exc.colno}:{exc.msg}"
+    except OSError as exc:
+        return None, f"read_error:{exc}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _stable_json(data: Any) -> str:
+    return json.dumps(data, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+
+
+def _repo_relative(path: Path, repo_root: Path | None) -> str:
+    resolved = path.resolve()
+    if repo_root is not None:
+        try:
+            return resolved.relative_to(repo_root.resolve()).as_posix()
+        except ValueError:
+            pass
+    return path.name
+
+
+def _contract_id_from_root(contract_root: Path) -> str | None:
+    if contract_root.parent.name == "contracts" and contract_root.parent.parent.name == ".signum":
+        return contract_root.name
+    return None
+
+
+def _audit_artifact_paths(audit: dict[str, Any]) -> set[str]:
+    paths: set[str] = set()
+    for item in _as_list(audit.get("agentReviewArtifacts")):
+        if isinstance(item, str):
+            paths.add(item)
+        elif isinstance(item, dict):
+            path = item.get("path") or item.get("relativePath")
+            if isinstance(path, str):
+                paths.add(path)
+    return paths
+
+
+def _path_mentions_codex_review(path: str, contract_id: str | None) -> bool:
+    normalized = path.replace("\\", "/").strip()
+    allowed = {"reviews/codex.json", "./reviews/codex.json"}
+    if normalized in allowed:
+        return True
+    if contract_id:
+        return normalized == f".signum/contracts/{contract_id}/reviews/codex.json"
+    return normalized.endswith("/reviews/codex.json")
+
+
+def _proofpack_has_codex_review(proofpack: dict[str, Any], contract_id: str | None) -> bool:
+    checks = _as_dict(proofpack.get("checks"))
+    reviews = _as_dict(checks.get("reviews"))
+    codex_review = _as_dict(reviews.get("codex"))
+    if codex_review.get("status") == "present":
+        return True
+    content = _as_dict(codex_review.get("content"))
+    if content.get("provider") == "codex":
+        return True
+
+    for item in _as_list(proofpack.get("artifactRefs")):
+        path = item if isinstance(item, str) else _as_dict(item).get("path")
+        if isinstance(path, str) and _path_mentions_codex_review(path, contract_id):
+            return True
+    return False
+
+
+def _determine_risk(contract: dict[str, Any], audit: dict[str, Any], proofpack: dict[str, Any]) -> str | None:
+    for source in (proofpack, audit, contract):
+        risk = source.get("riskLevel")
+        if isinstance(risk, str) and risk:
+            return risk
+    return None
+
+
+def _determine_decision(audit: dict[str, Any], proofpack: dict[str, Any]) -> str | None:
+    for source in (audit, proofpack):
+        decision = source.get("decision")
+        if isinstance(decision, str) and decision:
+            return decision
+    return None
+
+
+def evaluate(contract_root: Path, repo_root: Path | None = None) -> dict[str, Any]:
+    violations: list[str] = []
+    warnings: list[str] = []
+
+    contract_id = _contract_id_from_root(contract_root)
+    paths = {
+        "contract": contract_root / "contract.json",
+        "auditSummary": contract_root / "audit_summary.json",
+        "proofpack": contract_root / "proofpack.json",
+        "codexReview": contract_root / "reviews" / "codex.json",
+    }
+
+    if not contract_root.is_dir():
+        violations.append("contract_root.missing")
+
+    contract_raw, contract_error = _load_json(paths["contract"])
+    audit_raw, audit_error = _load_json(paths["auditSummary"])
+    proofpack_raw, proofpack_error = _load_json(paths["proofpack"])
+    review_raw, review_error = _load_json(paths["codexReview"])
+
+    contract = _as_dict(contract_raw)
+    audit = _as_dict(audit_raw)
+    proofpack = _as_dict(proofpack_raw)
+    review = _as_dict(review_raw)
+
+    if contract_error and contract_error != "missing":
+        violations.append("contract.invalid_json")
+    if audit_error:
+        violations.append("audit_summary.missing" if audit_error == "missing" else "audit_summary.invalid_json")
+    if proofpack_error:
+        violations.append("proofpack.missing" if proofpack_error == "missing" else "proofpack.invalid_json")
+
+    decision = _determine_decision(audit, proofpack)
+    risk_level = _determine_risk(contract, audit, proofpack)
+    required = decision == "AUTO_OK" and risk_level in REQUIRED_RISKS
+
+    if not required:
+        if review_error and review_error not in {"missing"}:
+            warnings.append("codex_review.invalid_json")
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "status": "ok" if not violations else "error",
+            "hardGatePassed": not violations,
+            "required": False,
+            "reason": "not_medium_high_auto_ok",
+            "contractId": contract_id,
+            "contractRoot": _repo_relative(contract_root, repo_root),
+            "decision": decision,
+            "riskLevel": risk_level,
+            "violations": sorted(set(violations)),
+            "warnings": sorted(set(warnings)),
+            "checks": {
+                "auditSummaryPresent": audit_error is None,
+                "proofpackPresent": proofpack_error is None,
+                "codexReviewPresent": review_error is None,
+            },
+        }
+
+    if review_error:
+        violations.append("codex_review.missing" if review_error == "missing" else "codex_review.invalid_json")
+
+    coverage = _as_dict(audit.get("agentReviewCoverage"))
+    artifact_paths = _audit_artifact_paths(audit)
+    has_artifact_ref = any(_path_mentions_codex_review(path, contract_id) for path in artifact_paths)
+
+    if coverage.get("codex") != READY_STATE:
+        violations.append("agent_review.coverage_not_ready")
+    if not has_artifact_ref:
+        violations.append("agent_review.artifact_not_recorded")
+
+    if review_error is None:
+        if review.get("provider") != "codex":
+            violations.append("codex_review.provider_mismatch")
+        if review.get("reviewerType") != "local_agent":
+            violations.append("codex_review.reviewer_type_missing")
+        if review.get("state") != READY_STATE:
+            violations.append("codex_review.state_not_ready")
+        if review.get("verdict") not in APPROVING_VERDICTS:
+            violations.append("codex_review.verdict_not_approving")
+        if not isinstance(review.get("findings"), list):
+            violations.append("codex_review.findings_shape")
+        if not isinstance(review.get("summary"), str) or not review.get("summary", "").strip():
+            violations.append("codex_review.summary_missing")
+
+    if proofpack_error is None:
+        if proofpack.get("decision") != decision:
+            violations.append("proofpack.decision_mismatch")
+        if not _proofpack_has_codex_review(proofpack, contract_id):
+            violations.append("proofpack.codex_review_missing")
+
+    unique_violations = sorted(set(violations))
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "status": "ok" if not unique_violations else "error",
+        "hardGatePassed": not unique_violations,
+        "required": True,
+        "contractId": contract_id,
+        "contractRoot": _repo_relative(contract_root, repo_root),
+        "decision": decision,
+        "riskLevel": risk_level,
+        "violations": unique_violations,
+        "warnings": sorted(set(warnings)),
+        "checks": {
+            "agentReviewArtifactRecorded": has_artifact_ref,
+            "agentReviewCoverageCodex": coverage.get("codex"),
+            "auditSummaryPresent": audit_error is None,
+            "codexReviewPresent": review_error is None,
+            "proofpackIncludesCodexReview": proofpack_error is None and _proofpack_has_codex_review(proofpack, contract_id),
+            "proofpackPresent": proofpack_error is None,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate Codex local agent-review evidence")
+    parser.add_argument("--contract-root", required=True, help="path to .signum/contracts/<contractId>")
+    parser.add_argument("--repo-root", default=".", help="repository root for relative output paths")
+    parser.add_argument("--json-output", help="optional path to write the canonical JSON report")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else None
+    report = evaluate(Path(args.contract_root), repo_root)
+    payload = _stable_json(report)
+    sys.stdout.write(payload)
+    if args.json_output:
+        Path(args.json_output).write_text(payload, encoding="utf-8")
+    return 0 if report.get("hardGatePassed") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test-codex-agent-review-check.sh
+++ b/tests/test-codex-agent-review-check.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# test-codex-agent-review-check.sh -- deterministic tests for Codex local review gate
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd "$SCRIPT_DIR/.." && pwd)"
+CHECKER="$REPO_ROOT/scripts/check_codex_agent_review.py"
+
+passed=0
+failed=0
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass() {
+  printf '  PASS: %s\n' "$1"
+  passed=$((passed + 1))
+}
+
+fail() {
+  printf '  FAIL: %s -- %s\n' "$1" "$2"
+  failed=$((failed + 1))
+}
+
+write_contract_root() {
+  local root="$1" risk="$2" decision="$3"
+  mkdir -p "$root/reviews"
+  cat > "$root/contract.json" <<JSON
+{"contractId":"$(basename "$root")","riskLevel":"$risk"}
+JSON
+  cat > "$root/audit_summary.json" <<JSON
+{
+  "decision": "$decision",
+  "riskLevel": "$risk",
+  "agentReviewCoverage": {"codex": "ready"},
+  "agentReviewArtifacts": [".signum/contracts/$(basename "$root")/reviews/codex.json"]
+}
+JSON
+  cat > "$root/proofpack.json" <<JSON
+{
+  "decision": "$decision",
+  "riskLevel": "$risk",
+  "checks": {
+    "reviews": {
+      "codex": {
+        "content": {"provider": "codex", "reviewerType": "local_agent", "state": "ready"},
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "sizeBytes": 80,
+        "status": "present"
+      }
+    }
+  },
+  "artifactRefs": [{"path": "reviews/codex.json"}]
+}
+JSON
+  cat > "$root/reviews/codex.json" <<JSON
+{
+  "provider": "codex",
+  "reviewerType": "local_agent",
+  "state": "ready",
+  "verdict": "APPROVE",
+  "findings": [],
+  "summary": "No blocking findings."
+}
+JSON
+}
+
+run_checker() {
+  local root="$1" output="$2"
+  python3 "$CHECKER" --repo-root "$REPO_ROOT" --contract-root "$root" > "$output"
+}
+
+assert_json_field() {
+  local name="$1" file="$2" filter="$3" expected="$4" actual
+  actual="$(jq -r "$filter" "$file")"
+  if [ "$actual" = "$expected" ]; then
+    pass "$name"
+  else
+    fail "$name" "expected $expected, got $actual"
+  fi
+}
+
+assert_ok() {
+  local name="$1" root="$2" out="$3"
+  local output
+  if output="$(python3 "$CHECKER" --repo-root "$REPO_ROOT" --contract-root "$root" --json-output "$out" 2>&1)"; then
+    printf '%s\n' "$output" | jq empty
+    cmp -s "$out" <(printf '%s\n' "$output") || {
+      fail "$name" "--json-output differs from stdout"
+      return
+    }
+    pass "$name"
+  else
+    fail "$name" "$output"
+  fi
+}
+
+assert_fail_violation() {
+  local name="$1" root="$2" expected="$3" out="$4"
+  local output exit_code
+  set +e
+  output="$(python3 "$CHECKER" --repo-root "$REPO_ROOT" --contract-root "$root" > "$out" 2>&1)"
+  exit_code=$?
+  set -e
+  if [ "$exit_code" -eq 0 ]; then
+    fail "$name" "expected failure, got exit 0"
+    return
+  fi
+  jq empty "$out"
+  if jq -e --arg expected "$expected" '.violations | index($expected)' "$out" >/dev/null; then
+    pass "$name"
+  else
+    fail "$name" "missing violation $expected in $output"
+  fi
+}
+
+echo "=== Codex local agent review checker ==="
+
+python3 -m py_compile "$CHECKER"
+pass "checker py_compile"
+
+VALID="$WORK/project/.signum/contracts/sig-codex-valid"
+write_contract_root "$VALID" medium AUTO_OK
+assert_ok "medium AUTO_OK with Codex review passes" "$VALID" "$WORK/valid.json"
+assert_json_field "valid result is required" "$WORK/valid.json" '.required' "true"
+assert_json_field "valid hard gate passes" "$WORK/valid.json" '.hardGatePassed' "true"
+assert_json_field "valid proofpack includes Codex review" "$WORK/valid.json" '.checks.proofpackIncludesCodexReview' "true"
+
+LOW="$WORK/project/.signum/contracts/sig-codex-low"
+write_contract_root "$LOW" low AUTO_OK
+rm -f "$LOW/reviews/codex.json"
+jq 'del(.agentReviewCoverage, .agentReviewArtifacts)' "$LOW/audit_summary.json" > "$LOW/audit_summary.tmp" \
+  && mv "$LOW/audit_summary.tmp" "$LOW/audit_summary.json"
+jq 'del(.checks.reviews.codex, .artifactRefs)' "$LOW/proofpack.json" > "$LOW/proofpack.tmp" \
+  && mv "$LOW/proofpack.tmp" "$LOW/proofpack.json"
+assert_ok "low AUTO_OK without Codex review is not gated" "$LOW" "$WORK/low.json"
+assert_json_field "low result is not required" "$WORK/low.json" '.required' "false"
+
+HUMAN="$WORK/project/.signum/contracts/sig-codex-human"
+write_contract_root "$HUMAN" high HUMAN_REVIEW
+rm -f "$HUMAN/reviews/codex.json"
+jq 'del(.agentReviewCoverage, .agentReviewArtifacts)' "$HUMAN/audit_summary.json" > "$HUMAN/audit_summary.tmp" \
+  && mv "$HUMAN/audit_summary.tmp" "$HUMAN/audit_summary.json"
+jq 'del(.checks.reviews.codex, .artifactRefs)' "$HUMAN/proofpack.json" > "$HUMAN/proofpack.tmp" \
+  && mv "$HUMAN/proofpack.tmp" "$HUMAN/proofpack.json"
+assert_ok "high HUMAN_REVIEW without Codex review is not gated" "$HUMAN" "$WORK/human.json"
+
+MISSING="$WORK/project/.signum/contracts/sig-codex-missing"
+write_contract_root "$MISSING" medium AUTO_OK
+rm -f "$MISSING/reviews/codex.json"
+assert_fail_violation "missing Codex review file fails" "$MISSING" "codex_review.missing" "$WORK/missing-review.json"
+
+DEGRADED="$WORK/project/.signum/contracts/sig-codex-degraded"
+write_contract_root "$DEGRADED" medium AUTO_OK
+jq '.agentReviewCoverage.codex = "runtime_error"' "$DEGRADED/audit_summary.json" > "$DEGRADED/audit_summary.tmp" \
+  && mv "$DEGRADED/audit_summary.tmp" "$DEGRADED/audit_summary.json"
+assert_fail_violation "degraded Codex review coverage fails" "$DEGRADED" "agent_review.coverage_not_ready" "$WORK/degraded.json"
+
+UNRECORDED="$WORK/project/.signum/contracts/sig-codex-unrecorded"
+write_contract_root "$UNRECORDED" medium AUTO_OK
+jq 'del(.agentReviewArtifacts)' "$UNRECORDED/audit_summary.json" > "$UNRECORDED/audit_summary.tmp" \
+  && mv "$UNRECORDED/audit_summary.tmp" "$UNRECORDED/audit_summary.json"
+assert_fail_violation "missing audit artifact reference fails" "$UNRECORDED" "agent_review.artifact_not_recorded" "$WORK/unrecorded.json"
+
+UNPACKED="$WORK/project/.signum/contracts/sig-codex-unpacked"
+write_contract_root "$UNPACKED" medium AUTO_OK
+jq 'del(.checks.reviews.codex, .artifactRefs)' "$UNPACKED/proofpack.json" > "$UNPACKED/proofpack.tmp" \
+  && mv "$UNPACKED/proofpack.tmp" "$UNPACKED/proofpack.json"
+assert_fail_violation "missing proofpack Codex review evidence fails" "$UNPACKED" "proofpack.codex_review_missing" "$WORK/unpacked.json"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"

--- a/tests/test-codex-plugin-metadata.sh
+++ b/tests/test-codex-plugin-metadata.sh
@@ -134,6 +134,7 @@ if [ -f "$CODEX_SKILL" ]; then
   assert_contains "Codex skill requires local Codex agent review artifact" "$CODEX_SKILL" "Codex must produce an internal local agent-review artifact"
   assert_contains "Codex skill writes local Codex review artifact" "$CODEX_SKILL" ".signum/contracts/<contractId>/reviews/codex.json"
   assert_contains "Codex skill records local reviewer type" "$CODEX_SKILL" "reviewerType"
+  assert_contains "Codex skill runs local review gate" "$CODEX_SKILL" "scripts/check_codex_agent_review.py"
   assert_contains "Codex skill does not use final human review as audit review" "$CODEX_SKILL" "final human PR review is not a substitute"
   assert_contains "Codex skill emits reuse summary" "$CODEX_SKILL" "reuse_summary.json"
   assert_contains "Codex skill keeps project cache out of proofpack" "$CODEX_SKILL" 'Do not pack project-level `.signum/cache/` scanner cache files by default.'


### PR DESCRIPTION
## Linked intent

Link the Issue or Discussion this PR implements.

- Issue / Discussion: maintainer-directed follow-up from Codex local agent-review protocol work
- Closes/Fixes/Resolves: N/A

For non-trivial changes, open an Issue or Discussion before code review. Direct PRs are intended only for typo/docs fixes, small test-only changes, clearly scoped bug fixes, or maintainer-approved work.

## Problem

The Codex prompt now requires an internal local agent-review artifact for non-trivial medium/high-risk work, but that rule was still easy to miss manually. A deterministic check is needed before a Codex run can safely claim `AUTO_OK`.

## Why now

PR #109 made the Codex review artifact contract explicit. This PR adds the smallest deterministic guard for that contract so future runs can verify the evidence exists instead of relying on prompt memory alone.

## Existing options checked

The existing Codex prompt eval catches simulated invariant failures, but it does not validate a real contract artifact root after a run. The proofpack validator checks general proofpack shape, but not the Codex-local review evidence requirement.

## Alternatives considered

- Wire the checker into CI/runtime immediately: deferred to keep this PR narrow and avoid changing global CI behavior.
- Extend scanner or policy rules: not relevant; this is an audit artifact evidence check.
- Depend only on prompt text: insufficient because the missing artifact case should be machine-checkable.

## No-code alternative

The prompt text already documents the rule. That helps but does not prevent missing local review evidence from slipping through.

## Why code is needed

A small checker can validate the actual `.signum/contracts/<contractId>/` artifact root and fail deterministically when medium/high `AUTO_OK` lacks Codex local review evidence.

## Summary

- Adds `scripts/check_codex_agent_review.py`.
- For medium/high `AUTO_OK`, validates ready Codex coverage, `reviews/codex.json`, audit artifact refs, and proofpack evidence.
- Allows low-risk and non-`AUTO_OK` runs to bypass this gate.
- Adds shell coverage for happy path, bypasses, and missing/degraded evidence failures.
- Updates the Codex skill to run the checker before accepting medium/high `AUTO_OK`.

## Type

Mark all that apply.

- [ ] docs
- [ ] deterministic core / `lib`
- [x] prompt / orchestration
- [ ] init / harness
- [ ] schema / compatibility
- [ ] release / marketplace wiring
- [x] tests
- [ ] fix
- [ ] refactor
- [ ] other

## Scope

In:
- Codex local review evidence checker
- Codex prompt reference to the checker
- Checker and metadata tests

Out:
- Scanner/catalog behavior
- Claude overlay runtime files
- Commands/runtime pipeline wiring
- CI wiring
- Eval baseline updates
- signum-evolve behavior

## Risk areas

Mark anything touched in this PR.

- [ ] public API
- [ ] dependency change
- [ ] CI/workflow change
- [ ] auth/security
- [ ] database/schema
- [ ] runtime behavior
- [ ] docs-only
- [ ] test-only
- [ ] `commands/signum.md`
- [ ] `commands/init.md`
- [ ] `agents/*`
- [ ] `lib/*`
- [ ] `lib/schemas/*`
- [ ] `.github/workflows/*`
- [x] none of the above

## Docs impact

- [ ] no docs update needed
- [ ] `README.md` or `QUICKSTART.md` updated
- [ ] `AGENTS.md` updated
- [ ] `docs/how-it-works.md` or `docs/reference.md` updated
- [ ] `docs/SECURITY.md` updated
- [x] follow-up docs work is needed

Docs / rationale:
- The Codex skill prompt documents the checker. Broader user docs can follow if this becomes part of canonical runtime wiring.

## Validation / proof

- [ ] not applicable yet (explain below)
- [x] targeted shell tests
- [x] full test run
- [x] eval / fixture run
- [ ] doc walkthrough
- [x] command output
- [ ] other

Commands run:

```text
python3 -m py_compile scripts/check_codex_agent_review.py
bash tests/test-codex-agent-review-check.sh
bash tests/test-codex-plugin-metadata.sh
bash tests/test-codex-prompt-evals.sh
bash tests/test-codex-prompt-eval-compare.sh
bash scripts/run-deterministic-tests.sh
```

Observed:

```text
tests/test-codex-agent-review-check.sh: 12 passed, 0 failed
tests/test-codex-plugin-metadata.sh: 62 passed, 0 failed
scripts/run-deterministic-tests.sh: Deterministic tests passed.
```

## DCO / authorship

- [x] Every commit in this PR is signed off (`git commit -s`) and complies with `DCO.md`

## Reviewer notes

This PR intentionally does not wire the checker into global CI or the root command runtime. It adds the deterministic checker and Codex prompt call site first, keeping behavior changes bounded.
