### PR TITLE
fix(release): compare version bumps from branch base

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,5 @@
   "license": "MIT",
   "name": "signum",
   "repository": "https://github.com/heurema/signum",
-  "version": "4.21.8"
+  "version": "4.21.9"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signum",
-  "version": "4.21.8",
+  "version": "4.21.9",
   "description": "Evidence-driven development pipeline with multi-model code review",
   "author": {
     "name": "heurema",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
 
+## [4.21.9] - 2026-05-16
+
+### Fixed
+- Version-bump guard now compares feature branches from the merge base and push events from the GitHub `before` SHA, avoiding base-tip and last-commit blind spots.
+
+### Changed
+- Signum plugin metadata and proofpack fixtures now report version `4.21.9`.
+
 ## [4.21.8] - 2026-05-16
 
 ### Added

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -29,7 +29,7 @@ Sparse paths: leave blank
 
 After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**.
 
-The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.8` or a newer release tag.
+The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.9` or a newer release tag.
 
 ## 2. Run Your First Pipeline
 

--- a/commands/signum.fragments/100-phase-pack.md
+++ b/commands/signum.fragments/100-phase-pack.md
@@ -434,7 +434,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.8" \
+  --arg signumVersion "4.21.9" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/commands/signum.fragments/20-explain-mode.md
+++ b/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.8",
+  "version": "4.21.9",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -46,7 +46,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.8",
+  "version": "4.21.9",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -4158,7 +4158,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.8" \
+  --arg signumVersion "4.21.9" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/examples/proofpack-validation/valid-proofpack.json
+++ b/examples/proofpack-validation/valid-proofpack.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.8",
+  "signumVersion": "4.21.9",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-example01",
   "contractId": "sig-proofpack-example-001",

--- a/platforms/claude-code/.claude-plugin/plugin.json
+++ b/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "signum",
   "description": "Evidence-driven development pipeline with multi-model code review",
-  "version": "4.21.8",
+  "version": "4.21.9",
   "author": {
     "name": "heurema"
   },

--- a/platforms/claude-code/CHANGELOG.md
+++ b/platforms/claude-code/CHANGELOG.md
@@ -5,6 +5,14 @@
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
 
+## [4.21.9] - 2026-05-16
+
+### Fixed
+- Version-bump guard now compares feature branches from the merge base and push events from the GitHub `before` SHA, avoiding base-tip and last-commit blind spots.
+
+### Changed
+- Signum plugin metadata and proofpack fixtures now report version `4.21.9`.
+
 ## [4.21.8] - 2026-05-16
 
 ### Added

--- a/platforms/claude-code/QUICKSTART.md
+++ b/platforms/claude-code/QUICKSTART.md
@@ -29,7 +29,7 @@ Sparse paths: leave blank
 
 After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**.
 
-The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.8` or a newer release tag.
+The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.9` or a newer release tag.
 
 ## 2. Run Your First Pipeline
 

--- a/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
+++ b/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
@@ -434,7 +434,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.8" \
+  --arg signumVersion "4.21.9" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
+++ b/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.8",
+  "version": "4.21.9",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -47,7 +47,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.8",
+  "version": "4.21.9",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -4180,7 +4180,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.8" \
+  --arg signumVersion "4.21.9" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/codex/.codex-plugin/plugin.json
+++ b/platforms/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signum",
-  "version": "4.21.8",
+  "version": "4.21.9",
   "description": "Evidence-driven development pipeline with multi-model code review",
   "author": {
     "name": "heurema",

--- a/scripts/check_version_bump.py
+++ b/scripts/check_version_bump.py
@@ -10,7 +10,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, NamedTuple
 
 
 SCHEMA_VERSION = "1.0"
@@ -33,6 +33,15 @@ SENSITIVE_EXACT = {
     "platforms/claude-code/.claude-plugin/plugin.json",
 }
 SEMVER_RE = re.compile(r"^([0-9]+)\.([0-9]+)\.([0-9]+)$")
+ZERO_SHA_RE = re.compile(r"^0+$")
+
+
+class BaseSelection(NamedTuple):
+    display_ref: str | None
+    comparison_ref: str | None
+    mode: str | None
+    source: str | None
+    skip_reason: str | None
 
 
 def run_git(repo_root: Path, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -56,21 +65,64 @@ def repo_rel(path: str) -> str:
     return normalized
 
 
-def resolve_base_ref(repo_root: Path, explicit: str | None) -> tuple[str | None, str | None]:
+def verify_commit(repo_root: Path, ref: str) -> bool:
+    result = run_git(repo_root, ["rev-parse", "--verify", f"{ref}^{{commit}}"], check=False)
+    return result.returncode == 0
+
+
+def merge_base(repo_root: Path, ref: str) -> str | None:
+    result = run_git(repo_root, ["merge-base", ref, "HEAD"], check=False)
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def push_event_before_ref(repo_root: Path) -> str | None:
+    if os.environ.get("GITHUB_EVENT_NAME") != "push":
+        return None
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return None
+    try:
+        event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    before = event.get("before")
+    if not isinstance(before, str) or not before or ZERO_SHA_RE.match(before):
+        return None
+    return before if verify_commit(repo_root, before) else None
+
+
+def branch_base_selection(repo_root: Path, ref: str, source: str) -> BaseSelection:
+    if not verify_commit(repo_root, ref):
+        return BaseSelection(ref, None, None, source, "base_ref_unavailable")
+    base = merge_base(repo_root, ref)
+    if base is None:
+        return BaseSelection(ref, None, None, source, "base_ref_unavailable")
+    return BaseSelection(ref, base, "merge_base", source, None)
+
+
+def resolve_base_ref(repo_root: Path, explicit: str | None) -> BaseSelection:
     if explicit:
-        result = run_git(repo_root, ["rev-parse", "--verify", f"{explicit}^{{commit}}"], check=False)
-        return (explicit, None) if result.returncode == 0 else (explicit, "base_ref_unavailable")
+        return branch_base_selection(repo_root, explicit, "argument")
 
     env_ref = os.environ.get("SIGNUM_VERSION_BUMP_BASE")
     if env_ref:
-        result = run_git(repo_root, ["rev-parse", "--verify", f"{env_ref}^{{commit}}"], check=False)
-        return (env_ref, None) if result.returncode == 0 else (env_ref, "base_ref_unavailable")
+        return branch_base_selection(repo_root, env_ref, "environment")
 
-    for ref in ("origin/main", "HEAD^"):
-        result = run_git(repo_root, ["rev-parse", "--verify", f"{ref}^{{commit}}"], check=False)
-        if result.returncode == 0:
-            return ref, None
-    return None, "base_ref_unavailable"
+    push_before = push_event_before_ref(repo_root)
+    if push_before:
+        return BaseSelection(push_before, push_before, "direct", "github_push_before", None)
+
+    if os.environ.get("GITHUB_EVENT_NAME") == "push" and os.environ.get("GITHUB_EVENT_PATH"):
+        return BaseSelection(None, None, None, "github_push_before", "base_ref_unavailable")
+
+    for ref in ("origin/main", "main"):
+        selection = branch_base_selection(repo_root, ref, "default_branch")
+        if selection.skip_reason is None:
+            return selection
+    return BaseSelection(None, None, None, None, "base_ref_unavailable")
 
 
 def load_current_version(repo_root: Path) -> str | None:
@@ -106,8 +158,8 @@ def parse_semver(version: str | None) -> tuple[int, int, int] | None:
     return tuple(int(part) for part in match.groups())
 
 
-def changed_files(repo_root: Path, base_ref: str) -> list[str]:
-    result = run_git(repo_root, ["diff", "--name-only", base_ref, "--"])
+def changed_files(repo_root: Path, comparison_ref: str) -> list[str]:
+    result = run_git(repo_root, ["diff", "--name-only", comparison_ref, "--"])
     files = {repo_rel(line) for line in result.stdout.splitlines() if line.strip()}
     untracked = run_git(repo_root, ["ls-files", "--others", "--exclude-standard"])
     files.update(repo_rel(line) for line in untracked.stdout.splitlines() if line.strip())
@@ -119,12 +171,14 @@ def is_sensitive(path: str) -> bool:
 
 
 def check(repo_root: Path, base_ref_arg: str | None) -> dict:
-    base_ref, skip_reason = resolve_base_ref(repo_root, base_ref_arg)
+    base = resolve_base_ref(repo_root, base_ref_arg)
     current_version = load_current_version(repo_root)
     report = {
         "schemaVersion": SCHEMA_VERSION,
         "status": "ok",
-        "baseRef": base_ref,
+        "baseRef": base.display_ref,
+        "baseMode": base.mode,
+        "baseSource": base.source,
         "baseVersion": None,
         "currentVersion": current_version,
         "versionBumpRequired": False,
@@ -133,14 +187,14 @@ def check(repo_root: Path, base_ref_arg: str | None) -> dict:
         "violations": [],
     }
 
-    if skip_reason is not None:
+    if base.skip_reason is not None or base.comparison_ref is None:
         report["status"] = "skipped"
         report["violations"] = []
-        report["skipReason"] = skip_reason
+        report["skipReason"] = base.skip_reason or "base_ref_unavailable"
         return report
 
-    base_version = load_base_version(repo_root, base_ref)
-    sensitive = [path for path in changed_files(repo_root, base_ref) if is_sensitive(path)]
+    base_version = load_base_version(repo_root, base.comparison_ref)
+    sensitive = [path for path in changed_files(repo_root, base.comparison_ref) if is_sensitive(path)]
     report["baseVersion"] = base_version
     report["sensitiveChangedFiles"] = sensitive
     report["versionBumpRequired"] = bool(sensitive)
@@ -153,7 +207,12 @@ def check(repo_root: Path, base_ref_arg: str | None) -> dict:
     violations: list[dict[str, str]] = []
 
     if base_semver is None:
-        violations.append({"id": "version.base_unreadable", "message": f"cannot read semver from {base_ref}:{PLUGIN_MANIFEST}"})
+        violations.append(
+            {
+                "id": "version.base_unreadable",
+                "message": f"cannot read semver from {base.display_ref}:{PLUGIN_MANIFEST}",
+            }
+        )
     if current_semver is None:
         violations.append({"id": "version.current_unreadable", "message": f"cannot read semver from {PLUGIN_MANIFEST}"})
     if base_semver is not None and current_semver is not None and current_semver <= base_semver:

--- a/tests/fixtures/proofpack/invalid-removal-evidence.json
+++ b/tests/fixtures/proofpack/invalid-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.8",
+  "signumVersion": "4.21.9",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-bad-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-artifact-ref.json
+++ b/tests/fixtures/proofpack/missing-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.8",
+  "signumVersion": "4.21.9",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-required.json
+++ b/tests/fixtures/proofpack/missing-required.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.8",
+  "signumVersion": "4.21.9",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/schema-version-mismatch.json
+++ b/tests/fixtures/proofpack/schema-version-mismatch.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.7",
-  "signumVersion": "4.21.8",
+  "signumVersion": "4.21.9",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/unsafe-artifact-path.json
+++ b/tests/fixtures/proofpack/unsafe-artifact-path.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.8",
+  "signumVersion": "4.21.9",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-minimal.json
+++ b/tests/fixtures/proofpack/valid-minimal.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.8",
+  "signumVersion": "4.21.9",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-artifact-ref.json
+++ b/tests/fixtures/proofpack/valid-with-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.8",
+  "signumVersion": "4.21.9",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-removal-evidence.json
+++ b/tests/fixtures/proofpack/valid-with-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.8",
+  "signumVersion": "4.21.9",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/wrong-type.json
+++ b/tests/fixtures/proofpack/wrong-type.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.8",
+  "signumVersion": "4.21.9",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/test-version-bump-required.sh
+++ b/tests/test-version-bump-required.sh
@@ -107,6 +107,101 @@ fi
 assert_json_eq "missing base ref status is skipped" "$UNKNOWN_REPORT" ".status" "skipped"
 assert_json_eq "missing base ref hard gate passes" "$UNKNOWN_REPORT" ".hardGatePassed" "true"
 
+MERGE_BASE_REPO="$TMP_DIR/merge-base-repo"
+git init -q -b main "$MERGE_BASE_REPO"
+cd "$MERGE_BASE_REPO"
+git config user.name "Signum Test"
+git config user.email "signum-test@example.invalid"
+mkdir -p .claude-plugin
+cat > .claude-plugin/plugin.json <<'JSON'
+{
+  "name": "signum",
+  "version": "1.0.0"
+}
+JSON
+git add .claude-plugin/plugin.json
+git commit -q -m "initial"
+git switch -q -c feature
+git switch -q main
+mkdir -p lib
+printf '#!/usr/bin/env bash\n' > lib/base-only.sh
+git add lib/base-only.sh
+git commit -q -m "main runtime change"
+git switch -q feature
+mkdir -p docs
+printf 'feature docs\n' > docs/readme.md
+MERGE_BASE_REPORT="$TMP_DIR/merge-base.json"
+if run_checker "$MERGE_BASE_REPO" main "$MERGE_BASE_REPORT"; then
+  pass "branch comparison ignores base-only sensitive changes"
+else
+  fail "branch comparison ignores base-only sensitive changes" "checker failed"
+fi
+assert_json_eq "merge-base comparison uses merge-base mode" "$MERGE_BASE_REPORT" ".baseMode" "merge_base"
+assert_json_eq "merge-base comparison does not require bump for docs-only feature" "$MERGE_BASE_REPORT" ".versionBumpRequired" "false"
+
+MULTI_COMMIT_REPO="$TMP_DIR/multi-commit-repo"
+git init -q -b main "$MULTI_COMMIT_REPO"
+cd "$MULTI_COMMIT_REPO"
+git config user.name "Signum Test"
+git config user.email "signum-test@example.invalid"
+mkdir -p .claude-plugin
+cat > .claude-plugin/plugin.json <<'JSON'
+{
+  "name": "signum",
+  "version": "1.0.0"
+}
+JSON
+git add .claude-plugin/plugin.json
+git commit -q -m "initial"
+git switch -q -c feature
+mkdir -p lib
+printf '#!/usr/bin/env bash\n' > lib/runtime.sh
+git add lib/runtime.sh
+git commit -q -m "runtime change"
+mkdir -p docs
+printf 'follow-up docs\n' > docs/readme.md
+git add docs/readme.md
+git commit -q -m "docs follow-up"
+MULTI_COMMIT_REPORT="$TMP_DIR/multi-commit.json"
+if run_checker "$MULTI_COMMIT_REPO" main "$MULTI_COMMIT_REPORT"; then
+  fail "branch comparison catches earlier sensitive commit" "checker unexpectedly passed"
+else
+  pass "branch comparison catches earlier sensitive commit"
+fi
+assert_json_eq "multi-commit branch requires bump" "$MULTI_COMMIT_REPORT" ".versionBumpRequired" "true"
+assert_json_eq "multi-commit branch reports bump violation" "$MULTI_COMMIT_REPORT" ".violations[0].id" "version.bump_required"
+
+PUSH_REPO="$TMP_DIR/push-repo"
+git init -q -b main "$PUSH_REPO"
+cd "$PUSH_REPO"
+git config user.name "Signum Test"
+git config user.email "signum-test@example.invalid"
+mkdir -p .claude-plugin
+cat > .claude-plugin/plugin.json <<'JSON'
+{
+  "name": "signum",
+  "version": "1.0.0"
+}
+JSON
+git add .claude-plugin/plugin.json
+git commit -q -m "initial"
+PUSH_BEFORE="$(git rev-parse HEAD)"
+mkdir -p lib
+printf '#!/usr/bin/env bash\n' > lib/runtime.sh
+git add lib/runtime.sh
+git commit -q -m "runtime change"
+PUSH_EVENT="$TMP_DIR/push-event.json"
+printf '{"before":"%s"}\n' "$PUSH_BEFORE" > "$PUSH_EVENT"
+PUSH_REPORT="$TMP_DIR/push.json"
+if GITHUB_EVENT_NAME=push GITHUB_EVENT_PATH="$PUSH_EVENT" python3 "$CHECKER" --repo-root "$PUSH_REPO" --json-output "$PUSH_REPORT"; then
+  fail "push event comparison catches sensitive commit" "checker unexpectedly passed"
+else
+  pass "push event comparison catches sensitive commit"
+fi
+assert_json_eq "push event uses previous sha source" "$PUSH_REPORT" ".baseSource" "github_push_before"
+assert_json_eq "push event uses direct diff mode" "$PUSH_REPORT" ".baseMode" "direct"
+assert_json_eq "push event reports bump violation" "$PUSH_REPORT" ".violations[0].id" "version.bump_required"
+
 CURRENT_REPORT="$TMP_DIR/current-repo.json"
 if python3 "$CHECKER" --repo-root "$REPO_ROOT" --json-output "$CURRENT_REPORT"; then
   pass "current repository version-bump guard passes"


### PR DESCRIPTION
## Summary

- Fixes the version-bump guard base selection found in Codex Review on #112.
- Compares feature branches from the merge base instead of the base branch tip.
- Uses the GitHub push event `before` SHA for push comparisons.
- Adds regression coverage for base-only changes, multi-commit feature branches, and push-event diffs.
- Bumps Signum plugin metadata and proofpack examples to `4.21.9`.

## Issue ID

- Related: #112
- Related: #107

## Test plan

- `python3 -m py_compile scripts/check_version_bump.py`
- `bash tests/test-version-bump-required.sh`
- `bash tests/test-ci-workflow.sh`
- `bash tests/test-metadata-consistency.sh`
- `bash tests/test-codex-plugin-metadata.sh`
- `bash tests/test-proofpack-validation.sh`
- `bash tests/test-signum-command-renderer.sh`
- `bash tests/test-signum-fragment-parity.sh`
- `bash tests/test-claude-overlay-doc-mirror.sh`
- `git diff --check`
- `PATH=/opt/homebrew/bin:$PATH bash scripts/run-deterministic-tests.sh`

## Notes

- Runtime scanner, policy catalog, Codex skill, CI wiring, and eval baselines are unchanged.
- Push event behavior is covered with a local synthetic GitHub event payload; GitHub Actions will verify the live workflow path on this PR.
