### PR TITLE
chore(release): require version bumps for runtime changes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,5 @@
   "license": "MIT",
   "name": "signum",
   "repository": "https://github.com/heurema/signum",
-  "version": "4.21.7"
+  "version": "4.21.8"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signum",
-  "version": "4.21.7",
+  "version": "4.21.8",
   "description": "Evidence-driven development pipeline with multi-model code review",
   "author": {
     "name": "heurema",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Checkout
         # pinned from actions/checkout@v4
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
 
       - name: Tool versions
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
 
+## [4.21.8] - 2026-05-16
+
+### Added
+- Deterministic version-bump guard now requires runtime/plugin surface changes to increase the Signum plugin version.
+
+### Changed
+- Signum plugin metadata and proofpack fixtures now report version `4.21.8`.
+
 ## [4.21.7] - 2026-05-08
 
 ### Added

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -29,7 +29,7 @@ Sparse paths: leave blank
 
 After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**.
 
-The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.7` or a newer release tag.
+The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.8` or a newer release tag.
 
 ## 2. Run Your First Pipeline
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ Run the deterministic test suite:
 bash scripts/run-deterministic-tests.sh
 ```
 
+The suite includes `scripts/check_version_bump.py`, which fails runtime/plugin
+surface changes unless `.claude-plugin/plugin.json` increases the Signum plugin
+version.
+
 Useful focused checks while editing docs:
 
 ```bash

--- a/commands/signum.fragments/100-phase-pack.md
+++ b/commands/signum.fragments/100-phase-pack.md
@@ -434,7 +434,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.7" \
+  --arg signumVersion "4.21.8" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/commands/signum.fragments/20-explain-mode.md
+++ b/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.7",
+  "version": "4.21.8",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -46,7 +46,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.7",
+  "version": "4.21.8",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -4158,7 +4158,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.7" \
+  --arg signumVersion "4.21.8" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -13,6 +13,7 @@ review_cadence: quarterly
 | --- | --- | --- | --- |
 | Run `/signum <task>` end-to-end | Core product promise | `commands/signum.md`, `agents/`, `lib/`, schemas | README + reference docs + deterministic shell tests |
 | Fresh marketplace install resolves current Signum release | Users should not install a stale registry target after a version bump | `.claude-plugin/plugin.json`, `.agents/plugins/marketplace.json`, `.codex-plugin/plugin.json`, `platforms/codex/.codex-plugin/plugin.json`, `platforms/codex/SKILL.md`, `heurema/emporium/.claude-plugin/marketplace.json`, `lib/update-emporium-marketplace.sh`, `lib/check-emporium-sync.sh`, `.github/workflows/release-guardrails.yml` | `bash lib/release-smoke.sh`, `bash tests/test-emporium-sync.sh`, `bash tests/test-update-emporium-marketplace.sh`, `bash tests/test-codex-plugin-metadata.sh`; CI syncs first, then verifies |
+| Runtime/plugin changes carry a visible release version | Marketplace installs and proofpacks should not silently drift after behavior or plugin surface changes | `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `platforms/codex/.codex-plugin/plugin.json`, `commands/`, `agents/`, `lib/`, `scripts/`, platform overlays | `python3 scripts/check_version_bump.py --repo-root .`, `bash tests/test-version-bump-required.sh` |
 | Generate correct runtime artifacts in `.signum/` | Needed for auditability and CI gating | `commands/signum.md`, `lib/`, `.signum/` artifact contract | `docs/reference.md`, `docs/how-it-works.md` |
 | Bootstrap project context with `/signum init` | Reduces missing-context failures in downstream repos | `commands/init.md`, `agents/init-synthesizer.md`, `lib/init-scanner.sh`, `lib/init-harness-scaffold.sh` | `tests/test-init.sh`, `tests/test-init-harness-scaffold.sh` |
 | Keep root docs and overlays aligned | Prevents trust loss from doc drift | `docs/reference.md`, `docs/overlay-deviations.json`, `lib/doc-parity-check.sh` | `tests/test-doc-parity.sh`, `.github/workflows/doc-parity.yml` |
@@ -29,6 +30,7 @@ review_cadence: quarterly
 | --- | --- | --- |
 | Canonical docs drift from actual behavior | `lib/doc-parity-check.sh` warnings | Fix docs or record a documented deviation |
 | Deterministic script regression | Failing `tests/test-*.sh` | Reproduce in shell, patch script, add/update regression test |
+| Runtime/plugin surface changed without plugin version bump | `scripts/check_version_bump.py` through deterministic tests | Increase `.claude-plugin/plugin.json` and matching Codex/overlay plugin metadata, then update generated command/proofpack fixtures |
 | Emporium registry drifts from Signum release metadata | `bash lib/release-smoke.sh`, `.github/workflows/release-guardrails.yml` | Let `Sync Emporium marketplace entry` update the registry automatically; if drift remains, update `heurema/emporium/.claude-plugin/marketplace.json` so `version` and `source.ref` match the local release |
 | Init/bootstrap drift | `tests/test-init.sh`, `tests/test-init-harness-scaffold.sh` | Keep scanner/scaffold deterministic, avoid LLM-only behavior for structure |
 | Overlay divergence becomes accidental | Parity warnings and deviation review | Promote to root, remove from overlay, or document in `docs/overlay-deviations.json` |
@@ -36,6 +38,8 @@ review_cadence: quarterly
 
 ## Operational Checks
 - `bash lib/release-smoke.sh`
+- `python3 scripts/check_version_bump.py --repo-root .`
+- `bash tests/test-version-bump-required.sh`
 - `bash tests/test-codex-plugin-metadata.sh`
 - `bash tests/test-emporium-sync.sh`
 - `bash tests/test-update-emporium-marketplace.sh`

--- a/examples/proofpack-validation/valid-proofpack.json
+++ b/examples/proofpack-validation/valid-proofpack.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.7",
+  "signumVersion": "4.21.8",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-example01",
   "contractId": "sig-proofpack-example-001",

--- a/platforms/claude-code/.claude-plugin/plugin.json
+++ b/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "signum",
   "description": "Evidence-driven development pipeline with multi-model code review",
-  "version": "4.21.7",
+  "version": "4.21.8",
   "author": {
     "name": "heurema"
   },

--- a/platforms/claude-code/CHANGELOG.md
+++ b/platforms/claude-code/CHANGELOG.md
@@ -5,6 +5,14 @@
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
 
+## [4.21.8] - 2026-05-16
+
+### Added
+- Deterministic version-bump guard now requires runtime/plugin surface changes to increase the Signum plugin version.
+
+### Changed
+- Signum plugin metadata and proofpack fixtures now report version `4.21.8`.
+
 ## [4.21.7] - 2026-05-08
 
 ### Added

--- a/platforms/claude-code/QUICKSTART.md
+++ b/platforms/claude-code/QUICKSTART.md
@@ -29,7 +29,7 @@ Sparse paths: leave blank
 
 After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**.
 
-The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.7` or a newer release tag.
+The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.8` or a newer release tag.
 
 ## 2. Run Your First Pipeline
 

--- a/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
+++ b/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
@@ -434,7 +434,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.7" \
+  --arg signumVersion "4.21.8" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
+++ b/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.7",
+  "version": "4.21.8",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -47,7 +47,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.7",
+  "version": "4.21.8",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -4180,7 +4180,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.7" \
+  --arg signumVersion "4.21.8" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/codex/.codex-plugin/plugin.json
+++ b/platforms/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signum",
-  "version": "4.21.7",
+  "version": "4.21.8",
   "description": "Evidence-driven development pipeline with multi-model code review",
   "author": {
     "name": "heurema",

--- a/scripts/check_version_bump.py
+++ b/scripts/check_version_bump.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Require a plugin version bump for runtime/plugin surface changes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+SCHEMA_VERSION = "1.0"
+PLUGIN_MANIFEST = ".claude-plugin/plugin.json"
+SENSITIVE_PREFIXES = (
+    "agents/",
+    "commands/",
+    "lib/",
+    "platforms/claude-code/agents/",
+    "platforms/claude-code/commands/",
+    "platforms/claude-code/lib/",
+    "platforms/claude-code/scripts/",
+    "platforms/codex/",
+    "scripts/",
+)
+SENSITIVE_EXACT = {
+    ".agents/plugins/marketplace.json",
+    ".claude-plugin/plugin.json",
+    ".codex-plugin/plugin.json",
+    "platforms/claude-code/.claude-plugin/plugin.json",
+}
+SEMVER_RE = re.compile(r"^([0-9]+)\.([0-9]+)\.([0-9]+)$")
+
+
+def run_git(repo_root: Path, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"git {' '.join(args)} failed")
+    return result
+
+
+def repo_rel(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def resolve_base_ref(repo_root: Path, explicit: str | None) -> tuple[str | None, str | None]:
+    if explicit:
+        result = run_git(repo_root, ["rev-parse", "--verify", f"{explicit}^{{commit}}"], check=False)
+        return (explicit, None) if result.returncode == 0 else (explicit, "base_ref_unavailable")
+
+    env_ref = os.environ.get("SIGNUM_VERSION_BUMP_BASE")
+    if env_ref:
+        result = run_git(repo_root, ["rev-parse", "--verify", f"{env_ref}^{{commit}}"], check=False)
+        return (env_ref, None) if result.returncode == 0 else (env_ref, "base_ref_unavailable")
+
+    for ref in ("origin/main", "HEAD^"):
+        result = run_git(repo_root, ["rev-parse", "--verify", f"{ref}^{{commit}}"], check=False)
+        if result.returncode == 0:
+            return ref, None
+    return None, "base_ref_unavailable"
+
+
+def load_current_version(repo_root: Path) -> str | None:
+    path = repo_root / PLUGIN_MANIFEST
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    value = data.get("version")
+    return value if isinstance(value, str) else None
+
+
+def load_base_version(repo_root: Path, base_ref: str) -> str | None:
+    result = run_git(repo_root, ["show", f"{base_ref}:{PLUGIN_MANIFEST}"], check=False)
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    value = data.get("version")
+    return value if isinstance(value, str) else None
+
+
+def parse_semver(version: str | None) -> tuple[int, int, int] | None:
+    if not version:
+        return None
+    match = SEMVER_RE.match(version)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def changed_files(repo_root: Path, base_ref: str) -> list[str]:
+    result = run_git(repo_root, ["diff", "--name-only", base_ref, "--"])
+    files = {repo_rel(line) for line in result.stdout.splitlines() if line.strip()}
+    untracked = run_git(repo_root, ["ls-files", "--others", "--exclude-standard"])
+    files.update(repo_rel(line) for line in untracked.stdout.splitlines() if line.strip())
+    return sorted(files)
+
+
+def is_sensitive(path: str) -> bool:
+    return path in SENSITIVE_EXACT or any(path.startswith(prefix) for prefix in SENSITIVE_PREFIXES)
+
+
+def check(repo_root: Path, base_ref_arg: str | None) -> dict:
+    base_ref, skip_reason = resolve_base_ref(repo_root, base_ref_arg)
+    current_version = load_current_version(repo_root)
+    report = {
+        "schemaVersion": SCHEMA_VERSION,
+        "status": "ok",
+        "baseRef": base_ref,
+        "baseVersion": None,
+        "currentVersion": current_version,
+        "versionBumpRequired": False,
+        "hardGatePassed": True,
+        "sensitiveChangedFiles": [],
+        "violations": [],
+    }
+
+    if skip_reason is not None:
+        report["status"] = "skipped"
+        report["violations"] = []
+        report["skipReason"] = skip_reason
+        return report
+
+    base_version = load_base_version(repo_root, base_ref)
+    sensitive = [path for path in changed_files(repo_root, base_ref) if is_sensitive(path)]
+    report["baseVersion"] = base_version
+    report["sensitiveChangedFiles"] = sensitive
+    report["versionBumpRequired"] = bool(sensitive)
+
+    if not sensitive:
+        return report
+
+    base_semver = parse_semver(base_version)
+    current_semver = parse_semver(current_version)
+    violations: list[dict[str, str]] = []
+
+    if base_semver is None:
+        violations.append({"id": "version.base_unreadable", "message": f"cannot read semver from {base_ref}:{PLUGIN_MANIFEST}"})
+    if current_semver is None:
+        violations.append({"id": "version.current_unreadable", "message": f"cannot read semver from {PLUGIN_MANIFEST}"})
+    if base_semver is not None and current_semver is not None and current_semver <= base_semver:
+        violations.append(
+            {
+                "id": "version.bump_required",
+                "message": "runtime/plugin changes require .claude-plugin/plugin.json version to increase",
+            }
+        )
+
+    if violations:
+        report["status"] = "error"
+        report["hardGatePassed"] = False
+        report["violations"] = violations
+    return report
+
+
+def write_report(report: dict, output: Path | None) -> None:
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if output:
+        output.write_text(encoded, encoding="utf-8")
+    else:
+        sys.stdout.write(encoded)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="repository root to inspect")
+    parser.add_argument("--base-ref", help="base git ref to compare against")
+    parser.add_argument("--json-output", help="write deterministic JSON report to this path")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    repo_root = Path(args.repo_root).resolve()
+    output = Path(args.json_output) if args.json_output else None
+    try:
+        report = check(repo_root, args.base_ref)
+    except Exception as exc:  # pragma: no cover - defensive CLI boundary
+        report = {
+            "schemaVersion": SCHEMA_VERSION,
+            "status": "error",
+            "baseRef": args.base_ref,
+            "baseVersion": None,
+            "currentVersion": None,
+            "versionBumpRequired": False,
+            "hardGatePassed": False,
+            "sensitiveChangedFiles": [],
+            "violations": [{"id": "version.check_failed", "message": str(exc)}],
+        }
+    write_report(report, output)
+    return 0 if report.get("hardGatePassed") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/proofpack/invalid-removal-evidence.json
+++ b/tests/fixtures/proofpack/invalid-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.7",
+  "signumVersion": "4.21.8",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-bad-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-artifact-ref.json
+++ b/tests/fixtures/proofpack/missing-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.7",
+  "signumVersion": "4.21.8",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-required.json
+++ b/tests/fixtures/proofpack/missing-required.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.7",
+  "signumVersion": "4.21.8",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/schema-version-mismatch.json
+++ b/tests/fixtures/proofpack/schema-version-mismatch.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.7",
-  "signumVersion": "4.21.7",
+  "signumVersion": "4.21.8",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/unsafe-artifact-path.json
+++ b/tests/fixtures/proofpack/unsafe-artifact-path.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.7",
+  "signumVersion": "4.21.8",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-minimal.json
+++ b/tests/fixtures/proofpack/valid-minimal.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.7",
+  "signumVersion": "4.21.8",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-artifact-ref.json
+++ b/tests/fixtures/proofpack/valid-with-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.7",
+  "signumVersion": "4.21.8",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-removal-evidence.json
+++ b/tests/fixtures/proofpack/valid-with-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.7",
+  "signumVersion": "4.21.8",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/wrong-type.json
+++ b/tests/fixtures/proofpack/wrong-type.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.7",
+  "signumVersion": "4.21.8",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/test-ci-workflow.sh
+++ b/tests/test-ci-workflow.sh
@@ -94,6 +94,15 @@ assert_true(
     "workflow must call scripts/run-deterministic-tests.sh",
 )
 assert_true(
+    "ci workflow fetches history for version-bump guard",
+    re.search(
+        r"(?ms)uses:\s*actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5\s*\n\s*with:\s*\n\s*fetch-depth:\s*0\s*$",
+        workflow_text,
+    )
+    is not None,
+    "checkout must fetch enough history for scripts/check_version_bump.py to compare against origin/main",
+)
+assert_true(
     "ci workflow does not duplicate clean-room smoke step",
     "run-cleanroom-smoke.sh" not in workflow_text,
     "clean-room smoke should be reached through the deterministic runner, not a second workflow step",

--- a/tests/test-version-bump-required.sh
+++ b/tests/test-version-bump-required.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# test-version-bump-required.sh -- require plugin version bumps for runtime/plugin diffs
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECKER="$REPO_ROOT/scripts/check_version_bump.py"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+passed=0
+failed=0
+
+pass() {
+  printf '  PASS: %s\n' "$1"
+  passed=$((passed + 1))
+}
+
+fail() {
+  printf '  FAIL: %s -- %s\n' "$1" "$2"
+  failed=$((failed + 1))
+}
+
+assert_json_eq() {
+  local name="$1" file="$2" filter="$3" expected="$4" actual
+  actual="$(jq -r "$filter" "$file")"
+  if [ "$actual" = "$expected" ]; then
+    pass "$name"
+  else
+    fail "$name" "expected $expected, got $actual"
+  fi
+}
+
+run_checker() {
+  local repo="$1" base="$2" out="$3"
+  python3 "$CHECKER" --repo-root "$repo" --base-ref "$base" --json-output "$out"
+}
+
+REPO="$TMP_DIR/repo"
+git init -q "$REPO"
+cd "$REPO"
+git config user.name "Signum Test"
+git config user.email "signum-test@example.invalid"
+
+mkdir -p .claude-plugin
+cat > .claude-plugin/plugin.json <<'JSON'
+{
+  "name": "signum",
+  "version": "1.0.0"
+}
+JSON
+
+git add .claude-plugin/plugin.json
+git commit -q -m "initial"
+BASE_REF="HEAD"
+
+mkdir -p docs
+printf 'docs only\n' > docs/readme.md
+DOCS_REPORT="$TMP_DIR/docs.json"
+if run_checker "$REPO" "$BASE_REF" "$DOCS_REPORT"; then
+  pass "docs-only change does not require version bump"
+else
+  fail "docs-only change does not require version bump" "checker failed"
+fi
+assert_json_eq "docs-only hard gate passes" "$DOCS_REPORT" ".hardGatePassed" "true"
+assert_json_eq "docs-only does not require bump" "$DOCS_REPORT" ".versionBumpRequired" "false"
+rm -rf docs
+
+mkdir -p lib
+printf '#!/usr/bin/env bash\n' > lib/runtime.sh
+NO_BUMP_REPORT="$TMP_DIR/no-bump.json"
+if run_checker "$REPO" "$BASE_REF" "$NO_BUMP_REPORT"; then
+  fail "runtime change without version bump fails" "checker unexpectedly passed"
+else
+  pass "runtime change without version bump fails"
+fi
+assert_json_eq "runtime no-bump hard gate fails" "$NO_BUMP_REPORT" ".hardGatePassed" "false"
+assert_json_eq "runtime no-bump reports version requirement" "$NO_BUMP_REPORT" ".versionBumpRequired" "true"
+assert_json_eq "runtime no-bump reports violation" "$NO_BUMP_REPORT" ".violations[0].id" "version.bump_required"
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+path = Path(".claude-plugin/plugin.json")
+data = json.loads(path.read_text(encoding="utf-8"))
+data["version"] = "1.0.1"
+path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+BUMP_REPORT="$TMP_DIR/bump.json"
+if run_checker "$REPO" "$BASE_REF" "$BUMP_REPORT"; then
+  pass "runtime change with version bump passes"
+else
+  fail "runtime change with version bump passes" "checker failed"
+fi
+assert_json_eq "runtime bump hard gate passes" "$BUMP_REPORT" ".hardGatePassed" "true"
+assert_json_eq "runtime bump current version" "$BUMP_REPORT" ".currentVersion" "1.0.1"
+
+UNKNOWN_REPORT="$TMP_DIR/unknown.json"
+if python3 "$CHECKER" --repo-root "$REPO" --base-ref missing-ref --json-output "$UNKNOWN_REPORT"; then
+  pass "missing base ref skips without blocking"
+else
+  fail "missing base ref skips without blocking" "checker failed"
+fi
+assert_json_eq "missing base ref status is skipped" "$UNKNOWN_REPORT" ".status" "skipped"
+assert_json_eq "missing base ref hard gate passes" "$UNKNOWN_REPORT" ".hardGatePassed" "true"
+
+CURRENT_REPORT="$TMP_DIR/current-repo.json"
+if python3 "$CHECKER" --repo-root "$REPO_ROOT" --json-output "$CURRENT_REPORT"; then
+  pass "current repository version-bump guard passes"
+else
+  fail "current repository version-bump guard passes" "checker failed for current repository diff"
+fi
+assert_json_eq "current repository report has hard gate" "$CURRENT_REPORT" ".hardGatePassed" "true"
+assert_json_eq "current repository report has deterministic schema" "$CURRENT_REPORT" ".schemaVersion" "1.0"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+
+echo "ALL PASSED"


### PR DESCRIPTION
## Linked intent

Link the Issue or Discussion this PR implements.

- Issue / Discussion: maintainer-requested release hygiene fix
- Closes/Fixes/Resolves:

For non-trivial changes, open an Issue or Discussion before code review. Direct PRs are intended only for typo/docs fixes, small test-only changes, clearly scoped bug fixes, or maintainer-approved work.

## Problem

Signum runtime/plugin updates could pass with stale plugin metadata, leaving Codex/Claude marketplace installs and proofpack examples pointing at an older release version.

## Why now

The local development symlink path was removed so Signum should be consumed through the installed plugin/marketplace path. That makes version hygiene more important: runtime/plugin surface changes need a visible release bump before adoption.

## Existing options checked

Existing metadata consistency tests verified that current files agree with each other, but did not compare the branch against a base ref to require a version increase when runtime/plugin-sensitive files changed.

## Alternatives considered

- Manual release checklist only: insufficient because the missed bump should fail automatically.
- Release-only Emporium sync check: useful for registry drift, but too late for PR-time runtime/plugin diffs.

## No-code alternative

Documenting the requirement would help maintainers, but would not prevent another stale version from passing deterministic tests.

## Why code is needed

A deterministic checker can inspect changed paths against the base ref and fail PR tests when runtime/plugin-sensitive diffs do not increase `.claude-plugin/plugin.json` semver.

## Summary

- Bumps Signum plugin/runtime metadata from `4.21.7` to `4.21.8` across root, Codex, and Claude overlay surfaces.
- Updates rendered `/signum` command metadata and proofpack fixtures to `4.21.8`.
- Adds `scripts/check_version_bump.py` and `tests/test-version-bump-required.sh`.
- Fetches full CI checkout history so the version-bump checker can compare against the base ref.
- Documents the version-bump guard in README and reliability docs.

## Type

Mark all that apply.

- [x] docs
- [ ] deterministic core / `lib`
- [ ] prompt / orchestration
- [ ] init / harness
- [ ] schema / compatibility
- [x] release / marketplace wiring
- [x] tests
- [x] fix
- [ ] refactor
- [ ] other

## Scope

In:
- Signum version bump to `4.21.8`.
- Deterministic PR-time guard for runtime/plugin surface changes without a version bump.
- CI checkout history required by that guard.

Out:
- Scanner behavior changes.
- Policy rule changes.
- Codex prompt changes.
- Emporium registry commit/tag publication; those remain follow-up release steps after this lands.

## Risk areas

Mark anything touched in this PR.

- [ ] public API
- [ ] dependency change
- [x] CI/workflow change
- [ ] auth/security
- [ ] database/schema
- [x] runtime behavior
- [ ] docs-only
- [ ] test-only
- [x] `commands/signum.md`
- [ ] `commands/init.md`
- [ ] `agents/*`
- [ ] `lib/*`
- [ ] `lib/schemas/*`
- [x] `.github/workflows/*`
- [ ] none of the above

## Docs impact

- [ ] no docs update needed
- [x] `README.md` or `QUICKSTART.md` updated
- [ ] `AGENTS.md` updated
- [ ] `docs/how-it-works.md` or `docs/reference.md` updated
- [ ] `docs/SECURITY.md` updated
- [ ] follow-up docs work is needed

Docs / rationale:
- README and reliability docs now name the version-bump guard and focused check command.
- Quickstart pinned install references now point at `v4.21.8`.

## Validation / proof

- [ ] not applicable yet (explain below)
- [x] targeted shell tests
- [x] full test run
- [ ] eval / fixture run
- [x] doc walkthrough
- [x] command output
- [ ] other

Commands run:

```text
python3 -m py_compile scripts/check_version_bump.py
bash tests/test-version-bump-required.sh
bash tests/test-ci-workflow.sh
bash tests/test-metadata-consistency.sh
bash tests/test-codex-plugin-metadata.sh
bash tests/test-proofpack-validation.sh
bash tests/test-signum-command-renderer.sh
bash tests/test-signum-fragment-parity.sh
EMPORIUM_MARKETPLACE_PATH=/Users/vi/personal/heurema/emporium/.claude-plugin/marketplace.json bash lib/check-emporium-sync.sh
bash scripts/run-deterministic-tests.sh
```

Relevant results:

```text
Plugin version: 4.21.8
Proofpack schema version: 4.8
Deterministic tests passed.
OK: Emporium entry matches local Signum release metadata.
```

## DCO / authorship

- [x] Every commit in this PR is signed off (`git commit -s`) and complies with `DCO.md`

## Reviewer notes

- `scripts/check_version_bump.py` intentionally treats `commands/`, `agents/`, `lib/`, `scripts/`, Codex plugin surfaces, and Claude overlay runtime/plugin surfaces as version-sensitive.
- The external Emporium registry still needs a separate clean commit after this lands and the `v4.21.8` tag exists.
