### PR TITLE
chore(release): bump Signum to 4.21.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,5 @@
   "license": "MIT",
   "name": "signum",
   "repository": "https://github.com/heurema/signum",
-  "version": "4.21.9"
+  "version": "4.21.10"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signum",
-  "version": "4.21.9",
+  "version": "4.21.10",
   "description": "Evidence-driven development pipeline with multi-model code review",
   "author": {
     "name": "heurema",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## [Unreleased]
 
+## [4.21.10] - 2026-05-16
+
+### Added
+- Policy scanner eval corpus now covers generated-path dependency scenarios.
+
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
+- Signum plugin metadata and proofpack fixtures now report version `4.21.10`.
 
 ## [4.21.9] - 2026-05-16
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -29,7 +29,7 @@ Sparse paths: leave blank
 
 After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**.
 
-The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.9` or a newer release tag.
+The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.10` or a newer release tag.
 
 ## 2. Run Your First Pipeline
 

--- a/commands/signum.fragments/100-phase-pack.md
+++ b/commands/signum.fragments/100-phase-pack.md
@@ -434,7 +434,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.9" \
+  --arg signumVersion "4.21.10" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/commands/signum.fragments/20-explain-mode.md
+++ b/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.9",
+  "version": "4.21.10",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {

--- a/commands/signum.md
+++ b/commands/signum.md
@@ -46,7 +46,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.9",
+  "version": "4.21.10",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -4158,7 +4158,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.9" \
+  --arg signumVersion "4.21.10" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/examples/proofpack-validation/valid-proofpack.json
+++ b/examples/proofpack-validation/valid-proofpack.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.9",
+  "signumVersion": "4.21.10",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-example01",
   "contractId": "sig-proofpack-example-001",

--- a/platforms/claude-code/.claude-plugin/plugin.json
+++ b/platforms/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "signum",
   "description": "Evidence-driven development pipeline with multi-model code review",
-  "version": "4.21.9",
+  "version": "4.21.10",
   "author": {
     "name": "heurema"
   },

--- a/platforms/claude-code/CHANGELOG.md
+++ b/platforms/claude-code/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## [Unreleased]
 
+## [4.21.10] - 2026-05-16
+
+### Added
+- Policy scanner eval corpus now covers generated-path dependency scenarios.
+
 ### Changed
 - PR Intake Gate now auto-passes trusted maintainers/admins, enforces external contributor context/no-code/Issue-or-Discussion intake, and treats label/comment write failures as non-fatal warnings.
+- Signum plugin metadata and proofpack fixtures now report version `4.21.10`.
 
 ## [4.21.9] - 2026-05-16
 

--- a/platforms/claude-code/QUICKSTART.md
+++ b/platforms/claude-code/QUICKSTART.md
@@ -29,7 +29,7 @@ Sparse paths: leave blank
 
 After the marketplace is added, it appears in the Plugins source dropdown as **Heurema**; the installable plugin inside it is **Signum**.
 
-The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.9` or a newer release tag.
+The repo-level marketplace lives at `.agents/plugins/marketplace.json`, and the marketplace plugin manifest lives at `platforms/codex/.codex-plugin/plugin.json`. If you need sparse checkout for the marketplace install, include `.agents/plugins` and `platforms/codex`. For pinned installs, use `v4.21.10` or a newer release tag.
 
 ## 2. Run Your First Pipeline
 

--- a/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
+++ b/platforms/claude-code/commands/signum.fragments/100-phase-pack.md
@@ -434,7 +434,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.9" \
+  --arg signumVersion "4.21.10" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
+++ b/platforms/claude-code/commands/signum.fragments/20-explain-mode.md
@@ -5,7 +5,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.9",
+  "version": "4.21.10",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {

--- a/platforms/claude-code/commands/signum.md
+++ b/platforms/claude-code/commands/signum.md
@@ -47,7 +47,7 @@ If the user's task is exactly `explain` (case-insensitive), do NOT run the pipel
 ```json
 {
   "name": "Signum",
-  "version": "4.21.9",
+  "version": "4.21.10",
   "pipeline": ["CONTRACT", "EXECUTE", "AUDIT", "PACK"],
   "phases": {
     "CONTRACT": {
@@ -4180,7 +4180,7 @@ PACK_AVAILABLE_REVIEWS=$(jq -r '.availableReviews // 0' "$AUDIT_SUMMARY_PATH" 2>
 # Final assembly
 jq -n \
   --arg schemaVersion "4.8" \
-  --arg signumVersion "4.21.9" \
+  --arg signumVersion "4.21.10" \
   --arg createdAt "$RUN_DATE" \
   --arg runId "$RUN_ID" \
   --arg contractId "$PACK_CONTRACT_ID" \

--- a/platforms/codex/.codex-plugin/plugin.json
+++ b/platforms/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signum",
-  "version": "4.21.9",
+  "version": "4.21.10",
   "description": "Evidence-driven development pipeline with multi-model code review",
   "author": {
     "name": "heurema",

--- a/tests/fixtures/proofpack/invalid-removal-evidence.json
+++ b/tests/fixtures/proofpack/invalid-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.9",
+  "signumVersion": "4.21.10",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-bad-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-artifact-ref.json
+++ b/tests/fixtures/proofpack/missing-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.9",
+  "signumVersion": "4.21.10",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/missing-required.json
+++ b/tests/fixtures/proofpack/missing-required.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.9",
+  "signumVersion": "4.21.10",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/schema-version-mismatch.json
+++ b/tests/fixtures/proofpack/schema-version-mismatch.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.7",
-  "signumVersion": "4.21.9",
+  "signumVersion": "4.21.10",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/unsafe-artifact-path.json
+++ b/tests/fixtures/proofpack/unsafe-artifact-path.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.9",
+  "signumVersion": "4.21.10",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-minimal.json
+++ b/tests/fixtures/proofpack/valid-minimal.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.9",
+  "signumVersion": "4.21.10",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-artifact-ref.json
+++ b/tests/fixtures/proofpack/valid-with-artifact-ref.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.9",
+  "signumVersion": "4.21.10",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/valid-with-removal-evidence.json
+++ b/tests/fixtures/proofpack/valid-with-removal-evidence.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.9",
+  "signumVersion": "4.21.10",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-removal",
   "contractId": "sig-proofpack-001",

--- a/tests/fixtures/proofpack/wrong-type.json
+++ b/tests/fixtures/proofpack/wrong-type.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "4.8",
-  "signumVersion": "4.21.9",
+  "signumVersion": "4.21.10",
   "createdAt": "2026-04-26T00:00:00Z",
   "runId": "signum-2026-04-26-test01",
   "contractId": "sig-proofpack-001",


### PR DESCRIPTION
## Summary
- Bump Signum plugin metadata and proofpack fixtures to 4.21.10.
- Keep Codex marketplace, root Codex, root Claude, and Claude overlay metadata aligned.
- Update rendered Signum command version text, quickstart tag guidance, and mirrored changelogs.

## Issue
- N/A

## Test plan
- bash tests/test-metadata-consistency.sh
- bash tests/test-codex-plugin-metadata.sh
- bash tests/test-signum-command-renderer.sh
- bash tests/test-proofpack-validation.sh
- bash tests/test-claude-overlay-doc-mirror.sh
- bash tests/test-policy-scanner-evals.sh
- bash tests/test-policy-scanner-eval-compare.sh
- bash tests/test-version-bump-required.sh
- PATH=/opt/homebrew/bin:$PATH bash scripts/run-deterministic-tests.sh