### PR TITLE
chore: update repo-governance actions to v0.5.0

### DIFF
--- a/.github/workflows/pr-intake-gate.yml
+++ b/.github/workflows/pr-intake-gate.yml
@@ -31,8 +31,8 @@ jobs:
           persist-credentials: false
 
       - name: Run PR intake gate
-        # pinned from heurema/repo-governance/actions/pr-intake-gate@v0.4.0
-        uses: heurema/repo-governance/actions/pr-intake-gate@f6a16882fd5e28968d77be063bb0ed4dca266c99
+        # pinned from heurema/repo-governance/actions/pr-intake-gate@v0.5.0
+        uses: heurema/repo-governance/actions/pr-intake-gate@58c1878e1e16c4139e35594aab6d1cb00f1c1018
         with:
           policy-path: .github/pr-intake-gate.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/fixtures/github-action-pins.json
+++ b/tests/fixtures/github-action-pins.json
@@ -49,14 +49,14 @@
     {
       "file": ".github/workflows/pr-intake-gate.yml",
       "occurrence": 2,
-      "uses": "heurema/repo-governance/actions/pr-intake-gate@f6a16882fd5e28968d77be063bb0ed4dca266c99",
+      "uses": "heurema/repo-governance/actions/pr-intake-gate@58c1878e1e16c4139e35594aab6d1cb00f1c1018",
       "kind": "external_action",
       "action": "heurema/repo-governance/actions/pr-intake-gate",
       "status": "pinned",
-      "originalRef": "v0.4.0",
-      "pinnedSha": "f6a16882fd5e28968d77be063bb0ed4dca266c99",
+      "originalRef": "v0.5.0",
+      "pinnedSha": "58c1878e1e16c4139e35594aab6d1cb00f1c1018",
       "note": "pinned to full-length GitHub commit SHA; original ref preserved in adjacent YAML comment",
-      "resolution": "git rev-parse heurema/repo-governance v0.4.0^{commit}",
+      "resolution": "git rev-parse heurema/repo-governance v0.5.0^{commit}",
       "peeledTagUsed": true
     },
     {


### PR DESCRIPTION
Updates only repo-governance action refs to the v0.5.0 commit SHA.

v0.5.0 adds strict root-level PR Intake policy validation: unknown top-level policy keys now fail fast.

Local policy compatibility was checked before updating refs. Policy semantics are unchanged.

Runtime proof requires merge because pull_request_target uses the base workflow.

Tests run:
- bash tests/test-github-action-pinning.sh
- bash scripts/run-deterministic-tests.sh
- git diff --check