### PR TITLE
chore: update repo-governance actions to v0.4.0

### DIFF
--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -31,8 +31,8 @@ jobs:
           persist-credentials: false
 
       - name: Run PR intake gate
-        # pinned from heurema/repo-governance/actions/pr-intake-gate@main
-        uses: heurema/repo-governance/actions/pr-intake-gate@a1f0c72edbbbe0513471b973e5afc799e7c51da1
+        # pinned from heurema/repo-governance/actions/pr-intake-gate@v0.4.0
+        uses: heurema/repo-governance/actions/pr-intake-gate@f6a16882fd5e28968d77be063bb0ed4dca266c99
         with:
           policy-path: .github/pr-intake-gate.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/fixtures/github-action-pins.json
+++ b/tests/fixtures/github-action-pins.json
@@ -49,15 +49,15 @@
     {
       "file": ".github/workflows/pr-intake-gate.yml",
       "occurrence": 2,
-      "uses": "heurema/repo-governance/actions/pr-intake-gate@a1f0c72edbbbe0513471b973e5afc799e7c51da1",
+      "uses": "heurema/repo-governance/actions/pr-intake-gate@f6a16882fd5e28968d77be063bb0ed4dca266c99",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/pr-intake-gate",
       "status": "pinned",
-      "originalRef": "main",
-      "pinnedSha": "a1f0c72edbbbe0513471b973e5afc799e7c51da1",
+      "originalRef": "v0.4.0",
+      "pinnedSha": "f6a16882fd5e28968d77be063bb0ed4dca266c99",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
-      "resolution": "git rev-parse heurema/repo-governance main",
-      "peeledTagUsed": false
+      "resolution": "git rev-parse heurema/repo-governance v0.4.0^{commit}",
+      "peeledTagUsed": true
     },
     {
       "file": ".github/workflows/release-guardrails.yml",


### PR DESCRIPTION
## Summary

- Pin Signum's PR Intake Gate workflow to the repo-governance v0.4.0 release commit SHA.
- Update the adjacent original-ref comment and GitHub action pin inventory fixture.
- Do not change Signum PR intake policy semantics.

## Issue

- N/A

## Test plan

- `bash tests/test-github-action-pinning.sh`
- `git diff --check`

## Rollout / migration

- Runtime use of the new action starts only after this PR is merged and a later PR/run uses the updated default-branch workflow.

## Risk

- narrow - this changes only the shared repo-governance action pin and static pin inventory.